### PR TITLE
fix(claude): use --effort instead of deprecated --thinking flag

### DIFF
--- a/skillopt/model/claude_backend.py
+++ b/skillopt/model/claude_backend.py
@@ -254,7 +254,7 @@ def _run_claude_print(*, system: str, prompt: str, model: str, tools: list[dict[
         if system:
             cmd.extend(["--append-system-prompt", system])
         if effort:
-            cmd.extend(["--thinking", effort])
+            cmd.extend(["--effort", effort])
         structured_output = bool(return_message)
         if structured_output:
             cmd.extend(["--schema", _assistant_message_schema_wrapper()])


### PR DESCRIPTION
## Summary
Fix Claude CLI argument incompatibility: `--thinking` → `--effort`.

## Background
Claude Code CLI v2.x renamed `--thinking <mode>` to `--effort <level>`.
- Old (v1.x): `--thinking low|medium|high|xhigh|max`
- New (v2.x): `--effort low|medium|high|xhigh|max` (same values, different flag name)

On Claude CLI 2.1.87, using `--thinking low` fails with:
```
error: option '--thinking <mode>' argument 'low' is invalid.
Allowed choices are enabled, adaptive, disabled.
```

Every rollout then fails with empty responses (`total tokens: 0`, all steps `skip`).

## Change
One-line fix in `skillopt/model/claude_backend.py`:

```diff
-        cmd.extend(["--thinking", effort])
+        cmd.extend(["--effort", effort])
```

`_VALID_EFFORTS` unchanged (values are identical).

## Test plan
- [x] Reproduced failure on Claude CLI 2.1.87 before fix
- [x] After fix: SearchQA smoke runs end-to-end (29 LLM calls, gate/reflect pipeline OK)