### PR TITLE
fix(claude_backend): translate effort to claude CLI --thinking enum

### DIFF
--- a/skillopt/model/claude_backend.py
+++ b/skillopt/model/claude_backend.py
@@ -23,6 +23,14 @@ OPTIMIZER_DEPLOYMENT = os.environ.get("OPTIMIZER_DEPLOYMENT", "claude-sonnet-4-6
 TARGET_DEPLOYMENT = os.environ.get("TARGET_DEPLOYMENT", "claude-sonnet-4-6")
 REASONING_EFFORT: str | None = None
 _VALID_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
+_CLAUDE_CLI_THINKING_VALUES = {"enabled", "adaptive", "disabled"}
+_OPENAI_TO_CLAUDE_CLI_THINKING = {
+    "low": "disabled",
+    "medium": "adaptive",
+    "high": "enabled",
+    "xhigh": "enabled",
+    "max": "enabled",
+}
 
 
 def _parse_data_uri(url: str) -> tuple[bytes, str]:
@@ -209,9 +217,23 @@ def _normalize_reasoning_effort(effort: str | None) -> str | None:
     normalized = str(effort or "").strip().lower()
     if not normalized or normalized == "off":
         return None
-    if normalized in _VALID_EFFORTS:
+    if normalized in _VALID_EFFORTS or normalized in _CLAUDE_CLI_THINKING_VALUES:
         return normalized
     return None
+
+
+def _claude_cli_thinking_value(effort: str | None) -> str | None:
+    """Map a normalized effort to a value accepted by ``claude --thinking``.
+
+    The Claude CLI accepts only ``enabled``, ``adaptive``, or ``disabled`` for
+    its ``--thinking`` flag, so OpenAI-style effort levels are translated here.
+    Returns ``None`` when no thinking flag should be passed.
+    """
+    if not effort:
+        return None
+    if effort in _CLAUDE_CLI_THINKING_VALUES:
+        return effort
+    return _OPENAI_TO_CLAUDE_CLI_THINKING.get(effort)
 
 
 def _assistant_message_schema() -> dict[str, Any]:
@@ -243,6 +265,7 @@ def _assistant_message_schema_wrapper() -> str:
 
 def _run_claude_print(*, system: str, prompt: str, model: str, tools: list[dict[str, Any]] | None, tool_choice: str | dict[str, Any] | None, return_message: bool, timeout: int | None, attachments: list[dict[str, Any]] | None = None) -> tuple[str, dict[str, Any], dict[str, int]]:
     effort = _normalize_reasoning_effort(REASONING_EFFORT)
+    thinking_value = _claude_cli_thinking_value(effort)
     with tempfile.TemporaryDirectory(prefix="skillopt_claude_") as temp_dir:
         copied_attachments = _copy_attachments_to_temp(attachments or [], temp_dir)
         prompt_for_cli = _append_attachment_instructions(prompt, copied_attachments)
@@ -253,8 +276,8 @@ def _run_claude_print(*, system: str, prompt: str, model: str, tools: list[dict[
             cmd.extend(["--setting-sources", CLAUDE_SETTING_SOURCES])
         if system:
             cmd.extend(["--append-system-prompt", system])
-        if effort:
-            cmd.extend(["--thinking", effort])
+        if thinking_value:
+            cmd.extend(["--thinking", thinking_value])
         structured_output = bool(return_message)
         if structured_output:
             cmd.extend(["--schema", _assistant_message_schema_wrapper()])


### PR DESCRIPTION
## Summary

The Claude CLI's `--thinking` flag accepts only the enum values `enabled`, `adaptive`, or `disabled`, but `skillopt/model/claude_backend.py` forwarded the OpenAI-style `low` / `medium` / `high` effort values unchanged. As a result, every `claude_chat` rollout failed with:

```
error: option '--thinking <mode>' argument 'low' is invalid.
Allowed choices are enabled, adaptive, disabled.
```

This made the `claude_chat` backend unusable on the current Claude CLI (verified on 2.1.154).

## Change

- Add `_OPENAI_TO_CLAUDE_CLI_THINKING` mapping (`low → disabled`, `medium → adaptive`, `high|xhigh|max → enabled`).
- Extend `_normalize_reasoning_effort` to also accept the CLI's native enum values (`enabled` / `adaptive` / `disabled`) so users can opt in to a specific mode directly.
- Introduce `_claude_cli_thinking_value` and use it at the only `--thinking` call site in `_run_claude_print`.
- Unknown values continue to silently drop the flag, matching the prior behavior.

## Verification

Reproduced the original failure with a small SearchQA split using `claude-sonnet-4-6`:

- Before: every rollout returned `agent_ok=False` with `Claude backend failed after 5 retries: error: option '--thinking <mode>' argument 'low' is invalid`.
- After: with `reasoning_effort: low`, rollouts succeed (`agent_ok=True`), and a 2-step / 8-train-item / 4-val toy run completes 26 calls in 76s, with completion tokens dropping from ~4k (no thinking) to ~2k (now correctly translated to `--thinking disabled`).

No additional dependencies. Diff is +26 / -3 in a single file. Existing OpenAI-style usage (`low` / `medium` / `high`) keeps working transparently.

## Notes

- The mapping is intentionally conservative: anything outside the documented OpenAI levels and the CLI enum is dropped rather than guessed at, so we don't accidentally change behavior for unrecognized values.
- Happy to add a brief unit test if there's a preferred location — I didn't see a `tests/` directory in the tree, so I held off to avoid introducing a new convention.