### PR TITLE
feat: add Hermes skill evolution prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ docs/render_ablation_paper_tables.py
 docs/让*
 .gradio/
 .venv
+uv.lock

--- a/docs/hermes-skill-evolution.md
+++ b/docs/hermes-skill-evolution.md
@@ -1,0 +1,154 @@
+# Hermes Skill Evolution Engine Prototype
+
+## Status
+
+Prototype. The current implementation is intentionally conservative: it runs offline static checks, preserves rejected candidates, requires human review, and never writes to a live skill unless promotion is explicitly approved.
+
+## Goal
+
+Turn SkillOpt output into a governed Hermes skill evolution loop:
+
+```text
+SkillOpt candidate → staging → eval → gate → human review → promote
+```
+
+This prevents optimizer output from directly mutating `~/.hermes/skills` while still making skill improvement repeatable, auditable, and testable.
+
+## Components
+
+- `skillopt/evolution/pipeline.py`
+  - Local governance implementation.
+  - Does not call external models.
+  - Writes staged artifacts, eval reports, gate decisions, review requests, and promotion records.
+- `scripts/hermes_skill_evolve.py`
+  - CLI wrapper for the governance flow.
+- `tests/test_evolution_pipeline.py`
+  - Deterministic tests for staging, eval, gate, review, promotion, qmd grounding, regression fixtures, and dry-run promotion.
+
+## Flow
+
+### 1. Stage
+
+```bash
+python scripts/hermes_skill_evolve.py stage \
+  --registry .hermes-skill-evolution \
+  --skill-name qmd \
+  --candidate outputs/best_skill.md \
+  --base ~/.hermes/skills/research/qmd/SKILL.md
+```
+
+Purpose: copy a generated candidate into a staging registry and record manifest metadata, source path, candidate hash, and optional base skill hash.
+
+### 2. Eval
+
+```bash
+python scripts/hermes_skill_evolve.py eval \
+  --registry .hermes-skill-evolution \
+  --skill-name qmd \
+  --candidate-id <candidate-id> \
+  --regression-fixture tests/fixtures/qmd_skill_regression.json
+```
+
+Purpose: run deterministic local evaluation. Current score dimensions:
+
+- `correctness`: frontmatter, description, and minimum body length.
+- `tool_grounding`: command/code blocks must explain purpose near the snippet.
+- `qmd_grounding`: candidate cites `qmd://...` sources and/or tells the agent to use qmd lookup commands.
+- `regression`: fixture-defined required terms are present in candidate text.
+- `safety`: rejects secret-like strings and dangerous command patterns.
+- `user_style`: rewards Traditional Chinese / local purpose explanation style.
+- `operational_quality`: candidate includes verification guidance.
+- `cost_latency`: candidate acknowledges cost or latency.
+
+### 3. Gate
+
+```bash
+python scripts/hermes_skill_evolve.py gate \
+  --registry .hermes-skill-evolution \
+  --skill-name qmd \
+  --candidate-id <candidate-id> \
+  --min-score 0.8
+```
+
+Purpose: reject candidates with any score below the threshold. Rejected candidates are copied into `registry/rejected/<skill>/<candidate-id>/` for audit instead of being deleted.
+
+### 4. Human review
+
+```bash
+python scripts/hermes_skill_evolve.py review \
+  --registry .hermes-skill-evolution \
+  --skill-name qmd \
+  --candidate-id <candidate-id>
+```
+
+Purpose: create `human_review.md` containing candidate metadata, scores, diff path, and a review checklist.
+
+Review checklist requires the human to:
+
+- read `candidate.md`
+- read `candidate.diff` when a base skill exists
+- confirm qmd grounding references are relevant and non-sensitive
+- confirm regression fixture failures are absent or intentionally accepted
+- confirm no secrets or dangerous commands are present
+- confirm promotion dry-run output before writing live skill
+
+### 5. Promotion dry-run
+
+```bash
+python scripts/hermes_skill_evolve.py promote \
+  --registry .hermes-skill-evolution \
+  --skill-name qmd \
+  --candidate-id <candidate-id> \
+  --live-skill-path ~/.hermes/skills/research/qmd/SKILL.md \
+  --approved-by chiahsin \
+  --dry-run
+```
+
+Purpose: show what would be written without modifying the live skill. This should be run before real promotion.
+
+### 6. Promote
+
+```bash
+python scripts/hermes_skill_evolve.py promote \
+  --registry .hermes-skill-evolution \
+  --skill-name qmd \
+  --candidate-id <candidate-id> \
+  --live-skill-path ~/.hermes/skills/research/qmd/SKILL.md \
+  --approved-by chiahsin
+```
+
+Purpose: after explicit approval, archive the previous live skill and copy the candidate to the live path.
+
+## qmd / MCP integration pattern
+
+qmd is used as the local retrieval layer for skill evolution:
+
+- Use BM25 (`qmd search`) for fast smoke tests and exact lookup.
+- Use `qmd://...` references in candidate skills when they rely on local wiki or vault knowledge.
+- Use qmd MCP tools from Hermes after configuring:
+
+```bash
+hermes mcp add qmd --command qmd --args mcp
+```
+
+Purpose: register qmd's MCP server so Hermes can query local collections through native MCP tools.
+
+Important: vector/hybrid search requires embeddings and may download large local models. Do not run `qmd embed`, `qmd vsearch`, or `qmd query` in unattended optimization jobs unless model downloads and compute cost are explicitly accepted.
+
+## Safety rules
+
+- Never optimize directly against the live `~/.hermes/skills` directory.
+- Use staging registry or temporary Hermes profiles for candidates.
+- Treat optimizer output as untrusted until it passes eval, gate, and review.
+- Preserve rejected candidates for audit.
+- Promotion requires an explicit approver name.
+- Prefer promotion dry-run before every real write.
+- Do not include API keys, tokens, internal customer data, or banking records in fixtures or staged artifacts.
+
+## Next extensions
+
+- Replace the simple required-term regression fixture with task/rubric execution against realistic Hermes workflows.
+- Add qmd MCP live checks that verify every `qmd://...` reference resolves.
+- Add held-out evaluation comparing candidate and baseline responses.
+- Replace file-copy promotion with Hermes `skill_manage` integration for live profile edits.
+- Add a cron-friendly report mode that proposes candidates but never promotes them automatically.

--- a/scripts/eval_only.py
+++ b/scripts/eval_only.py
@@ -24,21 +24,20 @@ _PROJECT_ROOT = os.path.dirname(_SCRIPT_DIR)
 if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, _PROJECT_ROOT)
 
-from skillopt.model import (
+from skillopt.model import (  # noqa: E402
     configure_azure_openai,
     configure_claude_code_exec,
     configure_codex_exec,
+    set_optimizer_backend,
+    set_optimizer_deployment,
     set_reasoning_effort,
     set_target_backend,
     set_target_deployment,
-    set_optimizer_backend,
-    set_optimizer_deployment,
 )
-from skillopt.model.common import default_model_for_backend, normalize_backend_name
+from skillopt.model.common import default_model_for_backend, normalize_backend_name  # noqa: E402
 
 _OPENAI_DEFAULT_MODEL_SENTINELS = {"gpt-5.4", "gpt-5.5"}
-from skillopt.utils import compute_score
-
+from skillopt.utils import compute_score  # noqa: E402
 
 # ── Reuse registry from train.py ───────────────────────────────────────────
 
@@ -201,7 +200,8 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
 
-    from skillopt.config import load_config as _load, flatten_config, is_structured
+    from skillopt.config import flatten_config, is_structured
+    from skillopt.config import load_config as _load
 
     cfg = _load(args.config, overrides=args.cfg_options)
     structured = is_structured(cfg)

--- a/scripts/hermes_skill_evolve.py
+++ b/scripts/hermes_skill_evolve.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""CLI wrapper for the Hermes skill evolution governance prototype."""
+from __future__ import annotations
+
+from skillopt.evolution.pipeline import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -26,7 +26,7 @@ _PROJECT_ROOT = os.path.dirname(_SCRIPT_DIR)
 if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, _PROJECT_ROOT)
 
-from skillopt.model.common import default_model_for_backend, normalize_backend_name
+from skillopt.model.common import default_model_for_backend, normalize_backend_name  # noqa: E402
 
 _OPENAI_DEFAULT_MODEL_SENTINELS = {"gpt-5.4", "gpt-5.5"}
 
@@ -372,7 +372,8 @@ _LEGACY_TO_STRUCTURED: dict[str, str] = {
 
 def load_config(args: argparse.Namespace) -> dict:
     """Load config with _base_ inheritance, then apply CLI overrides."""
-    from skillopt.config import load_config as _load, flatten_config, is_structured
+    from skillopt.config import flatten_config, is_structured
+    from skillopt.config import load_config as _load
 
     cfg = _load(args.config, overrides=args.cfg_options)
     structured = is_structured(cfg)
@@ -507,7 +508,7 @@ def main() -> None:
     cfg = load_config(args)
 
     print(f"\n{'='*60}")
-    print(f"  SkillOpt — Executive Strategy for Self-Evolving Agent Skills")
+    print("  SkillOpt — Executive Strategy for Self-Evolving Agent Skills")
     print(f"{'='*60}")
     print(f"  env:            {cfg.get('env')}")
     print(f"  optimizer_model:  {cfg.get('optimizer_model')}")
@@ -518,7 +519,7 @@ def main() -> None:
     print(f"  rewrite_effort: {cfg.get('rewrite_reasoning_effort') or 'off'}")
     print(f"  epochs:         {cfg.get('num_epochs')}")
     print(f"  train_size:     {cfg.get('train_size') or 'from dataset'}")
-    print(f"  steps/epoch:    auto")
+    print("  steps/epoch:    auto")
     print(f"  batch_size:     {cfg.get('batch_size')}")
     print(f"  edit_budget:    {cfg.get('edit_budget')}")
     print(f"  lr_scheduler:   {cfg.get('lr_scheduler', 'constant')}")

--- a/skillopt/engine/trainer.py
+++ b/skillopt/engine/trainer.py
@@ -26,9 +26,22 @@ from skillopt.datasets.base import BatchSpec
 from skillopt.envs.base import EnvAdapter
 from skillopt.evaluation.gate import evaluate_gate, select_gate_score
 from skillopt.gradient.aggregate import merge_patches
-from skillopt.optimizer.meta_skill import run_meta_skill
+from skillopt.model import (
+    configure_azure_openai,
+    configure_claude_code_exec,
+    configure_codex_exec,
+    configure_minimax_chat,
+    configure_qwen_chat,
+    get_token_summary,
+    set_optimizer_backend,
+    set_optimizer_deployment,
+    set_reasoning_effort,
+    set_target_backend,
+    set_target_deployment,
+)
 from skillopt.optimizer.clip import rank_and_select
 from skillopt.optimizer.lr_autonomous import decide_autonomous_learning_rate
+from skillopt.optimizer.meta_skill import run_meta_skill
 from skillopt.optimizer.rewrite import rewrite_skill_from_suggestions
 from skillopt.optimizer.scheduler import build_scheduler
 from skillopt.optimizer.skill import apply_patch_with_report
@@ -47,22 +60,8 @@ from skillopt.optimizer.update_modes import (
     payload_label,
     short_item_summary,
 )
-from skillopt.model import (
-    configure_azure_openai,
-    configure_claude_code_exec,
-    configure_codex_exec,
-    configure_minimax_chat,
-    configure_qwen_chat,
-    get_token_summary,
-    reset_token_tracker,
-    set_reasoning_effort,
-    set_target_backend,
-    set_target_deployment,
-    set_optimizer_backend,
-    set_optimizer_deployment,
-)
 from skillopt.utils import compute_score, skill_hash
-
+from skillopt.utils.redaction import redact_secrets
 
 # ── Patch normalization ───────────────────────────────────────────────────────
 
@@ -246,25 +245,8 @@ def _build_longitudinal_pairs(
 
 # ── History / persistence helpers ─────────────────────────────────────────────
 
-_SECRET_KEYS = {
-    "azure_api_key",
-    "api_key",
-    "openai_api_key",
-}
-
-
-def _redact_value(val: str) -> str:
-    if len(val) <= 8:
-        return "*" * len(val)
-    return f"{val[:4]}...{val[-4:]}"
-
-
 def _redact_cfg(cfg: dict) -> dict:
-    redacted = dict(cfg)
-    for key in list(redacted):
-        if key.lower() in _SECRET_KEYS and redacted.get(key):
-            redacted[key] = _redact_value(str(redacted[key]))
-    return redacted
+    return redact_secrets(cfg)
 
 def _load_history(out_root: str) -> list[dict]:
     path = os.path.join(out_root, "history.json")
@@ -277,7 +259,7 @@ def _load_history(out_root: str) -> list[dict]:
 def _save_history(out_root: str, history: list[dict]) -> None:
     path = os.path.join(out_root, "history.json")
     with open(path, "w") as f:
-        json.dump(history, f, ensure_ascii=False, indent=2)
+        json.dump(redact_secrets(history), f, ensure_ascii=False, indent=2)
 
 
 def _save_skill(out_root: str, step: int, content: str) -> None:
@@ -324,7 +306,7 @@ def _load_runtime_state(out_root: str) -> dict | None:
 def _save_runtime_state(out_root: str, state: dict) -> None:
     path = os.path.join(out_root, "runtime_state.json")
     with open(path, "w") as f:
-        json.dump(state, f, ensure_ascii=False, indent=2)
+        json.dump(redact_secrets(state), f, ensure_ascii=False, indent=2)
 
 
 def _resolve_train_size(cfg: dict, dataloader) -> int:
@@ -602,6 +584,9 @@ class ReflACTTrainer:
             elif backend in {"qwen", "qwen_chat"}:
                 optimizer_backend = optimizer_backend or "openai_chat"
                 target_backend = target_backend or "qwen_chat"
+            elif backend in {"minimax", "minimax_chat"}:
+                optimizer_backend = optimizer_backend or "minimax_chat"
+                target_backend = target_backend or "minimax_chat"
             else:
                 optimizer_backend = optimizer_backend or "openai_chat"
                 target_backend = target_backend or "openai_chat"
@@ -653,6 +638,7 @@ class ReflACTTrainer:
             base_url=cfg.get("minimax_base_url") or None,
             api_key=cfg.get("minimax_api_key") or None,
             temperature=cfg.get("minimax_temperature"),
+            timeout_seconds=cfg.get("minimax_timeout_seconds"),
             max_tokens=cfg.get("minimax_max_tokens"),
             enable_thinking=cfg.get("minimax_enable_thinking"),
         )
@@ -1996,7 +1982,7 @@ class ReflACTTrainer:
 
             # Comparison
             delta_hard = (test_hard or 0) - (baseline_test_hard or 0)
-            print(f"\n  === Improvement (best vs baseline) ===")
+            print("\n  === Improvement (best vs baseline) ===")
             print(
                 f"    hard: {baseline_test_hard:.4f} -> {test_hard:.4f}  "
                 f"(delta={delta_hard:+.4f})"

--- a/skillopt/envs/_template/env_template.py
+++ b/skillopt/envs/_template/env_template.py
@@ -14,7 +14,7 @@ from skillopt.envs.base import EnvAdapter
 class TemplateBenchmarkEnv(EnvAdapter):
     """
     Environment adapter for <Your Benchmark Name>.
-    
+
     Rename this class and implement the abstract methods below.
     """
 
@@ -41,8 +41,7 @@ class TemplateBenchmarkEnv(EnvAdapter):
         # Step 2: Call the target model
         # TODO: Customize the message format for your benchmark
         messages = [
-            {"role": "system", "content": skill},
-            {"role": "user", "content": item.input},
+            {"role": "user", "content": prompt},
         ]
         response = await model.generate(messages)
 
@@ -66,7 +65,7 @@ class TemplateBenchmarkEnv(EnvAdapter):
 
         Returns:
             Float between 0.0 (wrong) and 1.0 (correct)
-        
+
         TODO: Implement your scoring metric. Common options:
         - Exact match: float(pred.strip().lower() == gt.strip().lower())
         - F1 score: compute token overlap
@@ -83,9 +82,9 @@ class TemplateBenchmarkEnv(EnvAdapter):
     def parse_response(self, response: str) -> str:
         """
         Extract the answer from the model's raw response.
-        
+
         TODO: Implement extraction logic. For example:
-        - Extract text after "Answer:" 
+        - Extract text after "Answer:"
         - Parse JSON output
         - Extract from code blocks
         """

--- a/skillopt/envs/_template/loader_template.py
+++ b/skillopt/envs/_template/loader_template.py
@@ -14,7 +14,7 @@ from pathlib import Path
 class TemplateBenchmarkLoader:
     """
     Data loader for <Your Benchmark Name>.
-    
+
     Rename this class and implement the methods below.
     """
 
@@ -26,9 +26,9 @@ class TemplateBenchmarkLoader:
     def setup(self, cfg: dict):
         """
         Initialize the loader with config.
-        
+
         Called once before training starts.
-        
+
         Args:
             cfg: Dict with keys like 'split_mode', 'train_ratio', 'val_ratio', etc.
         """
@@ -48,13 +48,13 @@ class TemplateBenchmarkLoader:
     def _load_items(self) -> list:
         """
         Load raw data into structured items.
-        
+
         TODO: Implement data loading. Each item should have at minimum:
         - id: unique identifier
         - input: the task input (question, instruction, etc.)
         - ground_truth: the expected answer
         - metadata: optional dict with extra info
-        
+
         Example:
             items = []
             for path in self.data_dir.glob("*.json"):
@@ -91,10 +91,10 @@ class TemplateBenchmarkLoader:
     def get_split_items(self, split: str) -> list:
         """
         Return items for a given split.
-        
+
         Args:
             split: One of "train", "valid", "test"
-            
+
         Returns:
             List of data items for the requested split
         """

--- a/skillopt/envs/alfworld/adapter.py
+++ b/skillopt/envs/alfworld/adapter.py
@@ -5,20 +5,19 @@ Connects the ReflACT training loop to ALFWorld by implementing
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
 import json
 import os
+from dataclasses import dataclass
 
 from skillopt.datasets.base import BatchSpec
-from skillopt.envs.base import EnvAdapter
 from skillopt.envs.alfworld.dataloader import ALFWorldDataLoader
 from skillopt.envs.alfworld.rollout import (
+    TASKS,
     build_alfworld_env,
     run_alfworld_batch,
-    TASKS,
 )
+from skillopt.envs.base import EnvAdapter
 from skillopt.gradient.reflect import run_minibatch_reflect
-from skillopt.utils import compute_score
 
 
 @dataclass(frozen=True)

--- a/skillopt/envs/alfworld/rollout.py
+++ b/skillopt/envs/alfworld/rollout.py
@@ -7,12 +7,10 @@ Provides:
 """
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import os
 import re
-import sys
-import concurrent.futures
-import numpy as np
 
 from skillopt.model import chat_target
 
@@ -86,8 +84,9 @@ def build_alfworld_env(
     Returns:
         env_manager: AlfWorldEnvironmentManager instance
     """
-    from omegaconf import OmegaConf
     from functools import partial
+
+    from omegaconf import OmegaConf
 
     from skillopt.envs.alfworld.vendor.alfworld_envs import build_alfworld_envs
     from skillopt.envs.alfworld.vendor.alfworld_projection import alfworld_projection
@@ -222,7 +221,7 @@ def run_alfworld_batch(
                 if _extract_action(response) is None:
                     return idx, "<think>missing action tag</think><action>look</action>"
                 return idx, response
-            except Exception as e:
+            except Exception:
                 return idx, "<think>error</think><action>look</action>"
 
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_api_workers)

--- a/skillopt/envs/alfworld/vendor/__init__.py
+++ b/skillopt/envs/alfworld/vendor/__init__.py
@@ -4,6 +4,14 @@ Minimal subset of SkillRL's agent_system package needed to run
 ALFWorld environments with ReflACT. Original source:
 https://github.com/NTU-LANTERN/SkillRL (Apache-2.0 License)
 """
-from .alfworld_envs import AlfworldEnvs, build_alfworld_envs
-from .alfworld_projection import alfworld_projection
-from .env_manager import AlfWorldEnvironmentManager
+from .alfworld_envs import AlfworldEnvs as AlfworldEnvs
+from .alfworld_envs import build_alfworld_envs as build_alfworld_envs
+from .alfworld_projection import alfworld_projection as alfworld_projection
+from .env_manager import AlfWorldEnvironmentManager as AlfWorldEnvironmentManager
+
+__all__ = [
+    "AlfWorldEnvironmentManager",
+    "AlfworldEnvs",
+    "alfworld_projection",
+    "build_alfworld_envs",
+]

--- a/skillopt/envs/alfworld/vendor/alfworld_envs.py
+++ b/skillopt/envs/alfworld/vendor/alfworld_envs.py
@@ -2,13 +2,12 @@
 # Original: agent_system/environments/env_package/alfworld/envs.py
 # Modified: imports use pip-installed alfworld package instead of vendored copy.
 
-import os
 import multiprocessing as mp
+import os
 import traceback
-import yaml
-import gymnasium as gym
-import numpy as np
 
+import gymnasium as gym
+import yaml
 from alfworld.agents.environment import get_environment
 
 

--- a/skillopt/envs/alfworld/vendor/alfworld_projection.py
+++ b/skillopt/envs/alfworld/vendor/alfworld_projection.py
@@ -1,8 +1,8 @@
 # Vendored from SkillRL (Apache-2.0 License)
 # Original: agent_system/environments/env_package/alfworld/projection.py
 
-from typing import List
 import re
+from typing import List
 
 
 def alfworld_projection(actions: List[str], action_pools: List[List[str]]):

--- a/skillopt/envs/alfworld/vendor/env_base.py
+++ b/skillopt/envs/alfworld/vendor/env_base.py
@@ -2,9 +2,10 @@
 # Original: agent_system/environments/base.py
 # Trimmed to only include what ALFWorld needs.
 
-from typing import List, Tuple, Dict, Any
-import numpy as np
 from collections import defaultdict
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
 
 
 def to_numpy(data):

--- a/skillopt/envs/alfworld/vendor/env_manager.py
+++ b/skillopt/envs/alfworld/vendor/env_manager.py
@@ -2,16 +2,13 @@
 # Original: agent_system/environments/env_manager.py
 # Trimmed to only include AlfWorldEnvironmentManager and its helpers.
 
-from typing import List, Dict, Any
-from collections import defaultdict
-import numpy as np
+from typing import List
 
-from skillopt.envs.alfworld.vendor.env_base import EnvironmentManagerBase, to_numpy
 from skillopt.envs.alfworld.vendor.alfworld_prompts import (
     ALFWORLD_TEMPLATE,
     ALFWORLD_TEMPLATE_NO_HIS,
-    ALFWORLD_TEMPLATE_WITH_MEMORY,
 )
+from skillopt.envs.alfworld.vendor.env_base import EnvironmentManagerBase, to_numpy
 from skillopt.envs.alfworld.vendor.memory import SimpleMemory
 
 

--- a/skillopt/envs/alfworld/vendor/memory.py
+++ b/skillopt/envs/alfworld/vendor/memory.py
@@ -3,7 +3,7 @@
 # Merged into a single file for simplicity.
 
 from abc import ABC, abstractmethod
-from typing import List, Dict, Any, Tuple
+from typing import Any, Dict, List, Tuple
 
 
 class BaseMemory(ABC):

--- a/skillopt/envs/base.py
+++ b/skillopt/envs/base.py
@@ -26,9 +26,8 @@ Example::
 """
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-import os
 import random
+from abc import ABC, abstractmethod
 
 from skillopt.datasets.base import BaseDataLoader, BatchSpec
 from skillopt.prompts import load_prompt

--- a/skillopt/envs/docvqa/rollout.py
+++ b/skillopt/envs/docvqa/rollout.py
@@ -6,7 +6,7 @@ import time
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 
 from skillopt.envs.docvqa.evaluator import evaluate
-from skillopt.model import chat_target_messages, get_target_backend, is_target_exec_backend
+from skillopt.model import chat_target_messages, is_target_exec_backend
 from skillopt.model.codex_harness import prepare_workspace, render_skill_md, run_target_exec
 from skillopt.prompts import load_prompt
 

--- a/skillopt/envs/livemathematicianbench/adapter.py
+++ b/skillopt/envs/livemathematicianbench/adapter.py
@@ -1,15 +1,13 @@
 """LiveMathematicianBench environment adapter for ReflACT."""
 from __future__ import annotations
 
-import json
 import os
 
 from skillopt.datasets.base import BatchSpec
-from skillopt.gradient.reflect import run_minibatch_reflect
 from skillopt.envs.base import EnvAdapter
 from skillopt.envs.livemathematicianbench.dataloader import LiveMathematicianBenchDataLoader
 from skillopt.envs.livemathematicianbench.rollout import run_batch
-from skillopt.model import get_target_backend
+from skillopt.gradient.reflect import run_minibatch_reflect
 
 
 class LiveMathematicianBenchAdapter(EnvAdapter):

--- a/skillopt/envs/livemathematicianbench/dataloader.py
+++ b/skillopt/envs/livemathematicianbench/dataloader.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from skillopt.datasets.base import BatchSpec, SplitDataLoader
 
-
 # ── Raw data loading utilities (for preprocessing / standalone eval) ─────
 
 _CHOICE_LABELS = ["A", "B", "C", "D", "E", "F", "G"]

--- a/skillopt/envs/livemathematicianbench/rollout.py
+++ b/skillopt/envs/livemathematicianbench/rollout.py
@@ -7,9 +7,10 @@ import time
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 
 from skillopt.envs.livemathematicianbench.evaluator import evaluate
-from skillopt.model import chat_target, get_target_backend, is_target_exec_backend
+from skillopt.model import chat_target, is_target_exec_backend
 from skillopt.model.codex_harness import prepare_workspace, render_skill_md, run_target_exec
 from skillopt.prompts import load_prompt
+
 
 def _build_system(skill_content: str) -> str:
     if skill_content.strip():

--- a/skillopt/envs/officeqa/dataloader.py
+++ b/skillopt/envs/officeqa/dataloader.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import csv
 import json
-import os
 from pathlib import Path
 
 from skillopt.datasets.base import SplitDataLoader

--- a/skillopt/envs/officeqa/evaluator.py
+++ b/skillopt/envs/officeqa/evaluator.py
@@ -4,7 +4,6 @@ import re
 import string
 from collections import Counter
 
-
 _NUMERIC_CHARS = set("0123456789.-")
 
 

--- a/skillopt/envs/officeqa/rollout.py
+++ b/skillopt/envs/officeqa/rollout.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
+
 import json
 import os
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
+
 from skillopt.envs.officeqa.evaluator import evaluate
 from skillopt.envs.officeqa.tool_runtime import (
     build_oracle_parsed_pages_context,
@@ -14,6 +16,7 @@ from skillopt.envs.officeqa.tool_runtime import (
 from skillopt.model import chat_target_messages, get_target_backend, is_target_exec_backend
 from skillopt.model.codex_harness import prepare_workspace, render_skill_md, run_target_exec
 from skillopt.prompts import load_prompt
+
 _TOOL_SCHEMAS = [
     {
         "type": "function",

--- a/skillopt/envs/searchqa/adapter.py
+++ b/skillopt/envs/searchqa/adapter.py
@@ -1,7 +1,6 @@
 """SearchQA environment adapter for ReflACT."""
 from __future__ import annotations
 
-import json
 import os
 
 from skillopt.datasets.base import BatchSpec
@@ -9,7 +8,6 @@ from skillopt.envs.base import EnvAdapter
 from skillopt.envs.searchqa.dataloader import SearchQADataLoader
 from skillopt.envs.searchqa.rollout import run_batch
 from skillopt.gradient.reflect import run_minibatch_reflect
-from skillopt.model import get_target_backend
 
 
 class SearchQAAdapter(EnvAdapter):

--- a/skillopt/envs/searchqa/dataloader.py
+++ b/skillopt/envs/searchqa/dataloader.py
@@ -5,7 +5,6 @@ import json
 
 from skillopt.datasets.base import SplitDataLoader
 
-
 # ── Raw data loading utilities (for preprocessing / standalone eval) ─────
 
 def _load_items(path: str) -> list[dict]:

--- a/skillopt/envs/searchqa/rollout.py
+++ b/skillopt/envs/searchqa/rollout.py
@@ -13,14 +13,12 @@ from __future__ import annotations
 import json
 import os
 import time
-import traceback
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 
-from skillopt.model import chat_target, get_target_backend, is_target_exec_backend
+from skillopt.envs.searchqa.evaluator import evaluate
+from skillopt.model import chat_target, is_target_exec_backend
 from skillopt.model.codex_harness import prepare_workspace, render_skill_md, run_target_exec
 from skillopt.prompts import load_prompt
-from skillopt.envs.searchqa.evaluator import evaluate
-
 
 # ── Prompt templates ─────────────────────────────────────────────────────────
 

--- a/skillopt/envs/spreadsheetbench/adapter.py
+++ b/skillopt/envs/spreadsheetbench/adapter.py
@@ -12,13 +12,11 @@ from skillopt.datasets.base import BatchSpec
 from skillopt.envs.base import EnvAdapter
 from skillopt.envs.spreadsheetbench.dataloader import SpreadsheetBenchDataLoader
 from skillopt.envs.spreadsheetbench.rollout import (
-    process_one,
     run_spreadsheet_batch,
     run_spreadsheet_batch_codegen,
 )
 from skillopt.gradient.reflect import run_minibatch_reflect
-from skillopt.model import get_target_backend, is_target_exec_backend
-
+from skillopt.model import is_target_exec_backend
 
 # Task types used for per-category breakdowns
 TASK_TYPES = ["cell_level", "sheet_level"]

--- a/skillopt/envs/spreadsheetbench/codegen_agent.py
+++ b/skillopt/envs/spreadsheetbench/codegen_agent.py
@@ -10,14 +10,11 @@ a Python code block, no function-calling / tool-use).
 """
 from __future__ import annotations
 
-import json
 import os
 import random
-import signal
 import time
 
 import openpyxl
-
 
 # ── Timeout helper ──────────────────────────────────────────────────────────
 
@@ -28,18 +25,17 @@ class TaskTimeout(Exception):
 def _timeout_handler(signum, frame):
     raise TaskTimeout("Task timed out")
 
-from skillopt.model.azure_openai import (
+from skillopt.envs.spreadsheetbench.evaluator import evaluate  # noqa: E402
+from skillopt.envs.spreadsheetbench.executor import run_generated_code  # noqa: E402
+from skillopt.model import is_target_exec_backend  # noqa: E402
+from skillopt.model.azure_openai import (  # noqa: E402
+    _needs_responses_api,
     get_reasoning_effort,
     get_target_client,
-    _needs_responses_api,
     tracker,
 )
-from skillopt.model import get_codex_exec_config, get_target_backend, is_target_exec_backend
-from skillopt.model.codex_harness import prepare_workspace, render_skill_md, run_target_exec
-from skillopt.prompts import load_prompt
-from skillopt.envs.spreadsheetbench.executor import run_generated_code
-from skillopt.envs.spreadsheetbench.evaluator import evaluate
-
+from skillopt.model.codex_harness import prepare_workspace, render_skill_md, run_target_exec  # noqa: E402
+from skillopt.prompts import load_prompt  # noqa: E402
 
 # ── Eval feedback helper (no golden value leakage) ─────────────────────────
 

--- a/skillopt/envs/spreadsheetbench/evaluator.py
+++ b/skillopt/envs/spreadsheetbench/evaluator.py
@@ -19,10 +19,8 @@ from __future__ import annotations
 
 import datetime
 import os
-import re
 
 import openpyxl
-
 
 # ---------- value transform / compare (official port) ----------
 

--- a/skillopt/envs/spreadsheetbench/executor.py
+++ b/skillopt/envs/spreadsheetbench/executor.py
@@ -8,7 +8,6 @@ import sys
 import tempfile
 import textwrap
 
-
 RUNNER_TEMPLATE = textwrap.dedent(
     """
     import os, sys, traceback

--- a/skillopt/envs/spreadsheetbench/rollout.py
+++ b/skillopt/envs/spreadsheetbench/rollout.py
@@ -20,15 +20,16 @@ from concurrent.futures import (
     FIRST_COMPLETED,
     ThreadPoolExecutor,
     wait,
+)
+from concurrent.futures import (
     TimeoutError as FuturesTimeoutError,
 )
 
 import openpyxl
 
-from skillopt.envs.spreadsheetbench.react_agent import run_react
-from skillopt.envs.spreadsheetbench.evaluator import evaluate, _generate_cell_names
+from skillopt.envs.spreadsheetbench.evaluator import _generate_cell_names, evaluate
 from skillopt.envs.spreadsheetbench.executor import run_generated_code
-
+from skillopt.envs.spreadsheetbench.react_agent import run_react
 
 # ── Data loading ─────────────────────────────────────────────────────────────
 
@@ -558,7 +559,7 @@ def process_one_codegen(
     This matches the official evaluation setting: LLM generates a Python code
     block, no function-calling / tool-use.
     """
-    from skillopt.envs.spreadsheetbench.codegen_agent import run_single, run_multi
+    from skillopt.envs.spreadsheetbench.codegen_agent import run_multi, run_single
 
     task_id = str(item["id"])
     instruction = item["instruction"]
@@ -614,7 +615,9 @@ def process_one_codegen(
 
         # ── Save context for Optimizer (Reflect stage) ──────────────────
         from skillopt.envs.spreadsheetbench.codegen_agent import (
-            _preview_workbook, _build_system, _build_user,
+            _build_system,
+            _build_user,
+            _preview_workbook,
         )
         first_input_for_preview = cases[0][1]
         try:

--- a/skillopt/evaluation/gate.py
+++ b/skillopt/evaluation/gate.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-
 GateAction = Literal["accept_new_best", "accept", "reject"]
 GateMetric = Literal["hard", "soft", "mixed"]
 

--- a/skillopt/evolution/__init__.py
+++ b/skillopt/evolution/__init__.py
@@ -1,0 +1,16 @@
+"""Hermes skill evolution prototype helpers."""
+from skillopt.evolution.pipeline import (
+    GateDecision,
+    evaluate_candidate,
+    gate_candidate,
+    promote_candidate,
+    stage_candidate,
+)
+
+__all__ = [
+    "GateDecision",
+    "evaluate_candidate",
+    "gate_candidate",
+    "promote_candidate",
+    "stage_candidate",
+]

--- a/skillopt/evolution/pipeline.py
+++ b/skillopt/evolution/pipeline.py
@@ -1,0 +1,416 @@
+"""Staging → eval → gate → human review → promote for Hermes skills.
+
+This module intentionally does not call external models and never writes to a
+live skill unless promotion is explicitly approved. It is a local governance
+prototype around SkillOpt-generated candidate artifacts such as ``best_skill.md``.
+"""
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import json
+import re
+import shutil
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from skillopt.utils.redaction import REDACTED, redact_secrets, redact_string
+
+_SECRET_RE = re.compile(
+    r"(Bearer\s+[A-Za-z0-9._~+/=-]{12,}|sk-[A-Za-z0-9][A-Za-z0-9._-]{12,}|gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})",
+    re.IGNORECASE,
+)
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)(api[_-]?key|access[_-]?token|auth[_-]?token|password|secret)\s*[=:]\s*[^\s,;]{8,}",
+)
+_DANGEROUS_RE = re.compile(
+    r"\b(rm\s+-rf|sudo\b|curl\b.*\|\s*(?:sh|bash)|chmod\s+777|launchctl\s+load|systemctl\s+enable)\b",
+    re.IGNORECASE,
+)
+_QMD_REF_RE = re.compile(r"qmd://[^\s)\]>'\"]+")
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    passed: bool
+    reasons: list[str]
+    scores: dict[str, float]
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _safe_name(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-") or "skill"
+
+
+def _read_json(path: Path) -> Any:
+    return json.loads(path.read_text())
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(redact_secrets(payload), indent=2, ensure_ascii=False) + "\n")
+
+
+def _secret_hits(text: str) -> list[str]:
+    """Return secret-like substrings without exposing them in reports."""
+    return _SECRET_RE.findall(text) + _SECRET_ASSIGNMENT_RE.findall(text)
+
+
+def stage_candidate(
+    *,
+    registry: Path,
+    skill_name: str,
+    candidate_path: Path,
+    base_skill_path: Path | None = None,
+    source: str = "skillopt",
+) -> dict[str, Any]:
+    """Copy a generated candidate into the staging registry and record lineage."""
+    candidate_path = candidate_path.expanduser().resolve()
+    if not candidate_path.exists():
+        raise FileNotFoundError(candidate_path)
+    skill_slug = _safe_name(skill_name)
+    candidate_id = f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}-{_sha256(candidate_path)[:12]}"
+    stage_dir = registry / "staging" / skill_slug / candidate_id
+    stage_dir.mkdir(parents=True, exist_ok=False)
+    staged_candidate = stage_dir / "candidate.md"
+    raw_candidate = candidate_path.read_text()
+    stage_secret_hits = _secret_hits(raw_candidate)
+    staged_candidate.write_text(redact_string(raw_candidate))
+
+    manifest: dict[str, Any] = {
+        "candidate_id": candidate_id,
+        "created_at": _utc_now(),
+        "skill_name": skill_name,
+        "source": source,
+        "candidate_path": str(staged_candidate),
+        "candidate_sha256": _sha256(staged_candidate),
+        "source_candidate_sha256": _sha256(candidate_path),
+        "candidate_redacted": bool(stage_secret_hits),
+        "stage_sensitive_hits": [REDACTED for _ in stage_secret_hits],
+        "status": "staged",
+    }
+    if base_skill_path is not None:
+        base = base_skill_path.expanduser().resolve()
+        if base.exists():
+            manifest.update({"base_skill_path": str(base), "base_sha256": _sha256(base)})
+    _write_json(stage_dir / "manifest.json", manifest)
+    return manifest
+
+
+def _score_tool_grounding(text: str) -> float:
+    fences = re.findall(r"```.*?```", text, flags=re.DOTALL)
+    if not fences:
+        return 1.0
+    explained = sum(1 for block in fences if "用途" in block or "purpose" in block.lower())
+    nearby = sum(
+        1
+        for block in fences
+        if re.search(r"用途|Purpose|purpose", text[max(0, text.find(block) - 200) : text.find(block) + len(block) + 300])
+    )
+    return min(1.0, max(explained, nearby) / len(fences))
+
+
+def _score_qmd_grounding(text: str) -> tuple[float, list[str]]:
+    """Score whether a candidate cites or instructs use of local qmd knowledge."""
+    references = sorted(set(_QMD_REF_RE.findall(text)))
+    mentions_qmd_lookup = bool(re.search(r"\bqmd\s+(?:search|query|get|multi-get|status)\b", text, flags=re.IGNORECASE))
+    if references and mentions_qmd_lookup:
+        return 1.0, references
+    if references or mentions_qmd_lookup:
+        return 0.8, references
+    return 0.8, references
+
+
+def _score_regression_fixture(text: str, fixture_path: Path | None) -> tuple[float, dict[str, Any]]:
+    """Evaluate a deterministic regression fixture against candidate text.
+
+    Fixture format: {"tasks": [{"name": "...", "required_terms": ["..."]}]}
+    A task passes when every required term appears in the candidate text.
+    """
+    if fixture_path is None:
+        return 0.8, {"path": None, "total": 0, "passed": 0, "failed": []}
+    fixture_path = fixture_path.expanduser().resolve()
+    fixture = _read_json(fixture_path)
+    tasks = fixture.get("tasks", [])
+    if not isinstance(tasks, list):
+        raise ValueError("regression fixture must contain a list at 'tasks'")
+    text_lower = text.lower()
+    failed: list[dict[str, Any]] = []
+    for idx, task in enumerate(tasks):
+        if not isinstance(task, dict):
+            raise ValueError(f"regression task #{idx} must be an object")
+        required_terms = task.get("required_terms", [])
+        if not isinstance(required_terms, list):
+            raise ValueError(f"regression task #{idx} required_terms must be a list")
+        missing = [str(term) for term in required_terms if str(term).lower() not in text_lower]
+        if missing:
+            failed.append({"name": task.get("name", f"task-{idx}"), "missing_terms": missing})
+    total = len(tasks)
+    passed = total - len(failed)
+    score = 0.8 if total == 0 else passed / total
+    return score, {"path": str(fixture_path), "total": total, "passed": passed, "failed": failed}
+
+
+def evaluate_candidate(
+    *,
+    registry: Path,
+    skill_name: str,
+    candidate_id: str,
+    regression_fixture: Path | None = None,
+) -> dict[str, Any]:
+    """Run static/offline evaluation for a staged candidate skill."""
+    stage_dir = registry / "staging" / _safe_name(skill_name) / candidate_id
+    candidate = stage_dir / "candidate.md"
+    manifest_path = stage_dir / "manifest.json"
+    manifest = _read_json(manifest_path)
+    text = candidate.read_text()
+    base_text = ""
+    if manifest.get("base_skill_path") and Path(manifest["base_skill_path"]).exists():
+        base_text = Path(manifest["base_skill_path"]).read_text()
+
+    has_frontmatter = text.startswith("---\n") and "\n---\n" in text[4:]
+    has_description = "description:" in text[:1000].lower()
+    secret_hits = _secret_hits(text) + list(manifest.get("stage_sensitive_hits", []))
+    dangerous_hits = _DANGEROUS_RE.findall(text)
+    qmd_grounding, qmd_references = _score_qmd_grounding(text)
+    regression_score, regression_findings = _score_regression_fixture(text, regression_fixture)
+    scores = {
+        "correctness": 1.0 if has_frontmatter and has_description and len(text.strip()) >= 200 else 0.4,
+        "tool_grounding": _score_tool_grounding(text),
+        "qmd_grounding": qmd_grounding,
+        "regression": regression_score,
+        "safety": 1.0 if not secret_hits and not dangerous_hits else 0.0,
+        "user_style": 1.0 if ("繁體" in text or "Traditional Chinese" in text or "用途" in text) else 0.7,
+        "operational_quality": 1.0 if ("Verify" in text or "驗證" in text or "Verification" in text) else 0.6,
+        "cost_latency": 1.0 if ("cost" in text.lower() or "latency" in text.lower() or "成本" in text or "延遲" in text) else 0.7,
+    }
+    diff = ""
+    if base_text:
+        diff = "".join(
+            difflib.unified_diff(
+                base_text.splitlines(keepends=True),
+                text.splitlines(keepends=True),
+                fromfile="base.md",
+                tofile="candidate.md",
+            )
+        )
+        (stage_dir / "candidate.diff").write_text(diff)
+
+    report = {
+        "candidate_id": candidate_id,
+        "evaluated_at": _utc_now(),
+        "scores": scores,
+        "findings": {
+            "has_frontmatter": has_frontmatter,
+            "has_description": has_description,
+            "secret_hits": [REDACTED for _ in secret_hits],
+            "dangerous_patterns": dangerous_hits,
+            "qmd_references": qmd_references,
+            "regression": regression_findings,
+            "diff_path": str(stage_dir / "candidate.diff") if diff else None,
+        },
+    }
+    _write_json(stage_dir / "eval.json", report)
+    manifest["status"] = "evaluated"
+    _write_json(manifest_path, manifest)
+    return report
+
+
+def gate_candidate(
+    *,
+    registry: Path,
+    skill_name: str,
+    candidate_id: str,
+    min_score: float = 0.8,
+) -> GateDecision:
+    """Decide whether a candidate can advance to human review."""
+    stage_dir = registry / "staging" / _safe_name(skill_name) / candidate_id
+    eval_report = _read_json(stage_dir / "eval.json")
+    scores = {str(k): float(v) for k, v in eval_report["scores"].items()}
+    reasons = [f"{name}={score:.2f} < {min_score:.2f}" for name, score in scores.items() if score < min_score]
+    passed = not reasons
+    decision = GateDecision(passed=passed, reasons=reasons, scores=scores)
+    _write_json(
+        stage_dir / "gate.json",
+        {
+            "candidate_id": candidate_id,
+            "gated_at": _utc_now(),
+            "passed": passed,
+            "reasons": reasons,
+            "scores": scores,
+            "next_state": "human_review" if passed else "rejected",
+        },
+    )
+    manifest = _read_json(stage_dir / "manifest.json")
+    manifest["status"] = "human_review" if passed else "rejected"
+    _write_json(stage_dir / "manifest.json", manifest)
+    if not passed:
+        rejected_dir = registry / "rejected" / _safe_name(skill_name) / candidate_id
+        rejected_dir.parent.mkdir(parents=True, exist_ok=True)
+        if rejected_dir.exists():
+            shutil.rmtree(rejected_dir)
+        shutil.copytree(stage_dir, rejected_dir)
+    return decision
+
+
+def write_review_request(*, registry: Path, skill_name: str, candidate_id: str) -> Path:
+    """Create a human-readable review request for the staged candidate."""
+    stage_dir = registry / "staging" / _safe_name(skill_name) / candidate_id
+    manifest = _read_json(stage_dir / "manifest.json")
+    eval_report = _read_json(stage_dir / "eval.json")
+    gate = _read_json(stage_dir / "gate.json")
+    review_path = stage_dir / "human_review.md"
+    review_path.write_text(
+        "# Human review request\n\n"
+        f"- skill: {skill_name}\n"
+        f"- candidate_id: {candidate_id}\n"
+        f"- status: {manifest.get('status')}\n"
+        f"- gate_passed: {gate.get('passed')}\n"
+        f"- scores: {json.dumps(eval_report.get('scores', {}), ensure_ascii=False)}\n"
+        f"- candidate: {manifest.get('candidate_path')}\n"
+        f"- diff: {eval_report.get('findings', {}).get('diff_path')}\n\n"
+        "## Human review checklist\n\n"
+        "- [ ] Read candidate.md, not just this summary.\n"
+        "- [ ] Read candidate.diff when a base skill exists.\n"
+        "- [ ] Confirm qmd grounding references are relevant and non-sensitive.\n"
+        "- [ ] Confirm regression fixture failures are absent or intentionally accepted.\n"
+        "- [ ] Confirm safety gate found no secrets or dangerous commands.\n"
+        "- [ ] Confirm promotion dry-run output before writing the live skill.\n\n"
+        "Promotion requires an explicit approver name.\n"
+    )
+    return review_path
+
+
+def promote_candidate(
+    *,
+    registry: Path,
+    skill_name: str,
+    candidate_id: str,
+    live_skill_path: Path,
+    approved_by: str,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Promote a gated candidate into a live skill path after explicit approval."""
+    if not approved_by.strip():
+        raise ValueError("approved_by is required for promotion")
+    stage_dir = registry / "staging" / _safe_name(skill_name) / candidate_id
+    gate = _read_json(stage_dir / "gate.json")
+    if not gate.get("passed"):
+        raise ValueError("candidate did not pass gate")
+    review_path = stage_dir / "human_review.md"
+    if not dry_run and not review_path.exists():
+        raise ValueError("human_review.md is required before promotion")
+    candidate = stage_dir / "candidate.md"
+    live_skill_path = live_skill_path.expanduser().resolve()
+    if dry_run:
+        return {
+            "candidate_id": candidate_id,
+            "skill_name": skill_name,
+            "dry_run": True,
+            "would_write": str(live_skill_path),
+            "candidate_sha256": _sha256(candidate),
+            "approved_by": approved_by,
+        }
+    archive_dir = registry / "archive" / _safe_name(skill_name) / candidate_id
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    if live_skill_path.exists():
+        shutil.copy2(live_skill_path, archive_dir / "previous_live.md")
+    live_skill_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(candidate, live_skill_path)
+    record = {
+        "candidate_id": candidate_id,
+        "skill_name": skill_name,
+        "dry_run": False,
+        "promoted_at": _utc_now(),
+        "approved_by": approved_by,
+        "live_skill_path": str(live_skill_path),
+        "live_sha256": _sha256(live_skill_path),
+        "previous_live_archive": str(archive_dir / "previous_live.md") if (archive_dir / "previous_live.md").exists() else None,
+    }
+    _write_json(stage_dir / "promotion.json", record)
+    manifest = _read_json(stage_dir / "manifest.json")
+    manifest["status"] = "promoted"
+    _write_json(stage_dir / "manifest.json", manifest)
+    return record
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Hermes skill evolution governance prototype")
+    sub = parser.add_subparsers(dest="command", required=True)
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--registry", type=Path, required=True)
+    common.add_argument("--skill-name", required=True)
+    stage = sub.add_parser("stage", parents=[common])
+    stage.add_argument("--candidate", type=Path, required=True)
+    stage.add_argument("--base", type=Path)
+    stage.add_argument("--source", default="skillopt")
+    evaluate = sub.add_parser("eval", parents=[common])
+    evaluate.add_argument("--candidate-id", required=True)
+    evaluate.add_argument("--regression-fixture", type=Path)
+    gate = sub.add_parser("gate", parents=[common])
+    gate.add_argument("--candidate-id", required=True)
+    gate.add_argument("--min-score", type=float, default=0.8)
+    review = sub.add_parser("review", parents=[common])
+    review.add_argument("--candidate-id", required=True)
+    promote = sub.add_parser("promote", parents=[common])
+    promote.add_argument("--candidate-id", required=True)
+    promote.add_argument("--live-skill-path", type=Path, required=True)
+    promote.add_argument("--approved-by", required=True)
+    promote.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.command == "stage":
+        result = stage_candidate(
+            registry=args.registry,
+            skill_name=args.skill_name,
+            candidate_path=args.candidate,
+            base_skill_path=args.base,
+            source=args.source,
+        )
+    elif args.command == "eval":
+        result = evaluate_candidate(
+            registry=args.registry,
+            skill_name=args.skill_name,
+            candidate_id=args.candidate_id,
+            regression_fixture=args.regression_fixture,
+        )
+    elif args.command == "gate":
+        decision = gate_candidate(
+            registry=args.registry,
+            skill_name=args.skill_name,
+            candidate_id=args.candidate_id,
+            min_score=args.min_score,
+        )
+        result = {"passed": decision.passed, "reasons": decision.reasons, "scores": decision.scores}
+    elif args.command == "review":
+        result = {"review_path": str(write_review_request(registry=args.registry, skill_name=args.skill_name, candidate_id=args.candidate_id))}
+    elif args.command == "promote":
+        result = promote_candidate(
+            registry=args.registry,
+            skill_name=args.skill_name,
+            candidate_id=args.candidate_id,
+            live_skill_path=args.live_skill_path,
+            approved_by=args.approved_by,
+            dry_run=args.dry_run,
+        )
+    else:  # pragma: no cover
+        raise AssertionError(args.command)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/skillopt/gradient/__init__.py
+++ b/skillopt/gradient/__init__.py
@@ -9,7 +9,7 @@ Modules
 - reflect: minibatch trajectory analysis (gradient computation)
 - aggregate: hierarchical patch merging (gradient aggregation)
 """
+from skillopt.gradient.aggregate import merge_patches  # noqa: F401
 from skillopt.gradient.reflect import (  # noqa: F401
     run_minibatch_reflect,
 )
-from skillopt.gradient.aggregate import merge_patches  # noqa: F401

--- a/skillopt/gradient/aggregate.py
+++ b/skillopt/gradient/aggregate.py
@@ -22,7 +22,6 @@ from skillopt.optimizer.update_modes import (
 from skillopt.prompts import load_prompt
 from skillopt.utils import extract_json
 
-
 # ── Internal helpers ──────────────────────────────────────────────────────────
 
 def _merge_batch(

--- a/skillopt/gradient/reflect.py
+++ b/skillopt/gradient/reflect.py
@@ -33,13 +33,11 @@ from skillopt.optimizer.update_modes import (
     get_payload_items,
     is_full_rewrite_minibatch_mode,
     normalize_update_mode,
-    payload_key,
     payload_label,
     truncate_payload,
 )
 from skillopt.prompts import load_prompt
 from skillopt.utils import extract_json
-
 
 # ── Trajectory formatting ────────────────────────────────────────────────────
 
@@ -300,9 +298,9 @@ def run_error_analyst_minibatch(
     )
     if is_full_rewrite_minibatch_mode(mode):
         user += (
-            f"## Update Format\n"
-            f"Produce one complete replacement skill candidate for this minibatch. "
-            f"Do not output edits, patches, or revise suggestions.\n\n"
+            "## Update Format\n"
+            "Produce one complete replacement skill candidate for this minibatch. "
+            "Do not output edits, patches, or revise suggestions.\n\n"
         )
     else:
         user += (
@@ -378,9 +376,9 @@ def run_success_analyst_minibatch(
     )
     if is_full_rewrite_minibatch_mode(mode):
         user += (
-            f"## Update Format\n"
-            f"Produce one complete replacement skill candidate for this minibatch. "
-            f"Do not output edits, patches, or revise suggestions.\n\n"
+            "## Update Format\n"
+            "Produce one complete replacement skill candidate for this minibatch. "
+            "Do not output edits, patches, or revise suggestions.\n\n"
         )
     else:
         user += (

--- a/skillopt/model/__init__.py
+++ b/skillopt/model/__init__.py
@@ -13,13 +13,13 @@ from skillopt.model.backend_config import (  # noqa: F401
     configure_codex_exec,
     get_claude_code_exec_config,
     get_codex_exec_config,
-    get_target_backend,
     get_optimizer_backend,
+    get_target_backend,
+    is_optimizer_chat_backend,
     is_target_chat_backend,
     is_target_exec_backend,
-    is_optimizer_chat_backend,
-    set_target_backend,
     set_optimizer_backend,
+    set_target_backend,
 )
 
 
@@ -97,6 +97,16 @@ def chat_optimizer(
         )
     if get_optimizer_backend() == "qwen_chat":
         return _qwen.chat_optimizer(
+            system=system,
+            user=user,
+            max_completion_tokens=max_completion_tokens,
+            retries=retries,
+            stage=stage,
+            reasoning_effort=reasoning_effort,
+            timeout=timeout,
+        )
+    if get_optimizer_backend() == "minimax_chat":
+        return _minimax.chat_optimizer(
             system=system,
             user=user,
             max_completion_tokens=max_completion_tokens,
@@ -193,6 +203,18 @@ def chat_optimizer_messages(
         )
     if get_optimizer_backend() == "qwen_chat":
         return _qwen.chat_optimizer_messages(
+            messages=messages,
+            max_completion_tokens=max_completion_tokens,
+            retries=retries,
+            stage=stage,
+            reasoning_effort=reasoning_effort,
+            tools=tools,
+            tool_choice=tool_choice,
+            return_message=return_message,
+            timeout=timeout,
+        )
+    if get_optimizer_backend() == "minimax_chat":
+        return _minimax.chat_optimizer_messages(
             messages=messages,
             max_completion_tokens=max_completion_tokens,
             retries=retries,
@@ -510,3 +532,4 @@ def set_optimizer_deployment(deployment: str) -> None:
     _openai.set_optimizer_deployment(deployment)
     _claude.set_optimizer_deployment(deployment)
     _qwen.set_optimizer_deployment(deployment)
+    _minimax.set_optimizer_deployment(deployment)

--- a/skillopt/model/azure_openai.py
+++ b/skillopt/model/azure_openai.py
@@ -12,6 +12,7 @@ import threading
 import time
 from types import SimpleNamespace
 from typing import Any
+
 from openai import AzureOpenAI, OpenAI
 
 # Sentinel value used as the api_version when the "openai_compatible"
@@ -673,12 +674,12 @@ def configure_azure_openai(
         _clean(optimizer_managed_identity_client_id)
         or shared_managed_identity_client_id
     )
-    
+
     # Auto-configure for openai_compatible mode
     if resolved_optimizer_auth_mode in {"openai_compatible", "compat", "openai"}:
         if resolved_optimizer_api_version is None:
             resolved_optimizer_api_version = _OPENAI_COMPATIBLE_API_VERSION
-    
+
     resolved_target_endpoint = _clean(target_endpoint) or shared_endpoint
     resolved_target_api_version = _clean(target_api_version) or shared_api_version
     resolved_target_api_key = _clean(target_api_key) or shared_api_key
@@ -688,7 +689,7 @@ def configure_azure_openai(
         _clean(target_managed_identity_client_id)
         or shared_managed_identity_client_id
     )
-    
+
     # Auto-configure for openai_compatible mode
     if resolved_target_auth_mode in {"openai_compatible", "compat", "openai"}:
         if resolved_target_api_version is None:

--- a/skillopt/model/backend_config.py
+++ b/skillopt/model/backend_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import os
 
-from skillopt.model.common import default_model_for_backend, normalize_backend_name
+from skillopt.model.common import normalize_backend_name
 
 
 def _parse_bool(value: str | None, default: bool) -> bool:

--- a/skillopt/model/claude_backend.py
+++ b/skillopt/model/claude_backend.py
@@ -12,7 +12,13 @@ import time
 from typing import Any
 from urllib.parse import unquote, urlparse
 
-from skillopt.model.common import CompatAssistantMessage, CompatToolCall, CompatToolFunction, default_model_for_backend, tracker
+from skillopt.model.common import (
+    CompatAssistantMessage,
+    CompatToolCall,
+    CompatToolFunction,
+    default_model_for_backend,
+    tracker,
+)
 
 CLAUDE_BIN = os.environ.get("CLAUDE_CLI_BIN", "claude")
 CLAUDE_PERMISSION_MODE = os.environ.get("CLAUDE_PERMISSION_MODE", "dontAsk")

--- a/skillopt/model/codex_backend.py
+++ b/skillopt/model/codex_backend.py
@@ -19,7 +19,6 @@ from skillopt.model.common import (
     tracker,
 )
 
-
 CODEX_BIN = os.environ.get("CODEX_CLI_BIN", "codex")
 CODEX_PROFILE = os.environ.get("CODEX_PROFILE", "review")
 CODEX_SANDBOX_MODE = os.environ.get("CODEX_SANDBOX_MODE", "read-only")

--- a/skillopt/model/codex_harness.py
+++ b/skillopt/model/codex_harness.py
@@ -17,7 +17,6 @@ from skillopt.model.backend_config import (
     get_target_backend,
 )
 
-
 ANSWER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {

--- a/skillopt/model/common.py
+++ b/skillopt/model/common.py
@@ -6,7 +6,6 @@ import threading
 from dataclasses import dataclass, field
 from typing import Any
 
-
 _RESPONSES_API_MODELS = {
     "gpt-5.3-codex",
     "gpt-5.1-codex",

--- a/skillopt/model/minimax_backend.py
+++ b/skillopt/model/minimax_backend.py
@@ -32,6 +32,10 @@ ENABLE_THINKING = os.environ.get("MINIMAX_ENABLE_THINKING", "false").strip().low
     "on",
 }
 
+OPTIMIZER_DEPLOYMENT = os.environ.get(
+    "OPTIMIZER_DEPLOYMENT",
+    default_model_for_backend("minimax_chat"),
+)
 TARGET_DEPLOYMENT = os.environ.get(
     "TARGET_DEPLOYMENT",
     default_model_for_backend("minimax_chat"),
@@ -214,6 +218,53 @@ def get_max_tokens() -> int:
     return MAX_TOKENS
 
 
+def chat_optimizer(
+    system: str,
+    user: str,
+    max_completion_tokens: int = 16384,
+    retries: int = 5,
+    stage: str = "optimizer",
+    reasoning_effort: str | None = None,
+    timeout: float | None = None,
+) -> tuple[str, dict[str, int]]:
+    del reasoning_effort
+    messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
+    return _chat_messages_impl(
+        messages,
+        max_completion_tokens,
+        retries,
+        stage,
+        deployment=OPTIMIZER_DEPLOYMENT,
+        timeout=timeout,
+    )
+
+
+def chat_optimizer_messages(
+    messages: list[dict[str, Any]],
+    max_completion_tokens: int = 16384,
+    retries: int = 5,
+    stage: str = "optimizer",
+    reasoning_effort: str | None = None,
+    *,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: str | dict[str, Any] | None = None,
+    return_message: bool = False,
+    timeout: float | None = None,
+) -> tuple[Any, dict[str, int]]:
+    del reasoning_effort
+    return _chat_messages_impl(
+        messages,
+        max_completion_tokens,
+        retries,
+        stage,
+        tools=tools,
+        tool_choice=tool_choice,
+        return_message=return_message,
+        deployment=OPTIMIZER_DEPLOYMENT,
+        timeout=timeout,
+    )
+
+
 def chat_target(
     system: str,
     user: str,
@@ -269,6 +320,12 @@ def reset_token_tracker() -> None:
 
 def set_reasoning_effort(effort: str | None) -> None:
     del effort
+
+
+def set_optimizer_deployment(deployment: str) -> None:
+    global OPTIMIZER_DEPLOYMENT
+    OPTIMIZER_DEPLOYMENT = deployment or default_model_for_backend("minimax_chat")
+    os.environ["OPTIMIZER_DEPLOYMENT"] = OPTIMIZER_DEPLOYMENT
 
 
 def set_target_deployment(deployment: str) -> None:

--- a/skillopt/model/qwen_backend.py
+++ b/skillopt/model/qwen_backend.py
@@ -1,13 +1,13 @@
 """OpenAI-compatible Qwen chat backend for optimizer and target paths."""
 from __future__ import annotations
 
-from dataclasses import dataclass
 import json
 import os
 import threading
 import time
 import urllib.error
 import urllib.request
+from dataclasses import dataclass
 from typing import Any
 
 from skillopt.model.common import (

--- a/skillopt/model/router.py
+++ b/skillopt/model/router.py
@@ -7,7 +7,6 @@ from typing import Any
 from . import azure_openai, claude_backend, codex_backend
 from .common import normalize_backend_name
 
-
 _ACTIVE_BACKEND = normalize_backend_name(
     os.environ.get("REFLACT_MODEL_BACKEND", "azure_openai")
 )

--- a/skillopt/optimizer/__init__.py
+++ b/skillopt/optimizer/__init__.py
@@ -11,5 +11,5 @@ Modules
 - slow_update: longitudinal comparison and guidance (EMA / regularization)
 - meta_skill: cross-epoch memory for optimizer context
 """
-from skillopt.optimizer.skill import apply_edit, apply_patch  # noqa: F401
 from skillopt.optimizer.clip import rank_and_select  # noqa: F401
+from skillopt.optimizer.skill import apply_edit, apply_patch  # noqa: F401

--- a/skillopt/optimizer/clip.py
+++ b/skillopt/optimizer/clip.py
@@ -19,7 +19,6 @@ from skillopt.optimizer.update_modes import (
 from skillopt.prompts import load_prompt
 from skillopt.utils import extract_json
 
-
 # ── Public API ────────────────────────────────────────────────────────────────
 
 def rank_and_select(

--- a/skillopt/optimizer/lr_autonomous.py
+++ b/skillopt/optimizer/lr_autonomous.py
@@ -1,7 +1,6 @@
 """Optimizer-driven autonomous update-size decisions."""
 from __future__ import annotations
 
-import json
 import re
 from typing import Any
 

--- a/skillopt/optimizer/rewrite.py
+++ b/skillopt/optimizer/rewrite.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import json
 
 from skillopt.model import chat_optimizer
-from skillopt.prompts import load_prompt
 from skillopt.optimizer.update_modes import get_payload_items
+from skillopt.prompts import load_prompt
 from skillopt.utils import extract_json
 
 

--- a/skillopt/optimizer/skill.py
+++ b/skillopt/optimizer/skill.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from skillopt.types import Edit as EditType, Patch as PatchType
+    from skillopt.types import Edit as EditType
+    from skillopt.types import Patch as PatchType
 
 SLOW_UPDATE_START = "<!-- SLOW_UPDATE_START -->"
 SLOW_UPDATE_END = "<!-- SLOW_UPDATE_END -->"

--- a/skillopt/types.py
+++ b/skillopt/types.py
@@ -11,12 +11,12 @@ BatchSpec              — from skillopt.datasets.base
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field, fields as dc_fields
+from dataclasses import dataclass, field
+from dataclasses import fields as dc_fields
 from typing import Any, Literal
 
-from skillopt.evaluation.gate import GateAction, GateResult  # noqa: F401
 from skillopt.datasets.base import BatchSpec  # noqa: F401
-
+from skillopt.evaluation.gate import GateAction, GateResult  # noqa: F401
 
 # ── Atomic types ─────────────────────────────────────────────────────────
 

--- a/skillopt/utils/json_utils.py
+++ b/skillopt/utils/json_utils.py
@@ -3,40 +3,52 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Iterator
+from typing import Any
+
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL | re.IGNORECASE)
+_DECODER = json.JSONDecoder()
+
+
+def _candidate_blocks(text: str) -> Iterator[str]:
+    """Yield fenced blocks before scanning the full text."""
+    for match in _JSON_FENCE_RE.finditer(text):
+        yield match.group(1).strip()
+    yield text
+
+
+def _raw_decode_at_offsets(text: str, start_chars: str) -> Iterator[Any]:
+    """Decode the first valid JSON value that starts at any requested char."""
+    for idx, char in enumerate(text):
+        if char not in start_chars:
+            continue
+        try:
+            value, _end = _DECODER.raw_decode(text[idx:])
+        except json.JSONDecodeError:
+            continue
+        yield value
+
+
+def _extract_typed_json(text: str, expected_type: type, start_chars: str) -> Any | None:
+    if not isinstance(text, str) or not text:
+        return None
+    for block in _candidate_blocks(text):
+        for value in _raw_decode_at_offsets(block, start_chars):
+            if isinstance(value, expected_type):
+                return value
+    return None
 
 
 def extract_json(text: str) -> dict | None:
-    """Extract a JSON object from LLM response text.
+    """Extract the first JSON object from LLM response text.
 
-    Tries ```json fences first, then bare {...} patterns.
+    Fenced JSON blocks are preferred. Bare text is scanned with
+    ``JSONDecoder.raw_decode`` instead of greedy regexes, so multiple adjacent
+    objects, nested objects, and arrays next to prose are handled safely.
     """
-    m = re.search(r"```json\s*(.*?)```", text, re.DOTALL)
-    if m:
-        try:
-            return json.loads(m.group(1))
-        except json.JSONDecodeError:
-            pass
-    m = re.search(r"\{.*\}", text, re.DOTALL)
-    if m:
-        try:
-            return json.loads(m.group(0))
-        except json.JSONDecodeError:
-            pass
-    return None
+    return _extract_typed_json(text, dict, "{")
 
 
 def extract_json_array(text: str) -> list | None:
-    """Extract a JSON array from LLM response text."""
-    m = re.search(r"```json\s*(.*?)```", text, re.DOTALL)
-    if m:
-        try:
-            return json.loads(m.group(1))
-        except json.JSONDecodeError:
-            pass
-    m = re.search(r"\[.*\]", text, re.DOTALL)
-    if m:
-        try:
-            return json.loads(m.group(0))
-        except json.JSONDecodeError:
-            pass
-    return None
+    """Extract the first JSON array from LLM response text."""
+    return _extract_typed_json(text, list, "[")

--- a/skillopt/utils/redaction.py
+++ b/skillopt/utils/redaction.py
@@ -1,0 +1,52 @@
+"""Secret redaction helpers for persisted SkillOpt artifacts."""
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+REDACTED = "[REDACTED]"
+
+_SECRET_KEY_RE = re.compile(
+    r"(?:^|[_-])(api[_-]?key|access[_-]?token|auth[_-]?token|bearer|client[_-]?secret|credential|password|secret|token)(?:$|[_-])",
+    re.IGNORECASE,
+)
+_SECRET_VALUE_RES = [
+    re.compile(r"Bearer\s+[A-Za-z0-9._~+/=-]{12,}", re.IGNORECASE),
+    re.compile(r"sk-[A-Za-z0-9][A-Za-z0-9._-]{12,}"),
+    re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"(?i)(api[_-]?key|access[_-]?token|auth[_-]?token|password|secret)\s*[=:]\s*[^\s,;]{8,}"),
+]
+
+
+def is_secret_key(key: str) -> bool:
+    """Return True when a mapping key is likely to contain a credential."""
+    return bool(_SECRET_KEY_RE.search(str(key)))
+
+
+def redact_string(value: str) -> str:
+    """Redact credential-like substrings in free-form text."""
+    redacted = value
+    for pattern in _SECRET_VALUE_RES:
+        redacted = pattern.sub(REDACTED, redacted)
+    return redacted
+
+
+def redact_secrets(value: Any) -> Any:
+    """Recursively redact secrets from JSON-serializable artifacts.
+
+    Mapping values are replaced wholesale when the key name is credential-like.
+    Free-form strings are scanned for common token patterns. Other scalar values
+    are preserved.
+    """
+    if isinstance(value, Mapping):
+        return {
+            str(key): REDACTED if is_secret_key(str(key)) and item not in (None, "") else redact_secrets(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, str):
+        return redact_string(value)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [redact_secrets(item) for item in value]
+    return value

--- a/skillopt_webui/__main__.py
+++ b/skillopt_webui/__main__.py
@@ -1,3 +1,4 @@
 # SkillOpt WebUI — `__main__` entry point
 from skillopt_webui.app import main
+
 main()

--- a/skillopt_webui/app.py
+++ b/skillopt_webui/app.py
@@ -12,7 +12,6 @@ import signal
 import subprocess
 import sys
 import threading
-import time
 from pathlib import Path
 
 import gradio as gr

--- a/tests/test_evolution_pipeline.py
+++ b/tests/test_evolution_pipeline.py
@@ -1,0 +1,165 @@
+"""Tests for Hermes skill evolution governance prototype."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from skillopt.evolution.pipeline import (
+    evaluate_candidate,
+    gate_candidate,
+    promote_candidate,
+    stage_candidate,
+    write_review_request,
+)
+
+GOOD_SKILL = """---
+name: demo-skill
+description: Demo skill for safe candidate evaluation.
+---
+
+# Demo Skill
+
+Use this skill to test staging.
+
+```bash
+qmd status
+```
+用途：確認 qmd index 狀態。
+
+## Verification
+
+Check cost and latency before promoting.
+"""
+
+
+def test_stage_eval_gate_review_promote_flow(tmp_path) -> None:
+    registry = tmp_path / "registry"
+    live = tmp_path / "live" / "SKILL.md"
+    candidate = tmp_path / "candidate.md"
+    live.parent.mkdir(parents=True)
+    live.write_text(GOOD_SKILL.replace("Demo Skill", "Old Demo Skill"))
+    candidate.write_text(GOOD_SKILL)
+
+    manifest = stage_candidate(
+        registry=registry,
+        skill_name="demo-skill",
+        candidate_path=candidate,
+        base_skill_path=live,
+    )
+    candidate_id = manifest["candidate_id"]
+
+    report = evaluate_candidate(registry=registry, skill_name="demo-skill", candidate_id=candidate_id)
+    assert report["scores"]["safety"] == 1.0
+
+    decision = gate_candidate(registry=registry, skill_name="demo-skill", candidate_id=candidate_id)
+    assert decision.passed
+
+    review_path = write_review_request(registry=registry, skill_name="demo-skill", candidate_id=candidate_id)
+    assert review_path.exists()
+
+    promotion = promote_candidate(
+        registry=registry,
+        skill_name="demo-skill",
+        candidate_id=candidate_id,
+        live_skill_path=live,
+        approved_by="unit-test",
+    )
+    assert promotion["approved_by"] == "unit-test"
+    assert live.read_text() == GOOD_SKILL
+
+
+def test_gate_rejects_secret_candidate(tmp_path) -> None:
+    registry = tmp_path / "registry"
+    candidate = tmp_path / "candidate.md"
+    candidate.write_text(GOOD_SKILL + "\napi_key=abcdefghijklmno\n")
+    manifest = stage_candidate(registry=registry, skill_name="demo", candidate_path=candidate)
+    candidate_id = manifest["candidate_id"]
+
+    staged = registry / "staging" / "demo" / candidate_id / "candidate.md"
+    assert "abcdefghijklmno" not in staged.read_text()
+    assert manifest["candidate_redacted"] is True
+    report = evaluate_candidate(registry=registry, skill_name="demo", candidate_id=candidate_id)
+    decision = gate_candidate(registry=registry, skill_name="demo", candidate_id=candidate_id)
+
+    assert report["scores"]["safety"] == 0.0
+    assert not decision.passed
+    gate = json.loads((registry / "staging" / "demo" / candidate_id / "gate.json").read_text())
+    assert gate["passed"] is False
+
+
+def test_eval_scores_regression_fixture_and_qmd_grounding(tmp_path) -> None:
+    registry = tmp_path / "registry"
+    candidate = tmp_path / "candidate.md"
+    fixture = tmp_path / "fixture.json"
+    candidate.write_text(
+        GOOD_SKILL
+        + "\n## Grounding\n"
+        + "- qmd://hermes-agent-architecture/index.md records Hermes Agent runtime context.\n"
+        + "- Use qmd search before editing skills.\n"
+        + "\n## Regression coverage\n"
+        + "This skill covers safety gate, human review, and promotion dry-run workflows.\n"
+    )
+    fixture.write_text(
+        json.dumps(
+            {
+                "tasks": [
+                    {"name": "safety", "required_terms": ["safety gate", "human review"]},
+                    {"name": "dry-run", "required_terms": ["promotion dry-run"]},
+                ]
+            }
+        )
+    )
+    manifest = stage_candidate(registry=registry, skill_name="demo", candidate_path=candidate)
+
+    report = evaluate_candidate(
+        registry=registry,
+        skill_name="demo",
+        candidate_id=manifest["candidate_id"],
+        regression_fixture=fixture,
+    )
+
+    assert report["scores"]["qmd_grounding"] == 1.0
+    assert report["scores"]["regression"] == 1.0
+    assert report["findings"]["qmd_references"] == ["qmd://hermes-agent-architecture/index.md"]
+    assert report["findings"]["regression"]["passed"] == 2
+
+
+def test_review_request_contains_checklist_and_promote_dry_run_does_not_write_live(tmp_path) -> None:
+    registry = tmp_path / "registry"
+    live = tmp_path / "live" / "SKILL.md"
+    candidate = tmp_path / "candidate.md"
+    live.parent.mkdir(parents=True)
+    live.write_text("old-live")
+    candidate.write_text(GOOD_SKILL)
+    manifest = stage_candidate(registry=registry, skill_name="demo", candidate_path=candidate)
+    candidate_id = manifest["candidate_id"]
+    evaluate_candidate(registry=registry, skill_name="demo", candidate_id=candidate_id)
+    gate_candidate(registry=registry, skill_name="demo", candidate_id=candidate_id, min_score=0.6)
+
+    with pytest.raises(ValueError, match="human_review.md is required"):
+        promote_candidate(
+            registry=registry,
+            skill_name="demo",
+            candidate_id=candidate_id,
+            live_skill_path=live,
+            approved_by="unit-test",
+        )
+
+    review_path = write_review_request(registry=registry, skill_name="demo", candidate_id=candidate_id)
+    review_text = review_path.read_text()
+    assert "## Human review checklist" in review_text
+    assert "[ ] Read candidate.md" in review_text
+    assert "[ ] Confirm promotion dry-run output" in review_text
+
+    promotion = promote_candidate(
+        registry=registry,
+        skill_name="demo",
+        candidate_id=candidate_id,
+        live_skill_path=live,
+        approved_by="unit-test",
+        dry_run=True,
+    )
+    assert promotion["dry_run"] is True
+    assert promotion["would_write"] == str(live)
+    assert live.read_text() == "old-live"

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,8 +1,6 @@
 """Tests for skillopt.utils.json_utils."""
 from __future__ import annotations
 
-import pytest
-
 from skillopt.utils.json_utils import extract_json, extract_json_array
 
 
@@ -38,6 +36,14 @@ class TestExtractJson:
     def test_nested_json(self) -> None:
         text = '```json\n{"outer": {"inner": [1, 2, 3]}}\n```'
         assert extract_json(text) == {"outer": {"inner": [1, 2, 3]}}
+
+    def test_multiple_objects_returns_first_valid_object(self) -> None:
+        text = 'first {"a": 1} second {"b": 2}'
+        assert extract_json(text) == {"a": 1}
+
+    def test_fenced_array_does_not_satisfy_object_extraction(self) -> None:
+        text = '```json\n[1, 2, 3]\n```\nthen {"fallback": true}'
+        assert extract_json(text) == {"fallback": True}
 
     def test_no_json_returns_none(self) -> None:
         assert extract_json("Just plain text without JSON.") is None
@@ -89,6 +95,14 @@ class TestExtractJsonArray:
     def test_nested_array(self) -> None:
         text = '```json\n[[1, 2], [3, 4]]\n```'
         assert extract_json_array(text) == [[1, 2], [3, 4]]
+
+    def test_multiple_arrays_returns_first_valid_array(self) -> None:
+        text = 'first [1] second [2]'
+        assert extract_json_array(text) == [1]
+
+    def test_fenced_object_does_not_satisfy_array_extraction(self) -> None:
+        text = '```json\n{"not": "array"}\n```\nthen ["fallback"]'
+        assert extract_json_array(text) == ["fallback"]
 
     def test_no_array_returns_none(self) -> None:
         assert extract_json_array("no brackets here") is None

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -1,0 +1,54 @@
+"""Tests for model backend routing."""
+from __future__ import annotations
+
+import skillopt.model as model
+
+
+def test_minimax_optimizer_backend_routes_to_minimax(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def fake_minimax_optimizer(**kwargs):
+        calls.append(("minimax", kwargs["stage"]))
+        return "minimax-ok", {"total_tokens": 1}
+
+    def fake_openai_optimizer(**kwargs):  # pragma: no cover - should not be called
+        calls.append(("openai", kwargs["stage"]))
+        return "openai-wrong", {"total_tokens": 1}
+
+    original_backend = model.get_optimizer_backend()
+    try:
+        monkeypatch.setattr(model._minimax, "chat_optimizer", fake_minimax_optimizer)
+        monkeypatch.setattr(model._openai, "chat_optimizer", fake_openai_optimizer)
+        model.set_optimizer_backend("minimax_chat")
+
+        text, usage = model.chat_optimizer("system", "user", stage="optimizer-test")
+
+        assert text == "minimax-ok"
+        assert usage == {"total_tokens": 1}
+        assert calls == [("minimax", "optimizer-test")]
+    finally:
+        model.set_optimizer_backend(original_backend)
+
+
+def test_minimax_optimizer_messages_backend_routes_to_minimax(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_minimax_messages(**kwargs):
+        calls.append(kwargs["stage"])
+        return "minimax-messages-ok", {"total_tokens": 2}
+
+    original_backend = model.get_optimizer_backend()
+    try:
+        monkeypatch.setattr(model._minimax, "chat_optimizer_messages", fake_minimax_messages)
+        model.set_optimizer_backend("minimax_chat")
+
+        text, usage = model.chat_optimizer_messages(
+            [{"role": "user", "content": "hello"}],
+            stage="messages-test",
+        )
+
+        assert text == "minimax-messages-ok"
+        assert usage == {"total_tokens": 2}
+        assert calls == ["messages-test"]
+    finally:
+        model.set_optimizer_backend(original_backend)

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,46 @@
+"""Tests for persisted artifact redaction."""
+from __future__ import annotations
+
+import json
+
+from skillopt.engine.trainer import _redact_cfg, _save_history, _save_runtime_state
+from skillopt.utils.redaction import REDACTED, redact_secrets
+
+
+def test_redact_secrets_recurses_keys_and_strings() -> None:
+    payload = {
+        "api_key": "sk-1234567890abcdef",
+        "nested": {
+            "client_secret": "very-secret-value",
+            "message": "Authorization: Bearer abcdefghijklmnop",
+        },
+        "items": [{"access_token": "ghp_abcdefghijklmnopqrstuvwxyz"}],
+    }
+
+    redacted = redact_secrets(payload)
+
+    assert redacted["api_key"] == REDACTED
+    assert redacted["nested"]["client_secret"] == REDACTED
+    assert REDACTED in redacted["nested"]["message"]
+    assert redacted["items"][0]["access_token"] == REDACTED
+
+
+def test_trainer_config_history_and_runtime_state_are_redacted(tmp_path) -> None:
+    cfg = {
+        "optimizer": "openai",
+        "openai_api_key": "sk-1234567890abcdef",
+        "nested": {"password": "do-not-store"},
+    }
+    assert _redact_cfg(cfg) == {
+        "optimizer": "openai",
+        "openai_api_key": REDACTED,
+        "nested": {"password": REDACTED},
+    }
+
+    _save_history(str(tmp_path), [{"note": "Bearer abcdefghijklmnop", "token": "abc123456789"}])
+    _save_runtime_state(str(tmp_path), {"api_key": "sk-1234567890abcdef"})
+
+    history = json.loads((tmp_path / "history.json").read_text())
+    state = json.loads((tmp_path / "runtime_state.json").read_text())
+    assert history == [{"note": REDACTED, "token": REDACTED}]
+    assert state == {"api_key": REDACTED}

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,10 +1,7 @@
 """Tests for skillopt.types — Edit and Patch dataclass serialization."""
 from __future__ import annotations
 
-import pytest
-
 from skillopt.types import Edit, Patch
-
 
 # ── Edit ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add a Hermes-oriented skill evolution pipeline with staged artifacts, evaluation, safety gating, human-review handoff, and promotion.
- Harden JSON extraction to avoid greedy matching across multiple JSON objects/arrays.
- Add recursive redaction for persisted artifacts and extend candidate safety checks for secret-like values.
- Add MiniMax optimizer routing support so `minimax`/`minimax_chat` does not drift to OpenAI optimizer defaults.
- Clean existing lint issues and ignore local `uv.lock` generated during smoke runs.

## Test Plan
- `uv run --with pytest --with ruff --with openai --with pyyaml --with numpy --with openpyxl --with azure-identity --with azure-core --with httpx pytest -q` → `72 passed in 0.48s`
- `uv run --with pytest --with ruff --with openai --with pyyaml --with numpy --with openpyxl --with azure-identity --with azure-core --with httpx ruff check .` → `All checks passed!`
- `uv run --with pytest --with ruff --with openai --with pyyaml --with numpy --with openpyxl --with azure-identity --with azure-core --with httpx python -m compileall -q skillopt scripts skillopt_webui` → exit 0
- `uv run --with pytest --with ruff --with openai --with pyyaml --with numpy --with openpyxl --with azure-identity --with azure-core --with httpx python scripts/hermes_skill_evolve.py eval --help` → exit 0
- `uv run --with pytest --with ruff --with openai --with pyyaml --with numpy --with openpyxl --with azure-identity --with azure-core --with httpx python scripts/hermes_skill_evolve.py promote --help` → exit 0
- `git diff --check` → exit 0

## Notes
- Draft PR because this is a prototype and includes a broad lint cleanup commit to make the current tree pass `ruff`.
- The secret scan hits are expected references to redaction logic, config key names, and synthetic test fixtures; no real credentials are included.
