### PR TITLE
Fix Gitmoot optimizer artifact contract

### DIFF
--- a/GOAL-GITMOOT-SKILLOPT-MVP.md
+++ b/GOAL-GITMOOT-SKILLOPT-MVP.md
@@ -1,0 +1,469 @@
+# Gitmoot-SkillOpt MVP
+
+Implement the plan task by task. Each task must be developed, reviewed, opened
+as its own pull request, merged, and verified before moving on, unless tasks are
+explicitly safe to run in parallel.
+
+Build the first Gitmoot-specific SkillOpt optimizer path. The intended outcome
+is a local-first optimizer repo that consumes Gitmoot training packages, runs
+the existing SkillOpt training loop through a Gitmoot adapter, emits a
+Gitmoot-compatible pending candidate package, and hands optimizer-produced
+artifacts back to Gitmoot through a verified artifact manifest. Gitmoot remains
+the registry, artifact-store owner, feedback collector, and human
+promotion/rejection layer.
+
+This goal touches two repositories:
+
+- Primary repo: `/root/gitmoot-skillopt`
+- Supporting contract repo: `/root/gitmoot`
+
+Do not implement live pairwise evaluation in this goal. That remains tracked in
+Gitmoot issue #77. Do not make `gitmoot-skillopt` write directly into
+`~/.gitmoot`, Gitmoot SQLite, or Gitmoot artifact blobs.
+
+External context checked before writing this goal:
+
+- Gitmoot issue #67 defines the approved architecture: Gitmoot exports training
+  packages, `gitmoot-skillopt` optimizes, Gitmoot imports pending candidates,
+  and humans promote or reject.
+- Gitmoot issue #77 tracks future live pairwise evaluation and is out of scope
+  for this MVP.
+- Artifact-system patterns favor immutable output packages, content hashes,
+  provenance metadata, and import-time verification by the owning registry.
+- Prompt-optimization systems need examples plus metrics/evaluators; prompt
+  text alone is not enough for reproducible optimization.
+
+## Core Rules
+
+- Work one task at a time in the listed order by default.
+- If tasks are independent, have disjoint file ownership, and do not depend on
+  each other's results, they may be done in parallel on separate branches.
+- Do not start dependent work until the prerequisite task has passed checks,
+  passed `codex exec review --uncommitted`, been pushed, opened as a PR, merged,
+  and verified on the target branch.
+- Do not commit generated data, reports, caches, build artifacts, secrets,
+  credentials, session archives, cloned helper repos, local plugin build output,
+  optimizer output directories, or large outputs unless the plan explicitly says
+  they are intended tracked fixtures/artifacts.
+- Preserve existing behavior unless the current task explicitly changes it.
+- Keep changes clean, scoped, and organized. Avoid broad rewrites.
+- Avoid code duplication. When repeated logic appears, extract small reusable
+  helpers that match existing repo patterns.
+- If implementation depends on external APIs, docs, CLIs, data formats,
+  generated scripts, installers, service launchers, subprocess calls, env vars,
+  config formats, or third-party libraries, verify the real contract with local
+  commands and/or official sources before editing.
+- For multi-repo tasks, identify every changed repository and run the relevant
+  checks and `codex exec review --uncommitted` in each changed repo.
+
+## Before Starting
+
+1. Inspect current repo state in both repos:
+   - `cd /root/gitmoot-skillopt && git status --short && git branch --show-current && git remote -v`
+   - `cd /root/gitmoot && git status --short && git branch --show-current && git remote -v`
+2. If either target branch is unclear, a remote looks wrong, or a worktree has
+   unrelated existing changes that make task commits ambiguous, stop and ask
+   before continuing.
+3. Confirm the target base branch from each repo. If unspecified, use the
+   current branch as the base.
+4. Inspect relevant existing patterns before editing.
+5. Verify PR tooling is available before the first PR:
+   - `gh auth status`
+   - each repo remote resolves to the expected GitHub repository.
+
+## Per-Task Branch Workflow
+
+1. Confirm the current task's scope.
+2. Create a task branch from the latest target base branch in the repo or repos
+   touched by the task.
+3. Implement only that task.
+4. Add or update focused tests/checks appropriate to the task.
+5. Run focused tests for touched modules.
+6. Run broader checks when the task touches shared behavior, CLI/API surfaces,
+   data/model/evaluation logic, generated scripts, installers, service
+   launchers, docs build systems, or user-facing workflows.
+7. For wrapper, installer, CLI, subprocess, generated-script, env propagation,
+   service-launcher, or deployment changes, include an operational smoke test or
+   direct contract check. Syntax checks alone are not enough.
+8. Identify every repository where files changed. In each changed repo, run:
+   `codex exec review --uncommitted`
+9. Preserve the exact raw review output per repo.
+
+## Review-Fix Loop
+
+1. If review finds issues, do not only patch the literal line.
+2. Identify the underlying invariant/class of bug.
+3. Audit nearby and sibling paths for the same issue.
+4. Write a concise fix plan using:
+
+   ```text
+   Review found these issues: <<PASTE RAW REVIEW RESULTS BY REPO>>.
+   For each issue, identify the underlying invariant/class of bug, audit sibling
+   paths for the same issue, and plan the smallest safe fix. Verify external
+   assumptions with local commands and/or official sources. Preserve repo
+   patterns, avoid unnecessary refactors, and list tests/checks per repo.
+   ```
+
+5. Execute the fix plan.
+6. Re-run focused tests/checks and `codex exec review --uncommitted` in every
+   repo with uncommitted changes.
+7. Repeat until the final raw review output contains no findings, or stop if
+   blocked or if a finding is incorrect after verification.
+
+## Commit Gate
+
+1. Before committing, run `git diff --check` and inspect the final diff.
+2. Commit only the current task's intended tracked changes.
+3. Use the commit message specified by the plan. If the plan does not specify
+   one, use a concise conventional message that describes only the current task.
+4. Push the task branch.
+5. Verify the task branch worktree is clean after push, except for intentionally
+   ignored generated files.
+
+## Pull Request Gate
+
+1. Create one PR for the current task in every changed repo. If a task changes
+   both repos, create linked PRs and merge them in dependency order.
+2. The PR title must describe only the current task.
+3. The PR body must include:
+   - WHAT: what was changed
+   - WHY: why the task was needed
+   - CHANGES: concrete implementation changes
+   - RESULTS: tests/checks/review results
+   - RISK: skipped checks, blockers, or residual risk
+4. Include the exact raw final `codex exec review --uncommitted` output for each
+   changed repo in the PR body.
+5. If CI or required checks exist, wait for them and fix failures before merge.
+6. Merge the PR using the repository's configured/preferred merge method. If no
+   preference is discoverable, use squash merge for a clean task-level history.
+7. After merge, update the local target base branch and verify the worktree is
+   clean.
+8. Record the PR number, PR URL, branch name, and merged commit hash.
+9. Delete the task branch after merge only if the repository normally does so or
+   the merge command supports safe branch deletion.
+
+## Parallel Task Rules
+
+- Parallelize only when tasks are independent, have disjoint file ownership, and
+  can be reviewed and merged without order-dependent assumptions.
+- Use a separate branch per task.
+- Clearly assign each branch a task number and file ownership.
+- Do not duplicate work across branches.
+- If parallel branches conflict after one PR merges, rebase or update the
+  remaining branch on the latest target base and re-run its checks/review.
+- If a task becomes dependent on another task, stop treating it as parallel and
+  merge the dependency first.
+
+## Final Response After All Tasks
+
+- List completed tasks.
+- For each task, list branch, PR URL, merge status, and merged commit hash.
+- List tests/checks run.
+- Include exact final raw `codex exec review --uncommitted` output for the last
+  task/repo.
+- Mention skipped checks, blockers, or residual risk.
+- Do not claim interactive `/review` is clean. Say:
+  `codex exec review is clean; ready for manual /review.`
+
+## Implementation Tasks
+
+### Task 1: Rebrand The Fork And Add The Gitmoot CLI Entry Point
+
+Scope:
+
+- In `/root/gitmoot-skillopt`, update project identity from upstream SkillOpt to
+  Gitmoot-SkillOpt while preserving upstream attribution and license.
+- Add a new console script entry point, preferably:
+  `gitmoot-skillopt = gitmoot_skillopt.cli:main`.
+- Keep existing `skillopt-train` and `skillopt-eval` commands working unless
+  there is a clear conflict.
+- Add a minimal `gitmoot_skillopt` package for Gitmoot-specific CLI and glue
+  code, leaving upstream `skillopt` modules intact where possible.
+- Add top-level README notes explaining that this fork is the Gitmoot optimizer
+  layer and does not own Gitmoot promotion state.
+
+Acceptance criteria:
+
+- `python -m gitmoot_skillopt --help` works.
+- `gitmoot-skillopt --help` works after editable install.
+- Existing `python scripts/train.py --help` still works.
+- README clearly explains the boundary:
+  `gitmoot-skillopt` proposes candidates; Gitmoot imports, reviews, and
+  promotes/rejects.
+
+Tests/checks:
+
+- `python -m compileall gitmoot_skillopt skillopt scripts`
+- `python -m gitmoot_skillopt --help`
+- `python scripts/train.py --help`
+- If dev deps are installed: `ruff check .`
+
+Suggested commit message:
+
+- `feat: add gitmoot-skillopt cli scaffold`
+
+### Task 2: Add Gitmoot Package Models And Artifact Resolution
+
+Scope:
+
+- Add Gitmoot contract models in `/root/gitmoot-skillopt`, matching Gitmoot's
+  v1 JSON contract:
+  - training package
+  - template snapshot
+  - eval run
+  - eval items
+  - artifact refs
+  - feedback events
+  - candidate package
+  - candidate artifact manifest entries
+- Add strict validation for:
+  - expected `kind`
+  - `contract_version == 1`
+  - template id and candidate metadata consistency
+  - non-empty template content
+  - artifact ids, paths, hashes, media types, and drivers
+- Add a Gitmoot artifact resolver that can read Gitmoot SHA256 blobs from
+  `--artifact-root`, using the Gitmoot layout:
+  `sha256/<first-2-hex>/<full-hex-hash>`.
+- Add safe local output artifact helpers that write optimizer-produced artifacts
+  under `--out-root/artifacts`, compute SHA256, and produce manifest entries.
+- Do not write to Gitmoot SQLite or `~/.gitmoot`.
+
+Acceptance criteria:
+
+- Valid fixture training packages load and round-trip.
+- Invalid package kind/version/hash/path data fails with actionable errors.
+- Artifact resolution refuses missing blobs and invalid hashes.
+- Local optimizer artifacts cannot escape the configured artifact output dir.
+
+Tests/checks:
+
+- Add pytest tests for package load/validation, Gitmoot blob resolution, and
+  optimizer artifact manifest generation.
+- `python -m pytest tests/test_gitmoot_package.py tests/test_gitmoot_artifacts.py`
+- `python -m compileall gitmoot_skillopt skillopt scripts`
+
+Suggested commit message:
+
+- `feat: add gitmoot package contract models`
+
+### Task 3: Add Gitmoot DataLoader And EnvAdapter
+
+Scope:
+
+- Add `skillopt/envs/gitmoot/` with:
+  - `package.py` or imports from `gitmoot_skillopt` contract code
+  - `dataloader.py`
+  - `adapter.py`
+  - `rollout.py`
+  - `evaluator.py`
+- Register the `gitmoot` adapter in the training CLI registry without breaking
+  existing built-in adapters.
+- Convert Gitmoot training package items into SkillOpt train/val/test batches.
+- Use package item metadata and artifact refs to build task prompts.
+- Start with text/Markdown artifacts. Other drivers must fail with a clear
+  "driver not supported yet" error.
+- Preserve YAML frontmatter from the template snapshot. SkillOpt should optimize
+  the Markdown body while candidate output remains a full agent-template
+  Markdown document.
+- Implement the MVP evaluator:
+  - use explicit evaluator config when supported
+  - otherwise use an LLM judge comparing source/baseline/candidate output
+  - mark judge-derived scores clearly in result metadata
+- Include existing feedback events as optimizer context, not as automatic
+  promotion.
+
+Acceptance criteria:
+
+- A fixture Gitmoot training package can be loaded into a Gitmoot adapter.
+- The adapter can build train and eval batches from package items.
+- Unsupported artifact drivers fail clearly.
+- Rollout returns SkillOpt-compatible result dicts with `id`, `hard`, `soft`,
+  `response`, `fail_reason`, and useful metadata.
+- The adapter does not mutate Gitmoot local state.
+
+Tests/checks:
+
+- Unit tests for `GitmootDataLoader` split/batch behavior.
+- Unit tests for text artifact prompt construction and unsupported drivers.
+- Unit tests for evaluator behavior with deterministic fixture evaluator config.
+- `python -m pytest tests/test_gitmoot_dataloader.py tests/test_gitmoot_adapter.py`
+- `python -m compileall gitmoot_skillopt skillopt scripts`
+
+Suggested commit message:
+
+- `feat: add gitmoot skillopt adapter`
+
+### Task 4: Implement `gitmoot-skillopt optimize`
+
+Scope:
+
+- Implement:
+
+  ```sh
+  gitmoot-skillopt optimize \
+    --training-package training.json \
+    --artifact-root ~/.gitmoot/evals/blobs \
+    --out-root outputs/<run-id> \
+    --candidate-output outputs/<run-id>/candidate.json
+  ```
+
+- Build a resolved SkillOpt config from the Gitmoot package plus CLI options.
+- Use the existing `ReflACTTrainer` instead of duplicating the training loop.
+- Persist the template snapshot content as the initial skill for the run.
+- Route the Gitmoot package path, artifact root, and output artifact dir through
+  config/env fields consumed by the Gitmoot adapter.
+- After training, read `best_skill.md` and emit a Gitmoot candidate package.
+- Write optimizer artifacts under `--out-root/artifacts`, including at least:
+  - `candidate.diff.md`
+  - `eval-report.json`
+  - optionally `preference-summary.md`
+- Candidate package `summary.diff_artifact_id` must reference the generated
+  artifact manifest id.
+- Candidate package must include `eval_report` and a concise
+  `preference_summary`.
+
+Acceptance criteria:
+
+- `gitmoot-skillopt optimize --help` documents all required flags.
+- A dry-run or tiny fixture mode can produce a structurally valid
+  `candidate.json` without network calls.
+- Normal optimize mode runs the existing trainer with the Gitmoot adapter.
+- Output artifacts include declared hashes and can be verified independently.
+- Candidate content is full agent-template Markdown with valid frontmatter.
+
+Tests/checks:
+
+- CLI tests for missing required flags, invalid package path, and invalid
+  artifact root.
+- Fixture end-to-end test that produces `candidate.json` and `artifacts/`
+  without external model calls.
+- `python -m pytest tests/test_gitmoot_optimize_cli.py`
+- `python -m compileall gitmoot_skillopt skillopt scripts`
+
+Suggested commit message:
+
+- `feat: add gitmoot optimize command`
+
+### Task 5: Add Gitmoot Candidate Artifact Manifest Import
+
+Scope:
+
+- In `/root/gitmoot`, extend `gitmoot skillopt import` with:
+
+  ```sh
+  gitmoot skillopt import --file candidate.json --artifact-dir ./artifacts
+  ```
+
+- Extend the Gitmoot candidate package contract with optional artifact manifest
+  entries:
+  - `id`
+  - `path`
+  - `hash`
+  - `media_type`
+  - `driver`
+  - optional `size_bytes`
+- Import logic must:
+  1. Load `candidate.json`.
+  2. If artifact entries exist, require `--artifact-dir`.
+  3. Resolve artifact paths only inside `--artifact-dir`.
+  4. Reject absolute paths and path traversal.
+  5. Verify SHA256 hashes.
+  6. Store verified blobs in Gitmoot content-addressed storage.
+  7. Register artifact metadata in SQLite.
+  8. Validate `summary.diff_artifact_id`.
+  9. Import the candidate as a pending template version.
+- Keep backward compatibility for candidate packages without artifact entries.
+
+Acceptance criteria:
+
+- `gitmoot skillopt import --file candidate.json --artifact-dir artifacts`
+  imports valid candidate artifacts and pending candidate metadata.
+- Invalid hashes, missing files, absolute paths, and path traversal fail before
+  mutating candidate state.
+- Packages without artifact entries still import as before.
+- `candidate show` can display the imported diff artifact id.
+
+Tests/checks:
+
+- Go unit tests for artifact manifest validation and path safety.
+- CLI e2e test for valid artifact import.
+- CLI tests for invalid hash, missing artifact dir, and path traversal.
+- `/root/temp/ts/tool/go test ./internal/skillopt ./internal/cli ./internal/artifact ./internal/db`
+- `/root/temp/ts/tool/go test ./...`
+
+Suggested commit message:
+
+- `feat: import skillopt candidate artifacts`
+
+### Task 6: Add Cross-Repo Smoke Documentation And Examples
+
+Scope:
+
+- Add docs in `/root/gitmoot-skillopt` showing the full flow:
+  1. export from Gitmoot
+  2. optimize with `gitmoot-skillopt`
+  3. import candidate with `--artifact-dir`
+  4. inspect candidate
+  5. collect Markdown or GitHub feedback
+  6. promote or reject
+- Add a tiny fixture package and artifact files only if they are intentionally
+  tracked test fixtures and small enough for the repo.
+- Add a smoke script or documented smoke command that exercises fixture output
+  without external model calls.
+- Add a short note in `/root/gitmoot` docs linking to the external
+  `gitmoot-skillopt` optimizer flow if appropriate.
+
+Acceptance criteria:
+
+- A new user can follow the docs without needing to know internal architecture.
+- Docs clearly state that `gitmoot-skillopt` does not auto-promote candidates.
+- Docs explain that live pairwise evaluation is out of scope for MVP and tracked
+  separately.
+- Fixture smoke validates candidate package shape and artifact hashes.
+
+Tests/checks:
+
+- `python -m pytest`
+- `python -m compileall gitmoot_skillopt skillopt scripts`
+- In `/root/gitmoot`, run docs/static checks if docs are changed.
+- In every changed repo, run `git diff --check`.
+
+Suggested commit message:
+
+- `docs: add gitmoot skillopt mvp workflow`
+
+### Task 7: End-To-End Local Contract Verification
+
+Scope:
+
+- Run a full local contract smoke using both repos and fixture data:
+  1. create or use a small Gitmoot fixture eval run
+  2. export `training.json`
+  3. run `gitmoot-skillopt optimize` in fixture/dry-run mode
+  4. import `candidate.json` with `--artifact-dir`
+  5. show the pending candidate
+  6. reject it with a test reason in a temp Gitmoot home
+- Do not mutate the user's real `~/.gitmoot` during smoke. Use a temp
+  `--home`/test home where supported.
+- If a gap in Gitmoot's fixture setup makes this impossible, add the smallest
+  deterministic test helper needed rather than using production state.
+
+Acceptance criteria:
+
+- The smoke proves the package boundary end to end without external model calls.
+- The smoke proves artifact hashes are verified by Gitmoot import.
+- The smoke proves the candidate remains pending until explicit promote/reject.
+- The smoke output is documented in the final PR body or final task summary.
+
+Tests/checks:
+
+- Full smoke command sequence in temp directories.
+- `python -m pytest`
+- `python -m compileall gitmoot_skillopt skillopt scripts`
+- `/root/temp/ts/tool/go test ./...` in `/root/gitmoot` if changed.
+- `codex exec review --uncommitted` in every changed repo.
+
+Suggested commit message:
+
+- `test: add gitmoot skillopt contract smoke`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
+# Gitmoot-SkillOpt
+
+Gitmoot-SkillOpt is the external optimizer layer for
+[Gitmoot](https://github.com/jerryfane/gitmoot). It consumes Gitmoot SkillOpt
+training packages, runs SkillOpt-style optimization over Gitmoot agent-template
+Markdown, and emits candidate packages that Gitmoot imports as pending template
+versions.
+
+Gitmoot remains the registry and review layer: it owns template versions,
+artifact storage, feedback collectors, and the explicit human
+promote/reject decision. Gitmoot-SkillOpt proposes candidates; Gitmoot imports,
+reviews, and promotes or rejects them.
+
+This repository is forked from
+[microsoft/SkillOpt](https://github.com/microsoft/SkillOpt) and preserves the
+upstream SkillOpt trainer, benchmark adapters, scripts, and MIT license while
+adding Gitmoot-specific package I/O and CLI glue.
+
+Initial command surface:
+
+```bash
+gitmoot-skillopt --help
+gitmoot-skillopt optimize \
+  --training-package training.json \
+  --artifact-root ~/.gitmoot/evals/blobs \
+  --out-root outputs/run-1 \
+  --candidate-output outputs/run-1/candidate.json
+```
+
+The `optimize` command shape is scaffolded first; Gitmoot package parsing,
+artifact resolution, adapter execution, and candidate emission are implemented
+task by task in `GOAL-GITMOOT-SKILLOPT-MVP.md`.
+
+## Upstream SkillOpt
+
 # SkillOpt: Executive Strategy for Self-Evolving Agent Skills
 
 *Train agent skills like you train neural networks — with epochs, (mini-)batchsize, learning rates, and validation gates — but without touching model weights.*

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ gitmoot-skillopt optimize \
   --candidate-output outputs/run-1/candidate.json
 ```
 
-The `optimize` command shape is scaffolded first; Gitmoot package parsing,
-artifact resolution, adapter execution, and candidate emission are implemented
-task by task in `GOAL-GITMOOT-SKILLOPT-MVP.md`.
+For the full Gitmoot export, optimize, import, review, and promote/reject
+workflow, see
+[`docs/guide/gitmoot-mvp-workflow.md`](docs/guide/gitmoot-mvp-workflow.md).
+For a no-network contract smoke, run the fixture command in that guide with
+`--dry-run`.
 
 ## Upstream SkillOpt
 

--- a/docs/guide/gitmoot-mvp-workflow.md
+++ b/docs/guide/gitmoot-mvp-workflow.md
@@ -1,0 +1,136 @@
+# Gitmoot MVP Workflow
+
+This guide shows the local boundary between Gitmoot and Gitmoot-SkillOpt.
+Gitmoot owns agent-template state, eval artifacts, feedback collection, and the
+human promote/reject decision. Gitmoot-SkillOpt consumes an exported training
+package, proposes a candidate package, and writes optimizer artifacts for
+Gitmoot to verify on import.
+
+The MVP uses saved baseline and candidate artifacts from a completed Gitmoot
+eval run. Live pairwise evaluation is intentionally out of scope for this repo
+flow and is tracked separately in Gitmoot issue #77.
+
+## 1. Export Training Data From Gitmoot
+
+Run this from the Gitmoot repo or any project where `gitmoot` is configured:
+
+```bash
+gitmoot skillopt export --run <run-id> --output training.json
+```
+
+The exported package includes:
+
+- the current agent-template snapshot
+- eval run metadata
+- eval items split by metadata when available
+- artifact refs for saved baseline, candidate, preview, or diff outputs
+- feedback events gathered from Markdown or GitHub collectors
+- evaluator config for deterministic fixture or judge-backed scoring
+
+Gitmoot artifact blobs stay in Gitmoot's content-addressed store. Pass that blob
+root to Gitmoot-SkillOpt as `--artifact-root`.
+
+## 2. Optimize With Gitmoot-SkillOpt
+
+Install this repo in editable mode, then run the optimizer:
+
+```bash
+pip install -e .
+
+gitmoot-skillopt optimize \
+  --training-package training.json \
+  --artifact-root ~/.gitmoot/evals/blobs \
+  --out-root outputs/run-1 \
+  --candidate-output outputs/run-1/candidate.json
+```
+
+For a no-network contract smoke, use the tracked fixture:
+
+```bash
+gitmoot-skillopt optimize \
+  --training-package examples/gitmoot/mvp-fixture/training.json \
+  --artifact-root examples/gitmoot/mvp-fixture/blobs \
+  --out-root /tmp/gitmoot-skillopt-smoke \
+  --candidate-output /tmp/gitmoot-skillopt-smoke/candidate.json \
+  --dry-run
+```
+
+The dry run validates package loading, Gitmoot artifact resolution, candidate
+package emission, and generated artifact manifests without starting the trainer
+or calling external model APIs.
+
+## 3. Import The Candidate Into Gitmoot
+
+Import the optimizer output back into Gitmoot:
+
+```bash
+gitmoot skillopt import \
+  --file outputs/run-1/candidate.json \
+  --artifact-dir outputs/run-1/artifacts
+```
+
+Gitmoot verifies every manifest entry before mutating candidate state:
+
+- artifact paths must stay inside `--artifact-dir`
+- absolute paths and path traversal are rejected
+- SHA256 hashes and optional sizes must match
+- blobs are stored in Gitmoot content-addressed storage
+- candidate metadata is registered as a pending template version
+
+Candidate packages without artifact manifest entries still import through the
+legacy path.
+
+## 4. Inspect The Pending Candidate
+
+List and inspect pending versions:
+
+```bash
+gitmoot skillopt candidate list --template <template-id>
+gitmoot skillopt candidate show <version-id>
+```
+
+`candidate show` displays the candidate state, eval report, preference summary,
+content diff, and imported `diff_artifact_id` when present.
+
+## 5. Collect Human Feedback
+
+Use Markdown packets for local review:
+
+```bash
+gitmoot skillopt feedback markdown export \
+  --run <run-id> \
+  --output .gitmoot/evals/<run-id>
+
+gitmoot skillopt feedback markdown import \
+  --packet .gitmoot/evals/<run-id> \
+  --reviewer <name>
+```
+
+Use GitHub when collaborators should review in issues or PR comments:
+
+```bash
+gitmoot skillopt feedback github publish \
+  --run <run-id> \
+  --repo owner/reviews
+
+gitmoot skillopt feedback github sync \
+  --run <run-id> \
+  --repo owner/reviews \
+  --issue <number>
+```
+
+Humans choose baseline or candidate per review item and may include reasoning.
+Feedback becomes optimizer context for later runs; it does not promote a
+candidate automatically.
+
+## 6. Promote Or Reject
+
+After inspection and feedback, explicitly decide:
+
+```bash
+gitmoot skillopt candidate promote <version-id>
+gitmoot skillopt candidate reject <version-id> --reason "Needs narrower scope"
+```
+
+Promotion makes the candidate the current Gitmoot agent-template version.
+Rejection records an auditable reason and leaves the current template unchanged.

--- a/docs/guide/gitmoot-mvp-workflow.md
+++ b/docs/guide/gitmoot-mvp-workflow.md
@@ -59,6 +59,18 @@ The dry run validates package loading, Gitmoot artifact resolution, candidate
 package emission, and generated artifact manifests without starting the trainer
 or calling external model APIs.
 
+To test the Gitmoot import boundary too, build or point to a current `gitmoot`
+binary and run:
+
+```bash
+.venv/bin/python scripts/gitmoot_contract_smoke.py --gitmoot-bin /path/to/gitmoot
+```
+
+The script uses a temporary Gitmoot home, installs
+`examples/gitmoot/mvp-fixture/template.md` as a local template, imports the
+generated candidate with `--artifact-dir`, verifies the pending candidate shows
+`candidate-diff`, and rejects it with a test reason.
+
 ## 3. Import The Candidate Into Gitmoot
 
 Import the optimizer output back into Gitmoot:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,5 +1,44 @@
 # CLI Reference
 
+## Gitmoot Optimizer
+
+```bash
+gitmoot-skillopt optimize \
+  --training-package training.json \
+  --artifact-root ~/.gitmoot/evals/blobs \
+  --out-root outputs/run-1 \
+  --candidate-output outputs/run-1/candidate.json
+```
+
+### Arguments
+
+| Argument | Description |
+|---|---|
+| `--training-package` | Gitmoot SkillOpt training package from `gitmoot skillopt export` |
+| `--artifact-root` | Gitmoot blob root, usually `~/.gitmoot/evals/blobs` |
+| `--out-root` | Optimizer output directory |
+| `--candidate-output` | Candidate package JSON path to import back into Gitmoot |
+| `--dry-run` | Emit deterministic fixture output without trainer/model calls |
+
+### Contract Smoke
+
+```bash
+gitmoot-skillopt optimize \
+  --training-package examples/gitmoot/mvp-fixture/training.json \
+  --artifact-root examples/gitmoot/mvp-fixture/blobs \
+  --out-root /tmp/gitmoot-skillopt-smoke \
+  --candidate-output /tmp/gitmoot-skillopt-smoke/candidate.json \
+  --dry-run
+```
+
+Import the generated candidate with:
+
+```bash
+gitmoot skillopt import \
+  --file /tmp/gitmoot-skillopt-smoke/candidate.json \
+  --artifact-dir /tmp/gitmoot-skillopt-smoke/artifacts
+```
+
 ## Training
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -39,6 +39,12 @@ gitmoot skillopt import \
   --artifact-dir /tmp/gitmoot-skillopt-smoke/artifacts
 ```
 
+Or run the full temp-home Gitmoot import smoke:
+
+```bash
+.venv/bin/python scripts/gitmoot_contract_smoke.py --gitmoot-bin /path/to/gitmoot
+```
+
 ## Training
 
 ```bash

--- a/examples/gitmoot/mvp-fixture/blobs/sha256/66/66d9267e4e2c9bca17821a5e8fe13f75fd2f69b22f6241efd0d95635b12036f7
+++ b/examples/gitmoot/mvp-fixture/blobs/sha256/66/66d9267e4e2c9bca17821a5e8fe13f75fd2f69b22f6241efd0d95635b12036f7
@@ -1,0 +1,3 @@
+# Baseline output
+
+The baseline plan is vague and misses verification.

--- a/examples/gitmoot/mvp-fixture/blobs/sha256/bc/bc31fe229466d0df6d23d314d4865dd232eea4ff9546137b6060be1235318287
+++ b/examples/gitmoot/mvp-fixture/blobs/sha256/bc/bc31fe229466d0df6d23d314d4865dd232eea4ff9546137b6060be1235318287
@@ -1,0 +1,3 @@
+# Candidate output
+
+The candidate plan is task-by-task, includes checks, and keeps human promotion explicit.

--- a/examples/gitmoot/mvp-fixture/template.md
+++ b/examples/gitmoot/mvp-fixture/template.md
@@ -1,0 +1,22 @@
+---
+id: planner-fixture
+name: Planner Fixture
+description: Plans implementation work for the Gitmoot-SkillOpt fixture.
+kind: agent-template
+version: 1
+capabilities:
+  - ask
+runtime_compatibility:
+  - codex
+  - claude
+tags:
+  - planning
+  - fixture
+inputs:
+  - request
+outputs:
+  - plan
+---
+# Planner Fixture
+
+Create concise task-by-task implementation plans with verification steps and human review gates.

--- a/examples/gitmoot/mvp-fixture/training.json
+++ b/examples/gitmoot/mvp-fixture/training.json
@@ -1,0 +1,117 @@
+{
+  "artifacts": [
+    {
+      "driver": "text",
+      "hash": "sha256:66d9267e4e2c9bca17821a5e8fe13f75fd2f69b22f6241efd0d95635b12036f7",
+      "id": "baseline",
+      "media_type": "text/markdown",
+      "size_bytes": 71
+    },
+    {
+      "driver": "text",
+      "hash": "sha256:bc31fe229466d0df6d23d314d4865dd232eea4ff9546137b6060be1235318287",
+      "id": "candidate",
+      "media_type": "text/markdown",
+      "size_bytes": 109
+    }
+  ],
+  "contract_version": 1,
+  "eval_run": {
+    "id": "fixture-run-1",
+    "metadata": {
+      "metric": "preference",
+      "source": "tracked-fixture"
+    },
+    "state": "completed",
+    "target_repo": "jerryfane/gitmoot-fixture",
+    "template_id": "planner",
+    "template_version_id": "planner@v1"
+  },
+  "evaluator_config": {
+    "mode": "fixture"
+  },
+  "feedback_events": [
+    {
+      "choice": "b",
+      "created_at": "2026-05-31T00:00:00Z",
+      "item_id": "train-1",
+      "reasoning": "The candidate explains ordered tasks and verification better.",
+      "reviewer": "fixture-reviewer",
+      "run_id": "fixture-run-1",
+      "source": "markdown",
+      "source_url": ""
+    }
+  ],
+  "items": [
+    {
+      "baseline_artifact_id": "baseline",
+      "candidate_artifact_id": "candidate",
+      "id": "train-1",
+      "metadata": {
+        "expected_hard": true,
+        "mock_response": "Candidate gives an ordered plan with checks.",
+        "split": "train"
+      },
+      "title": "Fixture train item"
+    },
+    {
+      "baseline_artifact_id": "baseline",
+      "candidate_artifact_id": "candidate",
+      "id": "val-1",
+      "metadata": {
+        "expected_hard": false,
+        "expected_soft": 0.25,
+        "mock_response": "Candidate is clearer but still needs tighter wording.",
+        "split": "val"
+      },
+      "title": "Fixture validation item"
+    },
+    {
+      "baseline_artifact_id": "baseline",
+      "candidate_artifact_id": "candidate",
+      "id": "test-1",
+      "metadata": {
+        "expected_hard": true,
+        "mock_response": "Candidate preserves the review gate.",
+        "split": "test"
+      },
+      "title": "Fixture test item"
+    }
+  ],
+  "kind": "gitmoot-skillopt-training-package",
+  "template": {
+    "content": "---\nid: planner\nname: Planner\ndescription: Plans implementation work.\nkind: agent-template\nversion: 1\ncapabilities:\n  - ask\nruntime_compatibility:\n  - codex\n  - claude\ntags:\n  - planning\ninputs:\n  - request\noutputs:\n  - plan\n---\n# Planner\n\nCreate concise task-by-task implementation plans with verification steps and human review gates.\n",
+    "content_hash": "sha256:01052aa735b47ec53434d812d0c97130fcae8386f2658e0c5aa64a43f396dedd",
+    "id": "planner",
+    "metadata": {
+      "capabilities": [
+        "ask"
+      ],
+      "description": "Plans implementation work.",
+      "id": "planner",
+      "inputs": [
+        "request"
+      ],
+      "kind": "agent-template",
+      "name": "Planner",
+      "outputs": [
+        "plan"
+      ],
+      "runtime_compatibility": [
+        "codex",
+        "claude"
+      ],
+      "tags": [
+        "planning"
+      ],
+      "version": 1
+    },
+    "resolved_commit": "fixture",
+    "source_path": "skills/gitmoot/agent-templates/planner.md",
+    "source_ref": "main",
+    "source_repo": "jerryfane/gitmoot",
+    "version_id": "planner@v1",
+    "version_number": 1,
+    "version_state": "current"
+  }
+}

--- a/examples/gitmoot/mvp-fixture/training.json
+++ b/examples/gitmoot/mvp-fixture/training.json
@@ -24,8 +24,8 @@
     },
     "state": "completed",
     "target_repo": "jerryfane/gitmoot-fixture",
-    "template_id": "planner",
-    "template_version_id": "planner@v1"
+    "template_id": "planner-fixture",
+    "template_version_id": "planner-fixture@v1"
   },
   "evaluator_config": {
     "mode": "fixture"
@@ -80,20 +80,20 @@
   ],
   "kind": "gitmoot-skillopt-training-package",
   "template": {
-    "content": "---\nid: planner\nname: Planner\ndescription: Plans implementation work.\nkind: agent-template\nversion: 1\ncapabilities:\n  - ask\nruntime_compatibility:\n  - codex\n  - claude\ntags:\n  - planning\ninputs:\n  - request\noutputs:\n  - plan\n---\n# Planner\n\nCreate concise task-by-task implementation plans with verification steps and human review gates.\n",
-    "content_hash": "sha256:01052aa735b47ec53434d812d0c97130fcae8386f2658e0c5aa64a43f396dedd",
-    "id": "planner",
+    "content": "---\nid: planner-fixture\nname: Planner Fixture\ndescription: Plans implementation work for the Gitmoot-SkillOpt fixture.\nkind: agent-template\nversion: 1\ncapabilities:\n  - ask\nruntime_compatibility:\n  - codex\n  - claude\ntags:\n  - planning\n  - fixture\ninputs:\n  - request\noutputs:\n  - plan\n---\n# Planner Fixture\n\nCreate concise task-by-task implementation plans with verification steps and human review gates.\n",
+    "content_hash": "sha256:7fc26e0618f0bfabc55f5516446a27278e25eeabb4f5574fe0e2537ffe95bea0",
+    "id": "planner-fixture",
     "metadata": {
       "capabilities": [
         "ask"
       ],
-      "description": "Plans implementation work.",
-      "id": "planner",
+      "description": "Plans implementation work for the Gitmoot-SkillOpt fixture.",
+      "id": "planner-fixture",
       "inputs": [
         "request"
       ],
       "kind": "agent-template",
-      "name": "Planner",
+      "name": "Planner Fixture",
       "outputs": [
         "plan"
       ],
@@ -102,15 +102,16 @@
         "claude"
       ],
       "tags": [
-        "planning"
+        "planning",
+        "fixture"
       ],
       "version": 1
     },
     "resolved_commit": "fixture",
-    "source_path": "skills/gitmoot/agent-templates/planner.md",
+    "source_path": "examples/gitmoot/mvp-fixture/template.md",
     "source_ref": "main",
     "source_repo": "jerryfane/gitmoot",
-    "version_id": "planner@v1",
+    "version_id": "planner-fixture@v1",
     "version_number": 1,
     "version_state": "current"
   }

--- a/gitmoot_skillopt/__init__.py
+++ b/gitmoot_skillopt/__init__.py
@@ -1,0 +1,21 @@
+"""Gitmoot-specific SkillOpt integration package."""
+
+from __future__ import annotations
+
+try:
+    from importlib.metadata import version
+except ImportError:  # pragma: no cover - Python 3.10+ always has it.
+    version = None  # type: ignore[assignment]
+
+
+def package_version() -> str:
+    """Return the installed package version when available."""
+    if version is None:
+        return "0.0.0"
+    try:
+        return version("gitmoot-skillopt")
+    except Exception:  # noqa: BLE001 - metadata is optional in source checkouts.
+        return "0.0.0"
+
+
+__all__ = ["package_version"]

--- a/gitmoot_skillopt/__main__.py
+++ b/gitmoot_skillopt/__main__.py
@@ -1,0 +1,8 @@
+"""Module entry point for ``python -m gitmoot_skillopt``."""
+
+from __future__ import annotations
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gitmoot_skillopt/artifacts.py
+++ b/gitmoot_skillopt/artifacts.py
@@ -1,0 +1,164 @@
+"""Artifact helpers for Gitmoot SkillOpt exchange packages."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+HASH_PREFIX = "sha256:"
+
+
+class ArtifactError(ValueError):
+    """Raised when an artifact hash or path is invalid."""
+
+
+def content_hash(content: bytes) -> str:
+    return HASH_PREFIX + hashlib.sha256(content).hexdigest()
+
+
+def normalize_hash(value: str) -> str:
+    value = value.strip().lower()
+    if value.startswith(HASH_PREFIX):
+        value = value[len(HASH_PREFIX) :]
+    if len(value) != hashlib.sha256().digest_size * 2:
+        raise ArtifactError(f"artifact hash must be {hashlib.sha256().digest_size * 2} hex characters")
+    try:
+        int(value, 16)
+    except ValueError as exc:
+        raise ArtifactError("artifact hash is not valid hex") from exc
+    return HASH_PREFIX + value
+
+
+def _hex_hash(value: str) -> str:
+    return normalize_hash(value)[len(HASH_PREFIX) :]
+
+
+@dataclass(frozen=True)
+class ResolvedArtifact:
+    hash: str
+    path: Path
+    content: bytes
+
+
+class GitmootArtifactResolver:
+    """Read Gitmoot content-addressed SHA256 blobs from an artifact root."""
+
+    def __init__(self, artifact_root: str | Path) -> None:
+        if str(artifact_root).strip() == "":
+            raise ArtifactError("artifact root is required")
+        root = Path(artifact_root).expanduser()
+        self.artifact_root = root
+
+    def path_for_hash(self, hash_value: str) -> Path:
+        hex_hash = _hex_hash(hash_value)
+        return self.artifact_root / "sha256" / hex_hash[:2] / hex_hash
+
+    def read(self, hash_value: str, *, expected_size: int | None = None) -> ResolvedArtifact:
+        normalized = normalize_hash(hash_value)
+        path = self.path_for_hash(normalized)
+        if not path.is_file():
+            raise ArtifactError(f"artifact blob {normalized} not found")
+        content = path.read_bytes()
+        actual_hash = content_hash(content)
+        if actual_hash != normalized:
+            raise ArtifactError(f"artifact blob {normalized} content hash mismatch: got {actual_hash}")
+        if expected_size is not None and len(content) != expected_size:
+            raise ArtifactError(f"artifact blob {normalized} has size {len(content)}, want {expected_size}")
+        return ResolvedArtifact(hash=normalized, path=path, content=content)
+
+
+@dataclass(frozen=True)
+class CandidateArtifactManifestEntry:
+    id: str
+    hash: str
+    media_type: str
+    size_bytes: int
+    driver: str
+    path: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "hash": self.hash,
+            "media_type": self.media_type,
+            "size_bytes": self.size_bytes,
+            "driver": self.driver,
+            "path": self.path,
+        }
+
+
+class OutputArtifactWriter:
+    """Write optimizer artifacts under ``out_root/artifacts`` and emit manifests."""
+
+    def __init__(self, out_root: str | Path) -> None:
+        if str(out_root).strip() == "":
+            raise ArtifactError("output root is required")
+        root = Path(out_root).expanduser()
+        self.out_root = root
+        self.artifact_root = self.out_root / "artifacts"
+
+    def write_bytes(
+        self,
+        relative_path: str | Path,
+        content: bytes,
+        *,
+        artifact_id: str,
+        media_type: str,
+        driver: str,
+    ) -> CandidateArtifactManifestEntry:
+        if not artifact_id.strip():
+            raise ArtifactError("artifact id is required")
+        if not media_type.strip():
+            raise ArtifactError("artifact media_type is required")
+        if not driver.strip():
+            raise ArtifactError("artifact driver is required")
+        destination = self._safe_destination(relative_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(content)
+        return CandidateArtifactManifestEntry(
+            id=artifact_id.strip(),
+            hash=content_hash(content),
+            media_type=media_type.strip(),
+            size_bytes=len(content),
+            driver=driver.strip(),
+            path=destination.relative_to(self.artifact_root).as_posix(),
+        )
+
+    def _safe_destination(self, relative_path: str | Path) -> Path:
+        path = Path(relative_path)
+        if path.is_absolute():
+            raise ArtifactError("artifact output path must be relative")
+        if any(part in {"", ".", ".."} for part in path.parts):
+            raise ArtifactError("artifact output path cannot contain empty, current, or parent segments")
+        destination = self.artifact_root / path
+        self._ensure_artifact_parent(path)
+        if destination.is_symlink():
+            raise ArtifactError("artifact output path cannot be a symlink")
+        root = self.artifact_root.resolve()
+        resolved = destination.resolve(strict=False)
+        try:
+            common = os.path.commonpath([root, resolved])
+        except ValueError as exc:
+            raise ArtifactError("artifact output path escapes artifact directory") from exc
+        if common != str(root):
+            raise ArtifactError("artifact output path escapes artifact directory")
+        return destination
+
+    def _ensure_artifact_parent(self, relative_path: Path) -> None:
+        if self.artifact_root.is_symlink():
+            raise ArtifactError("artifact output root cannot be a symlink")
+        if self.artifact_root.exists() and not self.artifact_root.is_dir():
+            raise ArtifactError("artifact output root must be a directory")
+        self.artifact_root.mkdir(parents=True, exist_ok=True)
+        current = self.artifact_root
+        for part in relative_path.parts[:-1]:
+            current = current / part
+            if current.is_symlink():
+                raise ArtifactError("artifact output path cannot traverse a symlink")
+            if current.exists():
+                if not current.is_dir():
+                    raise ArtifactError("artifact output path parent must be a directory")
+                continue
+            current.mkdir()

--- a/gitmoot_skillopt/artifacts.py
+++ b/gitmoot_skillopt/artifacts.py
@@ -74,19 +74,37 @@ class CandidateArtifactManifestEntry:
     id: str
     hash: str
     media_type: str
-    size_bytes: int
     driver: str
     path: str
+    size_bytes: int | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> "CandidateArtifactManifestEntry":
+        if not isinstance(data, dict):
+            raise ArtifactError("candidate artifact manifest entry must be an object")
+        size_bytes = data.get("size_bytes")
+        if size_bytes is not None and (isinstance(size_bytes, bool) or not isinstance(size_bytes, int) or size_bytes < 0):
+            raise ArtifactError("candidate artifact size_bytes must be a non-negative integer")
+        return cls(
+            id=_required_text(data.get("id"), "candidate artifact id"),
+            hash=normalize_hash(_required_text(data.get("hash"), "candidate artifact hash")),
+            media_type=_required_text(data.get("media_type"), "candidate artifact media_type"),
+            driver=_required_text(data.get("driver"), "candidate artifact driver"),
+            path=_required_relative_path(data.get("path")),
+            size_bytes=size_bytes,
+        )
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        data: dict[str, object] = {
             "id": self.id,
             "hash": self.hash,
             "media_type": self.media_type,
-            "size_bytes": self.size_bytes,
             "driver": self.driver,
             "path": self.path,
         }
+        if self.size_bytes is not None:
+            data["size_bytes"] = self.size_bytes
+        return data
 
 
 class OutputArtifactWriter:
@@ -162,3 +180,17 @@ class OutputArtifactWriter:
                     raise ArtifactError("artifact output path parent must be a directory")
                 continue
             current.mkdir()
+
+
+def _required_text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ArtifactError(f"{label} is required")
+    return value.strip()
+
+
+def _required_relative_path(value: object) -> str:
+    path_text = _required_text(value, "candidate artifact path")
+    path = Path(path_text)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ArtifactError("candidate artifact path must be relative and cannot traverse directories")
+    return path.as_posix()

--- a/gitmoot_skillopt/artifacts.py
+++ b/gitmoot_skillopt/artifacts.py
@@ -108,14 +108,17 @@ class CandidateArtifactManifestEntry:
 
 
 class OutputArtifactWriter:
-    """Write optimizer artifacts under ``out_root/artifacts`` and emit manifests."""
+    """Write optimizer artifacts under an artifact directory and emit manifests."""
 
-    def __init__(self, out_root: str | Path) -> None:
+    def __init__(self, out_root: str | Path, artifact_dir: str | Path | None = None) -> None:
         if str(out_root).strip() == "":
             raise ArtifactError("output root is required")
         root = Path(out_root).expanduser()
         self.out_root = root
-        self.artifact_root = self.out_root / "artifacts"
+        if artifact_dir is None or str(artifact_dir).strip() == "":
+            self.artifact_root = self.out_root / "artifacts"
+        else:
+            self.artifact_root = Path(artifact_dir).expanduser()
 
     def write_bytes(
         self,

--- a/gitmoot_skillopt/cli.py
+++ b/gitmoot_skillopt/cli.py
@@ -28,9 +28,9 @@ def build_parser() -> argparse.ArgumentParser:
         "optimize",
         help="optimize a Gitmoot training package into a candidate package",
         description=(
-            "Optimize a Gitmoot training package. This scaffold documents the "
-            "stable command shape; package parsing and training execution are "
-            "implemented in later goal tasks."
+            "Optimize a Gitmoot training package with the Gitmoot SkillOpt "
+            "adapter and write a Gitmoot-compatible candidate package plus "
+            "verified output artifacts."
         ),
     )
     optimize.add_argument(
@@ -53,17 +53,49 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="path where the candidate package JSON should be written",
     )
+    optimize.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="produce a candidate package with zero training epochs; useful for fixture smoke tests",
+    )
+    optimize.add_argument("--num-epochs", type=int, default=1, help="number of optimization epochs")
+    optimize.add_argument("--batch-size", type=int, default=4, help="training batch size")
+    optimize.add_argument("--seed", type=int, default=42, help="random seed")
+    optimize.add_argument("--optimizer-model", default="gpt-5.5", help="optimizer model name")
+    optimize.add_argument("--target-model", default="gpt-5.5", help="target model name")
+    optimize.add_argument("--optimizer-backend", default="openai_chat", help="optimizer backend")
+    optimize.add_argument("--target-backend", default="openai_chat", help="target backend")
+    optimize.add_argument(
+        "--skill-update-mode",
+        default="patch",
+        choices=["patch", "rewrite_from_suggestions", "full_rewrite_minibatch"],
+        help="SkillOpt update mode",
+    )
     optimize.set_defaults(func=_run_optimize)
 
     return parser
 
 
 def _run_optimize(args: argparse.Namespace) -> int:
-    del args
-    raise SystemExit(
-        "gitmoot-skillopt optimize is scaffolded; implementation follows in "
-        "the Gitmoot adapter and package-contract tasks."
+    from .optimize import run_optimize
+
+    run_optimize(
+        training_package=args.training_package,
+        artifact_root=args.artifact_root,
+        out_root=args.out_root,
+        candidate_output=args.candidate_output,
+        dry_run=args.dry_run,
+        num_epochs=args.num_epochs,
+        batch_size=args.batch_size,
+        seed=args.seed,
+        optimizer_model=args.optimizer_model,
+        target_model=args.target_model,
+        optimizer_backend=args.optimizer_backend,
+        target_backend=args.target_backend,
+        skill_update_mode=args.skill_update_mode,
     )
+    print(f"wrote candidate package: {args.candidate_output}")
+    return 0
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/gitmoot_skillopt/cli.py
+++ b/gitmoot_skillopt/cli.py
@@ -1,0 +1,76 @@
+"""Command line interface for Gitmoot-SkillOpt."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+
+from . import package_version
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="gitmoot-skillopt",
+        description=(
+            "Optimize Gitmoot agent templates from Gitmoot SkillOpt training "
+            "packages and emit pending candidate packages for Gitmoot review."
+        ),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {package_version()}",
+    )
+
+    subcommands = parser.add_subparsers(dest="command", metavar="<command>")
+
+    optimize = subcommands.add_parser(
+        "optimize",
+        help="optimize a Gitmoot training package into a candidate package",
+        description=(
+            "Optimize a Gitmoot training package. This scaffold documents the "
+            "stable command shape; package parsing and training execution are "
+            "implemented in later goal tasks."
+        ),
+    )
+    optimize.add_argument(
+        "--training-package",
+        required=True,
+        help="path to a Gitmoot skillopt training package JSON file",
+    )
+    optimize.add_argument(
+        "--artifact-root",
+        required=True,
+        help="path to Gitmoot's content-addressed artifact blob root",
+    )
+    optimize.add_argument(
+        "--out-root",
+        required=True,
+        help="directory for optimizer run output",
+    )
+    optimize.add_argument(
+        "--candidate-output",
+        required=True,
+        help="path where the candidate package JSON should be written",
+    )
+    optimize.set_defaults(func=_run_optimize)
+
+    return parser
+
+
+def _run_optimize(args: argparse.Namespace) -> int:
+    del args
+    raise SystemExit(
+        "gitmoot-skillopt optimize is scaffolded; implementation follows in "
+        "the Gitmoot adapter and package-contract tasks."
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    command = getattr(args, "func", None)
+    if command is None:
+        parser.print_help()
+        return 0
+    return int(command(args) or 0)

--- a/gitmoot_skillopt/cli.py
+++ b/gitmoot_skillopt/cli.py
@@ -66,6 +66,11 @@ def build_parser() -> argparse.ArgumentParser:
     optimize.add_argument("--optimizer-backend", default="openai_chat", help="optimizer backend")
     optimize.add_argument("--target-backend", default="openai_chat", help="target backend")
     optimize.add_argument(
+        "--reasoning-effort",
+        default="",
+        help="optional reasoning effort for models that support it; omit for standard OpenAI chat models",
+    )
+    optimize.add_argument(
         "--skill-update-mode",
         default="patch",
         choices=["patch", "rewrite_from_suggestions", "full_rewrite_minibatch"],
@@ -92,6 +97,7 @@ def _run_optimize(args: argparse.Namespace) -> int:
         target_model=args.target_model,
         optimizer_backend=args.optimizer_backend,
         target_backend=args.target_backend,
+        reasoning_effort=args.reasoning_effort,
         skill_update_mode=args.skill_update_mode,
     )
     print(f"wrote candidate package: {args.candidate_output}")

--- a/gitmoot_skillopt/cli.py
+++ b/gitmoot_skillopt/cli.py
@@ -54,6 +54,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="path where the candidate package JSON should be written",
     )
     optimize.add_argument(
+        "--artifact-dir",
+        default="",
+        help="directory where candidate artifact files should be written; defaults to OUT_ROOT/artifacts",
+    )
+    optimize.add_argument(
         "--dry-run",
         action="store_true",
         help="produce a candidate package with zero training epochs; useful for fixture smoke tests",
@@ -95,6 +100,7 @@ def _run_optimize(args: argparse.Namespace) -> int:
         artifact_root=args.artifact_root,
         out_root=args.out_root,
         candidate_output=args.candidate_output,
+        artifact_dir=args.artifact_dir,
         dry_run=args.dry_run,
         num_epochs=args.num_epochs,
         batch_size=args.batch_size,

--- a/gitmoot_skillopt/cli.py
+++ b/gitmoot_skillopt/cli.py
@@ -66,6 +66,12 @@ def build_parser() -> argparse.ArgumentParser:
     optimize.add_argument("--optimizer-backend", default="openai_chat", help="optimizer backend")
     optimize.add_argument("--target-backend", default="openai_chat", help="target backend")
     optimize.add_argument(
+        "--gate-metric",
+        default="hard",
+        choices=["hard", "soft", "mixed"],
+        help="selection gate metric used by SkillOpt when accepting candidate updates",
+    )
+    optimize.add_argument(
         "--reasoning-effort",
         default="",
         help="optional reasoning effort for models that support it; omit for standard OpenAI chat models",
@@ -97,6 +103,7 @@ def _run_optimize(args: argparse.Namespace) -> int:
         target_model=args.target_model,
         optimizer_backend=args.optimizer_backend,
         target_backend=args.target_backend,
+        gate_metric=args.gate_metric,
         reasoning_effort=args.reasoning_effort,
         skill_update_mode=args.skill_update_mode,
     )

--- a/gitmoot_skillopt/contracts.py
+++ b/gitmoot_skillopt/contracts.py
@@ -1,0 +1,573 @@
+"""Gitmoot SkillOpt exchange package models."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+CONTRACT_VERSION = 1
+TRAINING_PACKAGE_KIND = "gitmoot-skillopt-training-package"
+CANDIDATE_PACKAGE_KIND = "gitmoot-skillopt-candidate-package"
+
+_TEMPLATE_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+_TEMPLATE_KIND = "agent-template"
+_TEMPLATE_VERSION = 1
+_VALID_CAPABILITIES = {"ask", "review", "implement"}
+_VALID_RUNTIMES = {"codex", "claude", "shell"}
+_ARTIFACT_REF_FIELDS = (
+    "source_artifact_id",
+    "baseline_artifact_id",
+    "candidate_artifact_id",
+    "preview_artifact_id",
+    "diff_artifact_id",
+)
+
+
+class ContractError(ValueError):
+    """Raised when a Gitmoot SkillOpt package violates the v1 contract."""
+
+
+def _require_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ContractError(f"{label} must be an object")
+    return value
+
+
+def _require_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or value.strip() == "":
+        raise ContractError(f"{label} is required")
+    return value.strip()
+
+
+def _require_text(value: Any, label: str) -> str:
+    if not isinstance(value, str) or value.strip() == "":
+        raise ContractError(f"{label} is required")
+    return value
+
+
+def _optional_string(value: Any) -> str:
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ContractError("optional string field must be a string")
+    return value.strip()
+
+
+def _require_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ContractError(f"{label} must be an integer")
+    return value
+
+
+def _raw_json(value: Any) -> Any:
+    if value is None:
+        return None
+    json.dumps(value)
+    return value
+
+
+def validate_template_id(template_id: str, label: str = "template id") -> str:
+    template_id = _require_string(template_id, label)
+    if not _TEMPLATE_ID_RE.match(template_id):
+        raise ContractError(f"invalid {label} {template_id!r}; use lowercase letters, numbers, and single dashes")
+    return template_id
+
+
+def _normalize_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(metadata)
+    for key, value in list(normalized.items()):
+        if isinstance(value, str):
+            normalized[key] = value.strip()
+        elif isinstance(value, list):
+            if all(isinstance(item, str) and item.strip() for item in value):
+                normalized[key] = [item.strip() for item in value]
+    evaluation = normalized.get("evaluation")
+    if isinstance(evaluation, dict):
+        if all(isinstance(key, str) and key.strip() and isinstance(value, str) and value.strip() for key, value in evaluation.items()):
+            normalized["evaluation"] = {key.strip(): value.strip() for key, value in evaluation.items()}
+    return normalized
+
+
+def _require_metadata_list(metadata: dict[str, Any], key: str) -> list[str]:
+    value = metadata.get(key)
+    if not isinstance(value, list) or len(value) == 0:
+        raise ContractError(f"template frontmatter missing {key}")
+    if not all(isinstance(item, str) and item.strip() for item in value):
+        raise ContractError(f"template frontmatter {key} must contain strings")
+    return [item.strip() for item in value]
+
+
+def _validate_known_values(label: str, values: list[str], allowed: set[str]) -> None:
+    for value in values:
+        if value not in allowed:
+            raise ContractError(f"template frontmatter has invalid {label} {value!r}")
+
+
+def _validate_template_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    metadata = _normalize_metadata(metadata)
+    validate_template_id(str(metadata.get("id", "")), "template frontmatter id")
+    for key in ("name", "description"):
+        if not isinstance(metadata.get(key), str) or not metadata[key].strip():
+            raise ContractError(f"template frontmatter missing {key}")
+    if metadata.get("kind") != _TEMPLATE_KIND:
+        raise ContractError(f"template kind must be {_TEMPLATE_KIND!r}")
+    version = metadata.get("version")
+    if isinstance(version, bool) or version != _TEMPLATE_VERSION:
+        raise ContractError(f"template version must be {_TEMPLATE_VERSION}")
+    capabilities = _require_metadata_list(metadata, "capabilities")
+    _validate_known_values("capability", capabilities, _VALID_CAPABILITIES)
+    runtimes = _require_metadata_list(metadata, "runtime_compatibility")
+    _validate_known_values("runtime_compatibility", runtimes, _VALID_RUNTIMES)
+    _require_metadata_list(metadata, "tags")
+    _require_metadata_list(metadata, "inputs")
+    _require_metadata_list(metadata, "outputs")
+    evaluation = metadata.get("evaluation")
+    if evaluation is not None and not isinstance(evaluation, dict):
+        raise ContractError("template frontmatter evaluation must be an object")
+    if isinstance(evaluation, dict) and not all(
+        isinstance(key, str) and key.strip() and isinstance(value, str) and value.strip()
+        for key, value in evaluation.items()
+    ):
+        raise ContractError("template frontmatter evaluation must contain string keys and values")
+    return metadata
+
+
+def _split_frontmatter(content: str) -> tuple[dict[str, Any], str]:
+    content = content.replace("\r\n", "\n").strip()
+    if not content:
+        raise ContractError("candidate template content is empty")
+    lines = content.split("\n")
+    if len(lines) < 3 or lines[0].strip() != "---":
+        raise ContractError("candidate template must start with YAML frontmatter")
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() != "---":
+            continue
+        frontmatter = "\n".join(lines[1:index])
+        body = "\n".join(lines[index + 1 :]).lstrip("\n")
+        parsed = yaml.safe_load(frontmatter) or {}
+        if not isinstance(parsed, dict):
+            raise ContractError("candidate template frontmatter must be an object")
+        if body.strip() == "":
+            raise ContractError("candidate template body is empty")
+        return _validate_template_metadata(parsed), body
+    raise ContractError("candidate template frontmatter is missing closing ---")
+
+
+def validate_template_content_metadata(content: str, metadata: dict[str, Any], template_id: str) -> None:
+    parsed_metadata, _body = _split_frontmatter(content)
+    parsed_id = validate_template_id(str(parsed_metadata.get("id", "")), "candidate template id")
+    if parsed_id != template_id:
+        raise ContractError(f"candidate template id {parsed_id!r} does not match package template_id {template_id!r}")
+    if _validate_template_metadata(metadata) != parsed_metadata:
+        raise ContractError("candidate metadata does not match candidate template frontmatter")
+
+
+def _validate_kind_and_version(kind: str, contract_version: int, expected_kind: str, label: str) -> None:
+    if kind != expected_kind:
+        raise ContractError(f"{label} kind must be {expected_kind!r}")
+    if contract_version != CONTRACT_VERSION:
+        raise ContractError(f"{label} contract_version must be {CONTRACT_VERSION}")
+
+
+@dataclass(frozen=True)
+class TemplateSnapshot:
+    id: str
+    version_id: str
+    version_number: int
+    version_state: str
+    content_hash: str
+    source_repo: str
+    source_ref: str
+    source_path: str
+    resolved_commit: str
+    metadata: dict[str, Any]
+    content: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TemplateSnapshot:
+        from .artifacts import content_hash, normalize_hash
+
+        data = _require_mapping(data, "template")
+        content = _require_text(data.get("content"), "template.content")
+        expected_hash = normalize_hash(_require_string(data.get("content_hash"), "template.content_hash"))
+        actual_hash = content_hash(content.encode())
+        if actual_hash != expected_hash:
+            raise ContractError(f"template.content_hash mismatch: got {actual_hash}, want {expected_hash}")
+        snapshot = cls(
+            id=validate_template_id(str(data.get("id", "")), "template id"),
+            version_id=_require_string(data.get("version_id"), "template.version_id"),
+            version_number=_require_int(data.get("version_number"), "template.version_number"),
+            version_state=_require_string(data.get("version_state"), "template.version_state"),
+            content_hash=expected_hash,
+            source_repo=_optional_string(data.get("source_repo")),
+            source_ref=_optional_string(data.get("source_ref")),
+            source_path=_optional_string(data.get("source_path")),
+            resolved_commit=_optional_string(data.get("resolved_commit")),
+            metadata=_validate_template_metadata(_require_mapping(data.get("metadata"), "template.metadata")),
+            content=content,
+        )
+        if str(snapshot.metadata.get("id", "")).strip() != snapshot.id:
+            raise ContractError("template.metadata.id must match template.id")
+        return snapshot
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "version_id": self.version_id,
+            "version_number": self.version_number,
+            "version_state": self.version_state,
+            "content_hash": self.content_hash,
+            "source_repo": self.source_repo,
+            "source_ref": self.source_ref,
+            "source_path": self.source_path,
+            "resolved_commit": self.resolved_commit,
+            "metadata": self.metadata,
+            "content": self.content,
+        }
+
+
+@dataclass(frozen=True)
+class ArtifactRef:
+    id: str
+    hash: str
+    media_type: str
+    size_bytes: int
+    driver: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ArtifactRef:
+        from .artifacts import normalize_hash
+
+        data = _require_mapping(data, "artifact")
+        size_bytes = _require_int(data.get("size_bytes"), "artifact.size_bytes")
+        if size_bytes < 0:
+            raise ContractError("artifact.size_bytes cannot be negative")
+        artifact = cls(
+            id=_require_string(data.get("id"), "artifact.id"),
+            hash=normalize_hash(_require_string(data.get("hash"), "artifact.hash")),
+            media_type=_require_string(data.get("media_type"), "artifact.media_type"),
+            size_bytes=size_bytes,
+            driver=_require_string(data.get("driver"), "artifact.driver"),
+        )
+        return artifact
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "hash": self.hash,
+            "media_type": self.media_type,
+            "size_bytes": self.size_bytes,
+            "driver": self.driver,
+        }
+
+
+@dataclass(frozen=True)
+class EvalRun:
+    id: str
+    template_id: str
+    template_version_id: str
+    target_repo: str
+    state: str
+    metadata: Any = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EvalRun:
+        data = _require_mapping(data, "eval_run")
+        return cls(
+            id=_require_string(data.get("id"), "eval_run.id"),
+            template_id=validate_template_id(str(data.get("template_id", "")), "eval_run.template_id"),
+            template_version_id=_optional_string(data.get("template_version_id")),
+            target_repo=_optional_string(data.get("target_repo")),
+            state=_require_string(data.get("state"), "eval_run.state"),
+            metadata=_raw_json(data.get("metadata")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "id": self.id,
+            "template_id": self.template_id,
+            "template_version_id": self.template_version_id,
+            "target_repo": self.target_repo,
+            "state": self.state,
+        }
+        if self.metadata is not None:
+            data["metadata"] = self.metadata
+        return data
+
+
+@dataclass(frozen=True)
+class EvalItem:
+    id: str
+    title: str = ""
+    source_artifact_id: str = ""
+    baseline_artifact_id: str = ""
+    candidate_artifact_id: str = ""
+    preview_artifact_id: str = ""
+    diff_artifact_id: str = ""
+    metadata: Any = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EvalItem:
+        data = _require_mapping(data, "item")
+        return cls(
+            id=_require_string(data.get("id"), "item.id"),
+            title=_optional_string(data.get("title")),
+            source_artifact_id=_optional_string(data.get("source_artifact_id")),
+            baseline_artifact_id=_optional_string(data.get("baseline_artifact_id")),
+            candidate_artifact_id=_optional_string(data.get("candidate_artifact_id")),
+            preview_artifact_id=_optional_string(data.get("preview_artifact_id")),
+            diff_artifact_id=_optional_string(data.get("diff_artifact_id")),
+            metadata=_raw_json(data.get("metadata")),
+        )
+
+    def artifact_ids(self) -> list[str]:
+        return [
+            artifact_id
+            for artifact_id in (
+                self.source_artifact_id,
+                self.baseline_artifact_id,
+                self.candidate_artifact_id,
+                self.preview_artifact_id,
+                self.diff_artifact_id,
+            )
+            if artifact_id
+        ]
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "id": self.id,
+            "title": self.title,
+            "source_artifact_id": self.source_artifact_id,
+            "baseline_artifact_id": self.baseline_artifact_id,
+            "candidate_artifact_id": self.candidate_artifact_id,
+            "preview_artifact_id": self.preview_artifact_id,
+            "diff_artifact_id": self.diff_artifact_id,
+        }
+        if self.metadata is not None:
+            data["metadata"] = self.metadata
+        return data
+
+
+@dataclass(frozen=True)
+class FeedbackEvent:
+    run_id: str
+    item_id: str
+    choice: str
+    reviewer: str
+    source: str
+    created_at: str
+    reasoning: str = ""
+    source_url: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FeedbackEvent:
+        data = _require_mapping(data, "feedback event")
+        return cls(
+            run_id=_require_string(data.get("run_id"), "feedback.run_id"),
+            item_id=_require_string(data.get("item_id"), "feedback.item_id"),
+            choice=_require_string(data.get("choice"), "feedback.choice"),
+            reasoning=_optional_string(data.get("reasoning")),
+            reviewer=_require_string(data.get("reviewer"), "feedback.reviewer"),
+            source=_require_string(data.get("source"), "feedback.source"),
+            source_url=_optional_string(data.get("source_url")),
+            created_at=_require_string(data.get("created_at"), "feedback.created_at"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "item_id": self.item_id,
+            "choice": self.choice,
+            "reasoning": self.reasoning,
+            "reviewer": self.reviewer,
+            "source": self.source,
+            "source_url": self.source_url,
+            "created_at": self.created_at,
+        }
+
+
+@dataclass(frozen=True)
+class TrainingPackage:
+    kind: str
+    contract_version: int
+    template: TemplateSnapshot
+    eval_run: EvalRun
+    items: list[EvalItem] = field(default_factory=list)
+    artifacts: list[ArtifactRef] = field(default_factory=list)
+    feedback_events: list[FeedbackEvent] = field(default_factory=list)
+    evaluator_config: Any = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TrainingPackage:
+        data = _require_mapping(data, "training package")
+        kind = _require_string(data.get("kind"), "training package.kind")
+        contract_version = _require_int(data.get("contract_version"), "training package.contract_version")
+        _validate_kind_and_version(kind, contract_version, TRAINING_PACKAGE_KIND, "training package")
+        package = cls(
+            kind=kind,
+            contract_version=contract_version,
+            template=TemplateSnapshot.from_dict(data.get("template")),
+            eval_run=EvalRun.from_dict(data.get("eval_run")),
+            items=[EvalItem.from_dict(item) for item in data.get("items", [])],
+            artifacts=[ArtifactRef.from_dict(artifact) for artifact in data.get("artifacts", [])],
+            feedback_events=[FeedbackEvent.from_dict(event) for event in data.get("feedback_events", [])],
+            evaluator_config=_raw_json(data.get("evaluator_config")),
+        )
+        package.validate()
+        return package
+
+    @classmethod
+    def load(cls, path: str | Path) -> TrainingPackage:
+        with Path(path).open(encoding="utf-8") as handle:
+            return cls.from_dict(json.load(handle))
+
+    def validate(self) -> None:
+        if self.template.id != self.eval_run.template_id:
+            raise ContractError("eval_run.template_id must match template.id")
+        if self.eval_run.template_version_id and self.eval_run.template_version_id != self.template.version_id:
+            raise ContractError("eval_run.template_version_id must match template.version_id")
+        artifact_ids = {artifact.id for artifact in self.artifacts}
+        if len(artifact_ids) != len(self.artifacts):
+            raise ContractError("artifact ids must be unique")
+        item_ids = {item.id for item in self.items}
+        if len(item_ids) != len(self.items):
+            raise ContractError("item ids must be unique")
+        for item in self.items:
+            for artifact_id in item.artifact_ids():
+                if artifact_id not in artifact_ids:
+                    raise ContractError(f"item {item.id!r} references missing artifact {artifact_id!r}")
+        for event in self.feedback_events:
+            if event.run_id != self.eval_run.id:
+                raise ContractError(f"feedback event for item {event.item_id!r} has wrong run_id {event.run_id!r}")
+            if event.item_id not in item_ids:
+                raise ContractError(f"feedback event references missing item {event.item_id!r}")
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "kind": self.kind,
+            "contract_version": self.contract_version,
+            "template": self.template.to_dict(),
+            "eval_run": self.eval_run.to_dict(),
+            "items": [item.to_dict() for item in self.items],
+            "artifacts": [artifact.to_dict() for artifact in self.artifacts],
+            "feedback_events": [event.to_dict() for event in self.feedback_events],
+        }
+        if self.evaluator_config is not None:
+            data["evaluator_config"] = self.evaluator_config
+        return data
+
+    def dump(self, path: str | Path) -> None:
+        with Path(path).open("w", encoding="utf-8") as handle:
+            json.dump(self.to_dict(), handle, indent=2, sort_keys=True)
+            handle.write("\n")
+
+
+@dataclass(frozen=True)
+class CandidateTemplate:
+    content: str
+    metadata: dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CandidateTemplate:
+        data = _require_mapping(data, "candidate")
+        return cls(
+            content=_require_text(data.get("content"), "candidate.content"),
+            metadata=_require_mapping(data.get("metadata"), "candidate.metadata"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"content": self.content, "metadata": self.metadata}
+
+
+@dataclass(frozen=True)
+class CandidateSummary:
+    diff_artifact_id: str = ""
+    score: float | None = None
+    preference_summary: str = ""
+    metadata: Any = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> CandidateSummary:
+        if data is None:
+            return cls()
+        data = _require_mapping(data, "summary")
+        score = data.get("score")
+        if score is not None and (isinstance(score, bool) or not isinstance(score, int | float)):
+            raise ContractError("summary.score must be numeric")
+        return cls(
+            diff_artifact_id=_optional_string(data.get("diff_artifact_id")),
+            score=float(score) if score is not None else None,
+            preference_summary=_optional_string(data.get("preference_summary")),
+            metadata=_raw_json(data.get("metadata")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "diff_artifact_id": self.diff_artifact_id,
+            "preference_summary": self.preference_summary,
+        }
+        if self.score is not None:
+            data["score"] = self.score
+        if self.metadata is not None:
+            data["metadata"] = self.metadata
+        return data
+
+
+@dataclass(frozen=True)
+class CandidatePackage:
+    kind: str
+    contract_version: int
+    template_id: str
+    candidate: CandidateTemplate
+    base_version_id: str = ""
+    eval_report: Any = None
+    summary: CandidateSummary = field(default_factory=CandidateSummary)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CandidatePackage:
+        data = _require_mapping(data, "candidate package")
+        kind = _require_string(data.get("kind"), "candidate package.kind")
+        contract_version = _require_int(data.get("contract_version"), "candidate package.contract_version")
+        _validate_kind_and_version(kind, contract_version, CANDIDATE_PACKAGE_KIND, "candidate package")
+        package = cls(
+            kind=kind,
+            contract_version=contract_version,
+            template_id=validate_template_id(str(data.get("template_id", "")), "candidate package.template_id"),
+            base_version_id=_optional_string(data.get("base_version_id")),
+            candidate=CandidateTemplate.from_dict(data.get("candidate")),
+            eval_report=_raw_json(data.get("eval_report")),
+            summary=CandidateSummary.from_dict(data.get("summary")),
+        )
+        package.validate()
+        return package
+
+    @classmethod
+    def load(cls, path: str | Path) -> CandidatePackage:
+        with Path(path).open(encoding="utf-8") as handle:
+            return cls.from_dict(json.load(handle))
+
+    def validate(self) -> None:
+        validate_template_content_metadata(self.candidate.content, self.candidate.metadata, self.template_id)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = {
+            "kind": self.kind,
+            "contract_version": self.contract_version,
+            "template_id": self.template_id,
+            "base_version_id": self.base_version_id,
+            "candidate": self.candidate.to_dict(),
+            "summary": self.summary.to_dict(),
+        }
+        if self.eval_report is not None:
+            data["eval_report"] = self.eval_report
+        return data
+
+    def dump(self, path: str | Path) -> None:
+        with Path(path).open("w", encoding="utf-8") as handle:
+            json.dump(self.to_dict(), handle, indent=2, sort_keys=True)
+            handle.write("\n")

--- a/gitmoot_skillopt/contracts.py
+++ b/gitmoot_skillopt/contracts.py
@@ -525,6 +525,7 @@ class CandidatePackage:
     template_id: str
     candidate: CandidateTemplate
     base_version_id: str = ""
+    artifacts: list[Any] = field(default_factory=list)
     eval_report: Any = None
     summary: CandidateSummary = field(default_factory=CandidateSummary)
 
@@ -534,12 +535,21 @@ class CandidatePackage:
         kind = _require_string(data.get("kind"), "candidate package.kind")
         contract_version = _require_int(data.get("contract_version"), "candidate package.contract_version")
         _validate_kind_and_version(kind, contract_version, CANDIDATE_PACKAGE_KIND, "candidate package")
+        from .artifacts import CandidateArtifactManifestEntry
+
+        raw_artifacts = data["artifacts"] if "artifacts" in data else []
+        if not isinstance(raw_artifacts, list):
+            raise ContractError("candidate package.artifacts must be a list")
         package = cls(
             kind=kind,
             contract_version=contract_version,
             template_id=validate_template_id(str(data.get("template_id", "")), "candidate package.template_id"),
             base_version_id=_optional_string(data.get("base_version_id")),
             candidate=CandidateTemplate.from_dict(data.get("candidate")),
+            artifacts=[
+                CandidateArtifactManifestEntry.from_dict(artifact)
+                for artifact in raw_artifacts
+            ],
             eval_report=_raw_json(data.get("eval_report")),
             summary=CandidateSummary.from_dict(data.get("summary")),
         )
@@ -553,6 +563,16 @@ class CandidatePackage:
 
     def validate(self) -> None:
         validate_template_content_metadata(self.candidate.content, self.candidate.metadata, self.template_id)
+        artifact_ids: set[str] = set()
+        for artifact in self.artifacts:
+            artifact_id = getattr(artifact, "id", "")
+            if not isinstance(artifact_id, str) or not artifact_id.strip():
+                raise ContractError("candidate artifact id is required")
+            if artifact_id in artifact_ids:
+                raise ContractError(f"candidate artifact id is duplicated: {artifact_id}")
+            artifact_ids.add(artifact_id)
+        if artifact_ids and self.summary.diff_artifact_id not in artifact_ids:
+            raise ContractError("candidate summary.diff_artifact_id must reference a candidate artifact")
 
     def to_dict(self) -> dict[str, Any]:
         data = {
@@ -561,6 +581,7 @@ class CandidatePackage:
             "template_id": self.template_id,
             "base_version_id": self.base_version_id,
             "candidate": self.candidate.to_dict(),
+            "artifacts": [artifact.to_dict() for artifact in self.artifacts],
             "summary": self.summary.to_dict(),
         }
         if self.eval_report is not None:

--- a/gitmoot_skillopt/optimize.py
+++ b/gitmoot_skillopt/optimize.py
@@ -34,6 +34,7 @@ def run_optimize(
     target_model: str = "gpt-5.5",
     optimizer_backend: str = "openai_chat",
     target_backend: str = "openai_chat",
+    reasoning_effort: str = "",
     skill_update_mode: str = "patch",
 ) -> CandidatePackage:
     package_path = _require_file(training_package, "training package")
@@ -68,6 +69,7 @@ def run_optimize(
         target_model=target_model,
         optimizer_backend=optimizer_backend,
         target_backend=target_backend,
+        reasoning_effort=reasoning_effort,
         skill_update_mode=skill_update_mode,
     )
     adapter = GitmootAdapter(
@@ -105,6 +107,7 @@ def build_trainer_config(
     target_model: str,
     optimizer_backend: str,
     target_backend: str,
+    reasoning_effort: str,
     skill_update_mode: str,
 ) -> dict[str, Any]:
     actual_epochs = 0 if dry_run else max(1, int(num_epochs))
@@ -119,7 +122,7 @@ def build_trainer_config(
         "target_model": target_model,
         "optimizer_backend": optimizer_backend,
         "target_backend": target_backend,
-        "reasoning_effort": "medium",
+        "reasoning_effort": str(reasoning_effort or "").strip(),
         "rewrite_reasoning_effort": "",
         "rewrite_max_completion_tokens": 64000,
         "azure_openai_endpoint": "",

--- a/gitmoot_skillopt/optimize.py
+++ b/gitmoot_skillopt/optimize.py
@@ -34,6 +34,7 @@ def run_optimize(
     target_model: str = "gpt-5.5",
     optimizer_backend: str = "openai_chat",
     target_backend: str = "openai_chat",
+    gate_metric: str = "hard",
     reasoning_effort: str = "",
     skill_update_mode: str = "patch",
 ) -> CandidatePackage:
@@ -69,6 +70,7 @@ def run_optimize(
         target_model=target_model,
         optimizer_backend=optimizer_backend,
         target_backend=target_backend,
+        gate_metric=gate_metric,
         reasoning_effort=reasoning_effort,
         skill_update_mode=skill_update_mode,
     )
@@ -107,10 +109,14 @@ def build_trainer_config(
     target_model: str,
     optimizer_backend: str,
     target_backend: str,
+    gate_metric: str,
     reasoning_effort: str,
     skill_update_mode: str,
 ) -> dict[str, Any]:
     actual_epochs = 0 if dry_run else max(1, int(num_epochs))
+    normalized_gate_metric = str(gate_metric or "hard").strip().lower()
+    if normalized_gate_metric not in {"hard", "soft", "mixed"}:
+        raise ValueError(f"unsupported gate metric: {gate_metric}")
     return {
         "env": "gitmoot",
         "training_package": str(package_path),
@@ -190,7 +196,7 @@ def build_trainer_config(
         "longitudinal_pair_policy": "mixed",
         "use_meta_skill": False,
         "use_gate": True,
-        "gate_metric": "hard",
+        "gate_metric": normalized_gate_metric,
         "gate_mixed_weight": 0.5,
         "sel_env_num": 0,
         "test_env_num": 0,

--- a/gitmoot_skillopt/optimize.py
+++ b/gitmoot_skillopt/optimize.py
@@ -26,6 +26,7 @@ def run_optimize(
     artifact_root: str,
     out_root: str,
     candidate_output: str,
+    artifact_dir: str = "",
     dry_run: bool = False,
     num_epochs: int = 1,
     batch_size: int = 4,
@@ -42,6 +43,7 @@ def run_optimize(
     artifact_root_path = _require_dir(artifact_root, "artifact root")
     out_root_path = Path(out_root).expanduser()
     out_root_path.mkdir(parents=True, exist_ok=True)
+    artifact_dir_path = Path(artifact_dir).expanduser() if str(artifact_dir).strip() else out_root_path / "artifacts"
 
     package = TrainingPackage.load(package_path)
     initial_skill_path = out_root_path / "initial_skill.md"
@@ -53,6 +55,7 @@ def run_optimize(
             candidate_content=package.template.content,
             summary=_dry_run_summary(package),
             out_root=out_root_path,
+            artifact_dir=artifact_dir_path,
             candidate_output=Path(candidate_output).expanduser(),
             dry_run=True,
         )
@@ -89,6 +92,7 @@ def run_optimize(
         candidate_content=candidate_content,
         summary=summary,
         out_root=out_root_path,
+        artifact_dir=artifact_dir_path,
         candidate_output=Path(candidate_output).expanduser(),
         dry_run=dry_run,
     )
@@ -210,32 +214,34 @@ def write_candidate_package(
     candidate_content: str,
     summary: dict[str, Any],
     out_root: Path,
+    artifact_dir: Path,
     candidate_output: Path,
     dry_run: bool,
 ) -> CandidatePackage:
-    writer = OutputArtifactWriter(out_root)
+    writer = OutputArtifactWriter(out_root, artifact_dir)
     diff_text = _diff_text(package.template.content, candidate_content)
     eval_report = _eval_report(summary, dry_run=dry_run)
     preference_summary = _preference_summary(summary, dry_run=dry_run)
+    diff_artifact_id = _candidate_artifact_id(package, "candidate-diff")
     artifacts = [
         writer.write_bytes(
             "candidate.diff.md",
             diff_text.encode(),
-            artifact_id="candidate-diff",
+            artifact_id=diff_artifact_id,
             media_type="text/markdown",
             driver="gitmoot-skillopt",
         ),
         writer.write_bytes(
             "eval-report.json",
             json.dumps(eval_report, indent=2, sort_keys=True).encode() + b"\n",
-            artifact_id="eval-report",
+            artifact_id=_candidate_artifact_id(package, "eval-report"),
             media_type="application/json",
             driver="gitmoot-skillopt",
         ),
         writer.write_bytes(
             "preference-summary.md",
             preference_summary.encode(),
-            artifact_id="preference-summary",
+            artifact_id=_candidate_artifact_id(package, "preference-summary"),
             media_type="text/markdown",
             driver="gitmoot-skillopt",
         ),
@@ -252,7 +258,7 @@ def write_candidate_package(
         artifacts=artifacts,
         eval_report=eval_report,
         summary=CandidateSummary(
-            diff_artifact_id="candidate-diff",
+            diff_artifact_id=diff_artifact_id,
             score=_summary_score(summary),
             preference_summary=preference_summary.strip(),
             metadata={"artifact_ids": [artifact.id for artifact in artifacts]},
@@ -262,6 +268,13 @@ def write_candidate_package(
     candidate_output.parent.mkdir(parents=True, exist_ok=True)
     candidate.dump(candidate_output)
     return candidate
+
+
+def _candidate_artifact_id(package: TrainingPackage, suffix: str) -> str:
+    run_id = str(package.eval_run.id or "").strip()
+    if not run_id:
+        run_id = str(package.template.id or "candidate").strip()
+    return f"{run_id}/{suffix}"
 
 
 def _require_file(path_text: str, label: str) -> Path:

--- a/gitmoot_skillopt/optimize.py
+++ b/gitmoot_skillopt/optimize.py
@@ -1,0 +1,336 @@
+"""Gitmoot SkillOpt optimize command implementation."""
+
+from __future__ import annotations
+
+import difflib
+import json
+from pathlib import Path
+from typing import Any
+
+from gitmoot_skillopt.artifacts import OutputArtifactWriter
+from gitmoot_skillopt.contracts import (
+    CANDIDATE_PACKAGE_KIND,
+    CONTRACT_VERSION,
+    CandidatePackage,
+    CandidateSummary,
+    CandidateTemplate,
+    TrainingPackage,
+)
+from skillopt.engine.trainer import ReflACTTrainer
+from skillopt.envs.gitmoot.adapter import GitmootAdapter
+
+
+def run_optimize(
+    *,
+    training_package: str,
+    artifact_root: str,
+    out_root: str,
+    candidate_output: str,
+    dry_run: bool = False,
+    num_epochs: int = 1,
+    batch_size: int = 4,
+    seed: int = 42,
+    optimizer_model: str = "gpt-5.5",
+    target_model: str = "gpt-5.5",
+    optimizer_backend: str = "openai_chat",
+    target_backend: str = "openai_chat",
+    skill_update_mode: str = "patch",
+) -> CandidatePackage:
+    package_path = _require_file(training_package, "training package")
+    artifact_root_path = _require_dir(artifact_root, "artifact root")
+    out_root_path = Path(out_root).expanduser()
+    out_root_path.mkdir(parents=True, exist_ok=True)
+
+    package = TrainingPackage.load(package_path)
+    initial_skill_path = out_root_path / "initial_skill.md"
+    initial_skill_path.write_text(package.template.content, encoding="utf-8")
+
+    if dry_run:
+        return write_candidate_package(
+            package=package,
+            candidate_content=package.template.content,
+            summary=_dry_run_summary(package),
+            out_root=out_root_path,
+            candidate_output=Path(candidate_output).expanduser(),
+            dry_run=True,
+        )
+
+    cfg = build_trainer_config(
+        package_path=package_path,
+        artifact_root=artifact_root_path,
+        out_root=out_root_path,
+        initial_skill_path=initial_skill_path,
+        dry_run=dry_run,
+        num_epochs=num_epochs,
+        batch_size=batch_size,
+        seed=seed,
+        optimizer_model=optimizer_model,
+        target_model=target_model,
+        optimizer_backend=optimizer_backend,
+        target_backend=target_backend,
+        skill_update_mode=skill_update_mode,
+    )
+    adapter = GitmootAdapter(
+        training_package=str(package_path),
+        artifact_root=str(artifact_root_path),
+        seed=seed,
+        minibatch_size=cfg["minibatch_size"],
+        edit_budget=cfg["edit_budget"],
+        analyst_workers=cfg["analyst_workers"],
+    )
+    summary = ReflACTTrainer(cfg, adapter).train()
+    candidate_content = _read_best_skill(out_root_path, package.template.content)
+    candidate = write_candidate_package(
+        package=package,
+        candidate_content=candidate_content,
+        summary=summary,
+        out_root=out_root_path,
+        candidate_output=Path(candidate_output).expanduser(),
+        dry_run=dry_run,
+    )
+    return candidate
+
+
+def build_trainer_config(
+    *,
+    package_path: Path,
+    artifact_root: Path,
+    out_root: Path,
+    initial_skill_path: Path,
+    dry_run: bool,
+    num_epochs: int,
+    batch_size: int,
+    seed: int,
+    optimizer_model: str,
+    target_model: str,
+    optimizer_backend: str,
+    target_backend: str,
+    skill_update_mode: str,
+) -> dict[str, Any]:
+    actual_epochs = 0 if dry_run else max(1, int(num_epochs))
+    return {
+        "env": "gitmoot",
+        "training_package": str(package_path),
+        "artifact_root": str(artifact_root),
+        "out_root": str(out_root),
+        "skill_init": str(initial_skill_path),
+        "model_backend": target_backend,
+        "optimizer_model": optimizer_model,
+        "target_model": target_model,
+        "optimizer_backend": optimizer_backend,
+        "target_backend": target_backend,
+        "reasoning_effort": "medium",
+        "rewrite_reasoning_effort": "",
+        "rewrite_max_completion_tokens": 64000,
+        "azure_openai_endpoint": "",
+        "azure_openai_api_version": "2024-12-01-preview",
+        "azure_openai_api_key": "",
+        "azure_openai_auth_mode": "",
+        "azure_openai_ad_scope": "https://cognitiveservices.azure.com/.default",
+        "azure_openai_managed_identity_client_id": "",
+        "optimizer_azure_openai_endpoint": "",
+        "optimizer_azure_openai_api_version": "2024-12-01-preview",
+        "optimizer_azure_openai_api_key": "",
+        "optimizer_azure_openai_auth_mode": "",
+        "optimizer_azure_openai_ad_scope": "https://cognitiveservices.azure.com/.default",
+        "optimizer_azure_openai_managed_identity_client_id": "",
+        "target_azure_openai_endpoint": "",
+        "target_azure_openai_api_version": "2024-12-01-preview",
+        "target_azure_openai_api_key": "",
+        "target_azure_openai_auth_mode": "",
+        "target_azure_openai_ad_scope": "https://cognitiveservices.azure.com/.default",
+        "target_azure_openai_managed_identity_client_id": "",
+        "codex_exec_path": "codex",
+        "codex_exec_sandbox": "workspace-write",
+        "codex_exec_profile": "",
+        "codex_exec_full_auto": False,
+        "codex_exec_reasoning_effort": "none",
+        "codex_exec_use_sdk": "auto",
+        "codex_exec_network_access": False,
+        "codex_exec_web_search": False,
+        "codex_exec_approval_policy": "never",
+        "claude_code_exec_path": "claude",
+        "claude_code_exec_profile": "",
+        "claude_code_exec_use_sdk": "auto",
+        "claude_code_exec_effort": "medium",
+        "claude_code_exec_max_thinking_tokens": 16384,
+        "qwen_chat_base_url": "",
+        "qwen_chat_api_key": "",
+        "qwen_chat_temperature": None,
+        "qwen_chat_timeout_seconds": None,
+        "qwen_chat_max_tokens": None,
+        "qwen_chat_enable_thinking": None,
+        "minimax_base_url": "",
+        "minimax_api_key": "",
+        "minimax_model": "",
+        "minimax_temperature": None,
+        "minimax_max_tokens": None,
+        "minimax_enable_thinking": None,
+        "codex_trace_to_optimizer": False,
+        "num_epochs": actual_epochs,
+        "batch_size": max(1, int(batch_size)),
+        "accumulation": 1,
+        "seed": int(seed),
+        "minibatch_size": max(1, int(batch_size)),
+        "merge_batch_size": max(1, int(batch_size)),
+        "analyst_workers": 1,
+        "max_analyst_rounds": 1,
+        "failure_only": False,
+        "edit_budget": 4,
+        "min_edit_budget": 1,
+        "lr_scheduler": "constant",
+        "lr_control_mode": "fixed",
+        "skill_update_mode": skill_update_mode,
+        "use_slow_update": False,
+        "slow_update_samples": 0,
+        "slow_update_gate_with_selection": False,
+        "longitudinal_pair_policy": "mixed",
+        "use_meta_skill": False,
+        "use_gate": True,
+        "gate_metric": "hard",
+        "gate_mixed_weight": 0.5,
+        "sel_env_num": 0,
+        "test_env_num": 0,
+        "eval_test": False if dry_run else True,
+    }
+
+
+def write_candidate_package(
+    *,
+    package: TrainingPackage,
+    candidate_content: str,
+    summary: dict[str, Any],
+    out_root: Path,
+    candidate_output: Path,
+    dry_run: bool,
+) -> CandidatePackage:
+    writer = OutputArtifactWriter(out_root)
+    diff_text = _diff_text(package.template.content, candidate_content)
+    eval_report = _eval_report(summary, dry_run=dry_run)
+    preference_summary = _preference_summary(summary, dry_run=dry_run)
+    artifacts = [
+        writer.write_bytes(
+            "candidate.diff.md",
+            diff_text.encode(),
+            artifact_id="candidate-diff",
+            media_type="text/markdown",
+            driver="gitmoot-skillopt",
+        ),
+        writer.write_bytes(
+            "eval-report.json",
+            json.dumps(eval_report, indent=2, sort_keys=True).encode() + b"\n",
+            artifact_id="eval-report",
+            media_type="application/json",
+            driver="gitmoot-skillopt",
+        ),
+        writer.write_bytes(
+            "preference-summary.md",
+            preference_summary.encode(),
+            artifact_id="preference-summary",
+            media_type="text/markdown",
+            driver="gitmoot-skillopt",
+        ),
+    ]
+    candidate = CandidatePackage(
+        kind=CANDIDATE_PACKAGE_KIND,
+        contract_version=CONTRACT_VERSION,
+        template_id=package.template.id,
+        base_version_id=package.template.version_id,
+        candidate=CandidateTemplate(
+            content=candidate_content,
+            metadata=package.template.metadata,
+        ),
+        artifacts=artifacts,
+        eval_report=eval_report,
+        summary=CandidateSummary(
+            diff_artifact_id="candidate-diff",
+            score=_summary_score(summary),
+            preference_summary=preference_summary.strip(),
+            metadata={"artifact_ids": [artifact.id for artifact in artifacts]},
+        ),
+    )
+    candidate.validate()
+    candidate_output.parent.mkdir(parents=True, exist_ok=True)
+    candidate.dump(candidate_output)
+    return candidate
+
+
+def _require_file(path_text: str, label: str) -> Path:
+    path = Path(path_text).expanduser()
+    if not path.is_file():
+        raise FileNotFoundError(f"{label} not found: {path}")
+    return path
+
+
+def _require_dir(path_text: str, label: str) -> Path:
+    path = Path(path_text).expanduser()
+    if not path.is_dir():
+        raise FileNotFoundError(f"{label} not found: {path}")
+    return path
+
+
+def _read_best_skill(out_root: Path, fallback: str) -> str:
+    best_skill = out_root / "best_skill.md"
+    if best_skill.is_file():
+        return best_skill.read_text(encoding="utf-8")
+    return fallback
+
+
+def _diff_text(base: str, candidate: str) -> str:
+    lines = difflib.unified_diff(
+        base.splitlines(keepends=True),
+        candidate.splitlines(keepends=True),
+        fromfile="base-template.md",
+        tofile="candidate-template.md",
+    )
+    diff = "".join(lines)
+    return diff or "No content changes.\n"
+
+
+def _eval_report(summary: dict[str, Any], *, dry_run: bool) -> dict[str, Any]:
+    return {
+        "dry_run": dry_run,
+        "best_selection_hard": summary.get("best_selection_hard"),
+        "baseline_selection_hard": summary.get("baseline_selection_hard"),
+        "best_step": summary.get("best_step"),
+        "total_steps": summary.get("total_steps"),
+        "total_accepts": summary.get("total_accepts"),
+        "total_rejects": summary.get("total_rejects"),
+        "total_skips": summary.get("total_skips"),
+        "token_summary": summary.get("token_summary", {}),
+    }
+
+
+def _dry_run_summary(package: TrainingPackage) -> dict[str, Any]:
+    return {
+        "best_selection_hard": None,
+        "baseline_selection_hard": None,
+        "best_step": 0,
+        "total_steps": 0,
+        "total_accepts": 0,
+        "total_rejects": 0,
+        "total_skips": 0,
+        "token_summary": {},
+        "training_package": {
+            "template_id": package.template.id,
+            "items": len(package.items),
+        },
+    }
+
+
+def _preference_summary(summary: dict[str, Any], *, dry_run: bool) -> str:
+    mode = "dry-run fixture" if dry_run else "optimizer"
+    return (
+        f"# Gitmoot SkillOpt Candidate\n\n"
+        f"Mode: {mode}\n\n"
+        f"Best selection hard: {summary.get('best_selection_hard')}\n"
+        f"Baseline selection hard: {summary.get('baseline_selection_hard')}\n"
+        f"Total steps: {summary.get('total_steps')}\n"
+    )
+
+
+def _summary_score(summary: dict[str, Any]) -> float | None:
+    score = summary.get("best_selection_hard")
+    if isinstance(score, bool) or not isinstance(score, int | float):
+        return None
+    return float(score)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - Getting Started:
     - Installation: guide/installation.md
     - First Experiment: guide/first-experiment.md
+    - Gitmoot MVP Workflow: guide/gitmoot-mvp-workflow.md
     - Configuration: guide/configuration.md
   - Core Concepts:
     - Training Loop: guide/training-loop.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,16 +3,17 @@ requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "skillopt"
+name = "gitmoot-skillopt"
 version = "0.1.0"
-description = "SkillOpt: Agentic Skill Optimization via Reflective Training Loops"
+description = "Gitmoot-SkillOpt: optimize Gitmoot agent templates with SkillOpt"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"
 authors = [
     {name = "SkillOpt Team"},
+    {name = "Gitmoot Contributors"},
 ]
-keywords = ["agent", "prompt-optimization", "skill-learning", "LLM", "agentic"]
+keywords = ["agent", "prompt-optimization", "skill-learning", "LLM", "agentic", "gitmoot"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
@@ -54,17 +55,19 @@ all = [
 ]
 
 [project.scripts]
+gitmoot-skillopt = "gitmoot_skillopt.cli:main"
 skillopt-train = "scripts.train:main"
 skillopt-eval = "scripts.eval_only:main"
 
 [project.urls]
-Homepage = "https://github.com/microsoft/SkillOpt"
-Documentation = "https://microsoft.github.io/SkillOpt"
-Repository = "https://github.com/microsoft/SkillOpt"
-Issues = "https://github.com/microsoft/SkillOpt/issues"
+Homepage = "https://github.com/jerryfane/gitmoot-skillopt"
+Documentation = "https://github.com/jerryfane/gitmoot-skillopt"
+Repository = "https://github.com/jerryfane/gitmoot-skillopt"
+Issues = "https://github.com/jerryfane/gitmoot-skillopt/issues"
+Upstream = "https://github.com/microsoft/SkillOpt"
 
 [tool.setuptools.packages.find]
-include = ["skillopt*", "scripts*"]
+include = ["gitmoot_skillopt*", "skillopt*", "scripts*"]
 
 [tool.ruff]
 line-length = 120

--- a/scripts/gitmoot_contract_smoke.py
+++ b/scripts/gitmoot_contract_smoke.py
@@ -1,0 +1,164 @@
+"""Run the local Gitmoot-SkillOpt contract smoke against a Gitmoot binary."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_ROOT = REPO_ROOT / "examples" / "gitmoot" / "mvp-fixture"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a no-network Gitmoot-SkillOpt smoke: optimize the fixture, "
+            "install a local Gitmoot template into a temp home, import the "
+            "candidate artifacts, show the pending candidate, and reject it."
+        )
+    )
+    parser.add_argument("--gitmoot-bin", default="gitmoot", help="Gitmoot executable to run")
+    parser.add_argument("--home", default="", help="Gitmoot home; defaults to a temp directory")
+    parser.add_argument("--out-root", default="", help="optimizer output root; defaults to a temp directory")
+    parser.add_argument("--keep-temp", action="store_true", help="do not delete temp home/output directories")
+    parser.add_argument("--training-package", default=str(FIXTURE_ROOT / "training.json"))
+    parser.add_argument("--artifact-root", default=str(FIXTURE_ROOT / "blobs"))
+    parser.add_argument("--template-file", default=str(FIXTURE_ROOT / "template.md"))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    temp_dirs: list[Path] = []
+    try:
+        home = Path(args.home).expanduser() if args.home else _make_temp_dir("gitmoot-home-", temp_dirs)
+        out_root = Path(args.out_root).expanduser() if args.out_root else _make_temp_dir("gitmoot-skillopt-out-", temp_dirs)
+        candidate = out_root / "candidate.json"
+        template_id = _template_id_from_package(Path(args.training_package))
+
+        _run(
+            [
+                sys.executable,
+                "-m",
+                "gitmoot_skillopt",
+                "optimize",
+                "--training-package",
+                args.training_package,
+                "--artifact-root",
+                args.artifact_root,
+                "--out-root",
+                str(out_root),
+                "--candidate-output",
+                str(candidate),
+                "--dry-run",
+            ],
+            cwd=REPO_ROOT,
+        )
+        _run(
+            [
+                args.gitmoot_bin,
+                "agent",
+                "template",
+                "add",
+                "--home",
+                str(home),
+                "--file",
+                args.template_file,
+                template_id,
+            ]
+        )
+        import_result = _run(
+            [
+                args.gitmoot_bin,
+                "skillopt",
+                "import",
+                "--home",
+                str(home),
+                "--file",
+                str(candidate),
+                "--artifact-dir",
+                str(out_root / "artifacts"),
+            ]
+        )
+        version_id = _version_id_from_import(import_result.stdout)
+        shown = _run([args.gitmoot_bin, "skillopt", "candidate", "show", "--home", str(home), version_id])
+        _assert_contains(shown.stdout, "state: pending")
+        _assert_contains(shown.stdout, "diff_artifact: candidate-diff")
+        _run(
+            [
+                args.gitmoot_bin,
+                "skillopt",
+                "candidate",
+                "reject",
+                "--home",
+                str(home),
+                "--reason",
+                "contract smoke",
+                version_id,
+            ]
+        )
+        rejected = _run([args.gitmoot_bin, "skillopt", "candidate", "show", "--home", str(home), version_id])
+        _assert_contains(rejected.stdout, "state: rejected")
+        print(f"contract smoke passed: {version_id}")
+        return 0
+    finally:
+        if not args.keep_temp:
+            for temp_dir in temp_dirs:
+                shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _make_temp_dir(prefix: str, temp_dirs: list[Path]) -> Path:
+    path = Path(tempfile.mkdtemp(prefix=prefix))
+    temp_dirs.append(path)
+    return path
+
+
+def _run(command: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+    python_path = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = str(REPO_ROOT) if not python_path else f"{REPO_ROOT}{os.pathsep}{python_path}"
+    result = subprocess.run(
+        command,
+        cwd=str(cwd) if cwd else None,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        quoted = " ".join(command)
+        raise RuntimeError(
+            f"command failed ({result.returncode}): {quoted}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _template_id_from_package(package_path: Path) -> str:
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    from gitmoot_skillopt.contracts import TrainingPackage
+
+    return TrainingPackage.load(package_path).template.id
+
+
+def _version_id_from_import(stdout: str) -> str:
+    prefix = "imported pending candidate "
+    for line in stdout.splitlines():
+        if line.startswith(prefix):
+            return line.removeprefix(prefix).strip()
+    raise RuntimeError(f"could not parse imported version id from output:\n{stdout}")
+
+
+def _assert_contains(text: str, expected: str) -> None:
+    if expected not in text:
+        raise RuntimeError(f"expected {expected!r} in output:\n{text}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -84,6 +84,11 @@ def _register_builtins() -> None:
     except ImportError:
         pass
     try:
+        from skillopt.envs.gitmoot.adapter import GitmootAdapter
+        _ENV_REGISTRY["gitmoot"] = GitmootAdapter
+    except ImportError:
+        pass
+    try:
         from skillopt.envs.sealqa.adapter import SealQAAdapter
         _ENV_REGISTRY["sealqa"] = SealQAAdapter
     except ImportError:

--- a/skillopt/envs/gitmoot/__init__.py
+++ b/skillopt/envs/gitmoot/__init__.py
@@ -1,0 +1,8 @@
+"""Gitmoot environment adapter for SkillOpt."""
+
+from __future__ import annotations
+
+from skillopt.envs.gitmoot.adapter import GitmootAdapter
+from skillopt.envs.gitmoot.dataloader import GitmootDataLoader
+
+__all__ = ["GitmootAdapter", "GitmootDataLoader"]

--- a/skillopt/envs/gitmoot/adapter.py
+++ b/skillopt/envs/gitmoot/adapter.py
@@ -1,0 +1,144 @@
+"""Gitmoot environment adapter."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from skillopt.datasets.base import BatchSpec
+from skillopt.envs.base import EnvAdapter
+from skillopt.envs.gitmoot.dataloader import GitmootDataLoader
+from skillopt.envs.gitmoot.package import TemplateDocument, split_template_document
+from skillopt.envs.gitmoot.rollout import run_batch
+from skillopt.gradient.reflect import run_minibatch_reflect
+from skillopt.optimizer.update_modes import (
+    get_payload_items,
+    is_full_rewrite_minibatch_mode,
+)
+
+
+class GitmootAdapter(EnvAdapter):
+    """Adapter that trains Gitmoot agent-template Markdown from review packages."""
+
+    def __init__(
+        self,
+        training_package: str = "",
+        artifact_root: str = "",
+        seed: int = 42,
+        limit: int = 0,
+        analyst_workers: int = 4,
+        minibatch_size: int = 4,
+        edit_budget: int = 4,
+        failure_only: bool = False,
+        max_completion_tokens: int = 4096,
+        **kwargs,
+    ) -> None:
+        del kwargs
+        self.analyst_workers = int(analyst_workers)
+        self.minibatch_size = int(minibatch_size)
+        self.edit_budget = int(edit_budget)
+        self.failure_only = bool(failure_only)
+        self.max_completion_tokens = int(max_completion_tokens)
+        self.dataloader = GitmootDataLoader(
+            training_package=training_package,
+            artifact_root=artifact_root,
+            seed=seed,
+            limit=limit,
+        )
+
+    def setup(self, cfg: dict) -> None:
+        super().setup(cfg)
+        self.dataloader.setup(cfg)
+        _ensure_package_skill_init(cfg, self.dataloader.initial_skill_content)
+
+    def get_dataloader(self) -> GitmootDataLoader:
+        return self.dataloader
+
+    def build_env_from_batch(self, batch: BatchSpec, **kwargs):
+        del kwargs
+        return list(batch.payload or [])
+
+    def build_train_env(self, batch_size: int, seed: int, **kwargs):
+        batch = self.dataloader.build_train_batch(batch_size=batch_size, seed=seed, **kwargs)
+        return self.build_env_from_batch(batch, **kwargs)
+
+    def build_eval_env(self, env_num: int, split: str, seed: int, **kwargs):
+        batch = self.dataloader.build_eval_batch(env_num=env_num, split=split, seed=seed, **kwargs)
+        return self.build_env_from_batch(batch, **kwargs)
+
+    def rollout(
+        self,
+        env_manager,
+        skill_content: str,
+        out_dir: str,
+        **kwargs,
+    ) -> list[dict[str, Any]]:
+        del kwargs
+        items: list[dict[str, Any]] = list(env_manager or [])
+        return run_batch(
+            items=items,
+            skill_content=skill_content,
+            out_root=out_dir,
+            max_completion_tokens=self.max_completion_tokens,
+        )
+
+    def reflect(
+        self,
+        results: list[dict],
+        skill_content: str,
+        out_dir: str,
+        **kwargs,
+    ) -> list[dict | None]:
+        template = split_template_document(skill_content)
+        update_mode = getattr(self, "_cfg", {}).get("skill_update_mode", "patch")
+        patches = run_minibatch_reflect(
+            results=results,
+            skill_content=template.body,
+            prediction_dir=kwargs.get("prediction_dir", os.path.join(out_dir, "predictions")),
+            patches_dir=kwargs.get("patches_dir", os.path.join(out_dir, "patches")),
+            workers=self.analyst_workers,
+            failure_only=self.failure_only,
+            minibatch_size=self.minibatch_size,
+            edit_budget=self.edit_budget,
+            random_seed=kwargs.get("random_seed"),
+            step_buffer_context=kwargs.get("step_buffer_context", ""),
+            meta_skill_context=kwargs.get("meta_skill_context", ""),
+            update_mode=update_mode,
+        )
+        if is_full_rewrite_minibatch_mode(update_mode):
+            _recompose_full_rewrite_candidates(patches, template)
+        return patches
+
+    def get_task_types(self) -> list[str]:
+        return ["gitmoot-skillopt"]
+
+
+def _recompose_full_rewrite_candidates(
+    patches: list[dict | None],
+    template: TemplateDocument,
+) -> None:
+    if not template.frontmatter.strip():
+        return
+    for patch in patches:
+        if not isinstance(patch, dict):
+            continue
+        for candidate in get_payload_items(patch.get("patch", {}), "full_rewrite_minibatch"):
+            if not isinstance(candidate, dict):
+                continue
+            new_skill = str(candidate.get("new_skill", "")).strip()
+            if not new_skill:
+                continue
+            candidate["new_skill"] = template.compose(split_template_document(new_skill).body)
+
+
+def _ensure_package_skill_init(cfg: dict, content: str) -> None:
+    if str(cfg.get("skill_init") or "").strip():
+        return
+    if not content.strip():
+        return
+    out_root = Path(str(cfg.get("out_root") or "outputs/gitmoot")).expanduser()
+    out_root.mkdir(parents=True, exist_ok=True)
+    skill_path = out_root / "gitmoot_initial_skill.md"
+    skill_path.write_text(content, encoding="utf-8")
+    cfg["skill_init"] = str(skill_path)

--- a/skillopt/envs/gitmoot/dataloader.py
+++ b/skillopt/envs/gitmoot/dataloader.py
@@ -1,0 +1,326 @@
+"""Gitmoot training package dataloader."""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from typing import Any
+
+from gitmoot_skillopt.artifacts import ArtifactError, GitmootArtifactResolver
+from gitmoot_skillopt.contracts import ArtifactRef, EvalItem, TrainingPackage
+from skillopt.datasets.base import BaseDataLoader, BatchSpec
+from skillopt.envs.gitmoot.package import (
+    artifact_ids_for_item,
+    artifact_refs_by_id,
+    feedback_events_for_item,
+    json_safe_metadata,
+    safe_item_path_segment,
+    split_template_document,
+)
+
+_SPLIT_ALIASES = {
+    "train": "train",
+    "selection": "val",
+    "valid_seen": "val",
+    "val": "val",
+    "test": "test",
+    "valid_unseen": "test",
+}
+
+_SUPPORTED_TEXT_DRIVERS = {"text", "markdown", "text/markdown"}
+
+
+class GitmootDataLoader(BaseDataLoader):
+    """Load Gitmoot SkillOpt training packages into SkillOpt batches."""
+
+    def __init__(
+        self,
+        training_package: str = "",
+        artifact_root: str = "",
+        seed: int = 42,
+        limit: int = 0,
+        **kwargs,
+    ) -> None:
+        del kwargs
+        self.training_package = training_package
+        self.artifact_root = artifact_root
+        self.seed = int(seed)
+        self.limit = int(limit)
+        self.package: TrainingPackage | None = None
+        self._splits: dict[str, list[dict[str, Any]]] = {"train": [], "val": [], "test": []}
+
+    def setup(self, cfg: dict) -> None:
+        if not self.training_package:
+            self.training_package = str(cfg.get("training_package") or "")
+        if not self.artifact_root:
+            self.artifact_root = str(cfg.get("artifact_root") or "")
+        if not self.training_package:
+            raise ValueError("GitmootDataLoader requires training_package")
+        if not self.artifact_root:
+            raise ValueError("GitmootDataLoader requires artifact_root")
+
+        self.package = TrainingPackage.load(self.training_package)
+        resolver = GitmootArtifactResolver(self.artifact_root)
+        items = [self._item_to_task(item, resolver) for item in self.package.items]
+        self._splits = self._split_items(items)
+        if self.limit:
+            self._splits = {name: split_items[: self.limit] for name, split_items in self._splits.items()}
+
+    @property
+    def initial_skill_content(self) -> str:
+        if self.package is None:
+            return ""
+        return self.package.template.content
+
+    @property
+    def initial_skill_body(self) -> str:
+        return split_template_document(self.initial_skill_content).body
+
+    def get_train_size(self) -> int:
+        return len(self._splits.get("train", []))
+
+    @property
+    def train_items(self) -> list[dict[str, Any]]:
+        return list(self._splits.get("train", []))
+
+    @property
+    def val_items(self) -> list[dict[str, Any]]:
+        return list(self._splits.get("val", []))
+
+    @property
+    def test_items(self) -> list[dict[str, Any]]:
+        return list(self._splits.get("test", []))
+
+    def get_split_items(self, split: str) -> list[dict[str, Any]]:
+        canonical = _SPLIT_ALIASES.get(str(split or "").strip(), "val")
+        return list(self._splits.get(canonical, []))
+
+    def plan_train_epoch(
+        self,
+        *,
+        epoch: int,
+        steps_per_epoch: int,
+        accumulation: int,
+        batch_size: int,
+        seed: int,
+        **kwargs,
+    ) -> list[BatchSpec]:
+        del kwargs
+        epoch_rng = random.Random(seed + epoch * 1000)
+        items = self.train_items
+        epoch_rng.shuffle(items)
+
+        total_batches = steps_per_epoch * accumulation
+        if total_batches <= 0:
+            return []
+
+        batches: list[BatchSpec] = []
+        cursor = 0
+        for batch_idx in range(total_batches):
+            batch_seed = seed + epoch * 1000 + batch_idx + 1
+            batch_items = items[cursor : cursor + batch_size]
+            cursor += len(batch_items)
+            if not batch_items and items:
+                refill_rng = random.Random(batch_seed)
+                batch_items = list(items)
+                refill_rng.shuffle(batch_items)
+                batch_items = batch_items[:batch_size]
+            batches.append(
+                BatchSpec(
+                    phase="train",
+                    split="train",
+                    seed=batch_seed,
+                    batch_size=len(batch_items),
+                    payload=batch_items,
+                )
+            )
+        return batches
+
+    def build_train_batch(self, batch_size: int, seed: int, **kwargs) -> BatchSpec:
+        del kwargs
+        items = self.get_split_items("train")
+        rng = random.Random(seed)
+        rng.shuffle(items)
+        selected = items[:batch_size]
+        return BatchSpec(
+            phase="train",
+            split="train",
+            seed=seed,
+            batch_size=len(selected),
+            payload=selected,
+        )
+
+    def build_eval_batch(self, env_num: int, split: str, seed: int, **kwargs) -> BatchSpec:
+        del kwargs
+        items = self.get_split_items(split)
+        if env_num and env_num < len(items):
+            items = items[:env_num]
+        return BatchSpec(
+            phase="eval",
+            split=split,
+            seed=seed,
+            batch_size=len(items),
+            payload=items,
+        )
+
+    def _item_to_task(self, item: EvalItem, resolver: GitmootArtifactResolver) -> dict[str, Any]:
+        assert self.package is not None
+        safe_item_path_segment(item.id)
+        metadata = json_safe_metadata(item.metadata)
+        artifact_refs = artifact_refs_by_id(self.package)
+        artifacts = self._resolve_item_artifacts(item, artifact_refs, resolver)
+        feedback_events = feedback_events_for_item(self.package, item.id)
+        prompt = build_task_prompt(
+            package=self.package,
+            item=item,
+            artifacts=artifacts,
+            feedback_events=[
+                {
+                    "choice": event.choice,
+                    "reasoning": event.reasoning,
+                    "reviewer": event.reviewer,
+                    "source": event.source,
+                    "created_at": event.created_at,
+                }
+                for event in feedback_events
+            ],
+        )
+        return {
+            "id": item.id,
+            "title": item.title,
+            "task_type": "gitmoot-skillopt",
+            "task_description": item.title or item.id,
+            "metadata": metadata,
+            "split": self._item_split(metadata),
+            "prompt": prompt,
+            "artifacts": artifacts,
+            "feedback_events": [event.to_dict() for event in feedback_events],
+            "evaluator_config": self.package.evaluator_config or {},
+        }
+
+    def _resolve_item_artifacts(
+        self,
+        item: EvalItem,
+        artifact_refs: dict[str, ArtifactRef],
+        resolver: GitmootArtifactResolver,
+    ) -> dict[str, dict[str, Any]]:
+        resolved: dict[str, dict[str, Any]] = {}
+        for role, artifact_id in artifact_ids_for_item(item).items():
+            if not artifact_id:
+                continue
+            ref = artifact_refs[artifact_id]
+            self._validate_text_artifact(ref)
+            blob = resolver.read(ref.hash, expected_size=ref.size_bytes)
+            try:
+                text = blob.content.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ArtifactError(f"artifact {ref.id!r} is not valid UTF-8 text") from exc
+            resolved[role] = {
+                "id": ref.id,
+                "hash": ref.hash,
+                "media_type": ref.media_type,
+                "driver": ref.driver,
+                "text": text,
+            }
+        return resolved
+
+    def _validate_text_artifact(self, artifact: ArtifactRef) -> None:
+        driver = artifact.driver.strip().lower()
+        if driver not in _SUPPORTED_TEXT_DRIVERS:
+            raise ArtifactError(f"artifact driver not supported yet: {artifact.driver}")
+        media_type = artifact.media_type.strip().lower()
+        if media_type and not (media_type.startswith("text/") or media_type in {"application/markdown"}):
+            raise ArtifactError(f"artifact media type not supported yet: {artifact.media_type}")
+
+    def _split_items(self, items: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+        splits: dict[str, list[dict[str, Any]]] = {"train": [], "val": [], "test": []}
+        has_explicit_split = any(item.get("split") for item in items)
+        if has_explicit_split:
+            for item in items:
+                splits[self._canonical_split(str(item.get("split") or ""))].append(item)
+        else:
+            splits = self._deterministic_holdout_split(items)
+        self._validate_splits(splits, explicit=has_explicit_split)
+        return splits
+
+    def _item_split(self, metadata: dict[str, Any]) -> str:
+        split = str(metadata.get("split") or "").strip()
+        if not split:
+            return ""
+        return self._canonical_split(split)
+
+    def _canonical_split(self, split: str) -> str:
+        split = str(split or "").strip()
+        if not split:
+            return "train"
+        if split not in _SPLIT_ALIASES:
+            raise ValueError(f"Gitmoot metadata.split {split!r} is not supported")
+        return _SPLIT_ALIASES[split]
+
+    def _deterministic_holdout_split(self, items: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+        if len(items) < 3:
+            raise ValueError(
+                "Gitmoot packages without metadata.split require at least three items "
+                "to create disjoint train, val, and test splits"
+            )
+        shuffled = list(items)
+        random.Random(self.seed).shuffle(shuffled)
+        test_count = max(1, len(shuffled) // 5)
+        val_count = max(1, len(shuffled) // 5)
+        train_count = len(shuffled) - val_count - test_count
+        if train_count < 1:
+            raise ValueError("Gitmoot split planning requires at least one training item")
+        splits = {
+            "train": [dict(item, split="train") for item in shuffled[:train_count]],
+            "val": [dict(item, split="val") for item in shuffled[train_count : train_count + val_count]],
+            "test": [dict(item, split="test") for item in shuffled[train_count + val_count :]],
+        }
+        return splits
+
+    def _validate_splits(self, splits: dict[str, list[dict[str, Any]]], *, explicit: bool) -> None:
+        missing = [name for name in ("train", "val", "test") if not splits.get(name)]
+        if missing:
+            source = "metadata.split" if explicit else "deterministic split"
+            raise ValueError(f"Gitmoot {source} must provide non-empty train, val, and test splits")
+
+
+def build_task_prompt(
+    *,
+    package: TrainingPackage,
+    item: EvalItem,
+    artifacts: dict[str, dict[str, Any]],
+    feedback_events: list[dict[str, Any]],
+) -> str:
+    parts = [
+        "# Gitmoot SkillOpt Item",
+        f"Template: {package.template.id} ({package.template.version_id})",
+        f"Eval run: {package.eval_run.id}",
+        f"Item: {item.id}",
+        f"Title: {item.title}",
+    ]
+    if item.metadata is not None:
+        parts.extend(["", "## Item Metadata", json.dumps(item.metadata, indent=2, sort_keys=True)])
+    for role in ("source", "baseline", "candidate", "preview", "diff"):
+        artifact = artifacts.get(role)
+        if not artifact:
+            continue
+        parts.extend(
+            [
+                "",
+                f"## {role.title()} Artifact",
+                f"Artifact id: {artifact['id']}",
+                artifact["text"],
+            ]
+        )
+    if feedback_events:
+        parts.extend(["", "## Human Feedback Events", json.dumps(feedback_events, indent=2, sort_keys=True)])
+    parts.append(
+        "\nUse the current skill to produce the requested improved response. "
+        "Ground the response in the artifacts and feedback above."
+    )
+    return "\n".join(parts)
+
+
+def load_package(path: str | Path) -> TrainingPackage:
+    return TrainingPackage.load(path)

--- a/skillopt/envs/gitmoot/evaluator.py
+++ b/skillopt/envs/gitmoot/evaluator.py
@@ -1,0 +1,118 @@
+"""Gitmoot rollout evaluators."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from skillopt.model import chat_optimizer
+from skillopt.utils import extract_json
+
+
+def evaluate_response(item: dict[str, Any], response: str, evaluator_config: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Evaluate one Gitmoot response.
+
+    Supported deterministic modes are intended for fixtures and CI. When no
+    supported explicit mode is present, an LLM judge compares the response
+    against source, baseline, candidate, and feedback context.
+    """
+    config = evaluator_config if isinstance(evaluator_config, dict) else {}
+    mode = str(config.get("mode") or item.get("metadata", {}).get("evaluator_mode") or "").strip().lower()
+    if mode in {"fixture", "deterministic", "mock"}:
+        return _fixture_score(item)
+    if mode in {"contains", "substring"}:
+        return _contains_score(item, response, config)
+    return _judge_score(item, response, config)
+
+
+def _fixture_score(item: dict[str, Any]) -> dict[str, Any]:
+    metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+    hard = bool(metadata.get("expected_hard", True))
+    soft = float(metadata.get("expected_soft", 1.0 if hard else 0.0))
+    return {
+        "hard": 1 if hard else 0,
+        "soft": max(0.0, min(1.0, soft)),
+        "fail_reason": "" if hard else str(metadata.get("fail_reason") or "fixture evaluator marked this item failed"),
+        "metadata": {"evaluator": "fixture"},
+    }
+
+
+def _contains_score(item: dict[str, Any], response: str, config: dict[str, Any]) -> dict[str, Any]:
+    metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+    required = str(config.get("required_text") or metadata.get("required_text") or "").strip()
+    if not required:
+        return {
+            "hard": 0,
+            "soft": 0.0,
+            "fail_reason": "contains evaluator requires required_text",
+            "metadata": {"evaluator": "contains"},
+        }
+    ok = required.lower() in response.lower()
+    return {
+        "hard": 1 if ok else 0,
+        "soft": 1.0 if ok else 0.0,
+        "fail_reason": "" if ok else f"response did not contain required text {required!r}",
+        "metadata": {"evaluator": "contains", "required_text": required},
+    }
+
+
+def _judge_score(item: dict[str, Any], response: str, config: dict[str, Any]) -> dict[str, Any]:
+    system = (
+        "You are evaluating a Gitmoot SkillOpt candidate response. "
+        "Return only JSON with keys hard, soft, fail_reason, and reasoning. "
+        "hard must be 0 or 1. soft must be a number from 0 to 1."
+    )
+    user = "\n\n".join(
+        [
+            "## Evaluation Config",
+            json.dumps(config, indent=2, sort_keys=True),
+            "## Task Prompt",
+            str(item.get("prompt") or ""),
+            "## Candidate Response",
+            response,
+        ]
+    )
+    raw, _usage = chat_optimizer(system=system, user=user, max_completion_tokens=2048, retries=2, stage="gitmoot_judge")
+    parsed = extract_json(raw)
+    if not isinstance(parsed, dict):
+        return {
+            "hard": 0,
+            "soft": 0.0,
+            "fail_reason": "judge did not return JSON",
+            "metadata": {"evaluator": "llm_judge", "raw": raw[:1000]},
+        }
+    hard = _parse_hard(parsed.get("hard"))
+    try:
+        soft = float(parsed.get("soft", hard))
+    except (TypeError, ValueError):
+        soft = float(hard)
+    soft = max(0.0, min(1.0, soft))
+    fail_reason = str(parsed.get("fail_reason") or "")
+    return {
+        "hard": hard,
+        "soft": soft,
+        "fail_reason": "" if hard else fail_reason or "judge marked this item failed",
+        "metadata": {
+            "evaluator": "llm_judge",
+            "judge_derived": True,
+            "reasoning": str(parsed.get("reasoning") or ""),
+        },
+    }
+
+
+def _parse_hard(value: Any) -> int:
+    if isinstance(value, bool):
+        return 1 if value else 0
+    if isinstance(value, int | float):
+        return 1 if float(value) > 0 else 0
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "pass", "passed", "success"}:
+            return 1
+        if normalized in {"0", "false", "no", "fail", "failed", "failure"}:
+            return 0
+        try:
+            return 1 if float(normalized) > 0 else 0
+        except ValueError:
+            return 0
+    return 0

--- a/skillopt/envs/gitmoot/package.py
+++ b/skillopt/envs/gitmoot/package.py
@@ -1,0 +1,72 @@
+"""Shared Gitmoot package helpers for the SkillOpt adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from gitmoot_skillopt.contracts import (
+    ArtifactRef,
+    EvalItem,
+    FeedbackEvent,
+    TrainingPackage,
+)
+
+
+@dataclass(frozen=True)
+class TemplateDocument:
+    """A template split into frontmatter and optimizable Markdown body."""
+
+    frontmatter: str
+    body: str
+
+    def compose(self, body: str | None = None) -> str:
+        actual_body = self.body if body is None else body
+        return f"---\n{self.frontmatter.strip()}\n---\n{actual_body.lstrip()}"
+
+
+def split_template_document(content: str) -> TemplateDocument:
+    """Split a full agent-template Markdown document without rewriting YAML."""
+    normalized = content.replace("\r\n", "\n").strip()
+    lines = normalized.split("\n")
+    if len(lines) < 3 or lines[0].strip() != "---":
+        return TemplateDocument(frontmatter="", body=content)
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return TemplateDocument(
+                frontmatter="\n".join(lines[1:index]),
+                body="\n".join(lines[index + 1 :]).lstrip("\n"),
+            )
+    return TemplateDocument(frontmatter="", body=content)
+
+
+def feedback_events_for_item(package: TrainingPackage, item_id: str) -> list[FeedbackEvent]:
+    return [event for event in package.feedback_events if event.item_id == item_id]
+
+
+def artifact_refs_by_id(package: TrainingPackage) -> dict[str, ArtifactRef]:
+    return {artifact.id: artifact for artifact in package.artifacts}
+
+
+def artifact_ids_for_item(item: EvalItem) -> dict[str, str]:
+    return {
+        "source": item.source_artifact_id,
+        "baseline": item.baseline_artifact_id,
+        "candidate": item.candidate_artifact_id,
+        "preview": item.preview_artifact_id,
+        "diff": item.diff_artifact_id,
+    }
+
+
+def json_safe_metadata(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def safe_item_path_segment(item_id: str) -> str:
+    """Return an item id that is safe to use as one filesystem path segment."""
+    value = str(item_id).strip()
+    if not value:
+        raise ValueError("Gitmoot item id is required")
+    if value in {".", ".."} or "/" in value or "\\" in value:
+        raise ValueError(f"Gitmoot item id {item_id!r} is not safe for filesystem output")
+    return value

--- a/skillopt/envs/gitmoot/rollout.py
+++ b/skillopt/envs/gitmoot/rollout.py
@@ -1,0 +1,135 @@
+"""Gitmoot rollout execution."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from skillopt.envs.gitmoot.evaluator import evaluate_response
+from skillopt.envs.gitmoot.package import safe_item_path_segment
+from skillopt.model import chat_target, is_target_chat_backend
+
+
+def run_batch(
+    *,
+    items: list[dict[str, Any]],
+    skill_content: str,
+    out_root: str,
+    max_completion_tokens: int = 4096,
+    evaluator_config: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    return [
+        process_one(
+            item=item,
+            skill_content=skill_content,
+            out_root=out_root,
+            max_completion_tokens=max_completion_tokens,
+            evaluator_config=evaluator_config,
+        )
+        for item in items
+    ]
+
+
+def process_one(
+    *,
+    item: dict[str, Any],
+    skill_content: str,
+    out_root: str,
+    max_completion_tokens: int = 4096,
+    evaluator_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    item_id = str(item["id"])
+    prediction_id = safe_item_path_segment(item_id)
+    pred_dir = os.path.join(out_root, "predictions", prediction_id)
+    os.makedirs(pred_dir, exist_ok=True)
+    system_prompt = _build_system_prompt(skill_content)
+    user_prompt = str(item.get("prompt") or "")
+    response = ""
+    fail_reason = ""
+    agent_ok = False
+    agent_failed = False
+
+    try:
+        response = _run_agent(item, system_prompt, user_prompt, max_completion_tokens)
+        agent_ok = True
+    except Exception as exc:  # noqa: BLE001 - rollout result records the failure.
+        agent_failed = True
+        fail_reason = str(exc) or "agent execution failed"
+
+    if agent_failed:
+        score = {
+            "hard": 0,
+            "soft": 0.0,
+            "fail_reason": fail_reason,
+            "metadata": {"evaluator": "not_run", "agent_error": True},
+        }
+    else:
+        config = evaluator_config if evaluator_config is not None else item.get("evaluator_config")
+        score = evaluate_response(item, response, config if isinstance(config, dict) else {})
+    result = {
+        "id": item_id,
+        "hard": int(score.get("hard", 0)),
+        "soft": float(score.get("soft", 0.0)),
+        "response": response,
+        "fail_reason": str(score.get("fail_reason") or ""),
+        "agent_ok": agent_ok,
+        "n_turns": 1 if agent_ok else 0,
+        "task_type": item.get("task_type", "gitmoot-skillopt"),
+        "task_description": item.get("task_description", item_id),
+        "metadata": {
+            **(item.get("metadata") if isinstance(item.get("metadata"), dict) else {}),
+            **(score.get("metadata") if isinstance(score.get("metadata"), dict) else {}),
+        },
+        "target_system_prompt": system_prompt,
+        "target_user_prompt": user_prompt,
+    }
+    _write_prediction(pred_dir, result)
+    return result
+
+
+def _run_agent(
+    item: dict[str, Any],
+    system_prompt: str,
+    user_prompt: str,
+    max_completion_tokens: int,
+) -> str:
+    metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+    if metadata.get("mock_response") is not None:
+        return str(metadata["mock_response"])
+    if not is_target_chat_backend():
+        raise RuntimeError("Gitmoot rollout currently requires a chat target backend or metadata.mock_response")
+    response, _usage = chat_target(
+        system=system_prompt,
+        user=user_prompt,
+        max_completion_tokens=max_completion_tokens,
+        retries=2,
+        stage="gitmoot_rollout",
+    )
+    return response
+
+
+def _build_system_prompt(skill_content: str) -> str:
+    return (
+        "Use the following Gitmoot agent-template skill to answer the task. "
+        "Preserve the intent of the skill and produce only the requested response.\n\n"
+        f"## Skill\n{skill_content.strip()}"
+    )
+
+
+def _write_prediction(pred_dir: str, result: dict[str, Any]) -> None:
+    with open(os.path.join(pred_dir, "result.json"), "w", encoding="utf-8") as handle:
+        json.dump(result, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    conversation = [
+        {"role": "system", "content": result["target_system_prompt"]},
+        {"role": "user", "content": result["target_user_prompt"]},
+        {"role": "assistant", "content": result["response"]},
+    ]
+    with open(os.path.join(pred_dir, "conversation.json"), "w", encoding="utf-8") as handle:
+        json.dump(conversation, handle, indent=2)
+        handle.write("\n")
+    with open(os.path.join(pred_dir, "target_system_prompt.txt"), "w", encoding="utf-8") as handle:
+        handle.write(result["target_system_prompt"])
+    with open(os.path.join(pred_dir, "target_user_prompt.txt"), "w", encoding="utf-8") as handle:
+        handle.write(result["target_user_prompt"])

--- a/tests/test_gitmoot_adapter.py
+++ b/tests/test_gitmoot_adapter.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from skillopt.envs.gitmoot.adapter import GitmootAdapter
+from skillopt.envs.gitmoot.evaluator import evaluate_response
+from skillopt.envs.gitmoot.rollout import process_one
+from tests.test_gitmoot_dataloader import write_training_package
+
+
+def test_train_registry_can_instantiate_gitmoot_adapter(tmp_path):
+    package_path, artifact_root = write_training_package(tmp_path)
+
+    from scripts.train import get_adapter
+
+    adapter = get_adapter(
+        {
+            "env": "gitmoot",
+            "training_package": str(package_path),
+            "artifact_root": str(artifact_root),
+        }
+    )
+
+    assert isinstance(adapter, GitmootAdapter)
+
+
+def test_adapter_setup_uses_package_template_as_initial_skill(tmp_path):
+    package_path, artifact_root = write_training_package(tmp_path)
+    adapter = GitmootAdapter(str(package_path), str(artifact_root))
+    cfg = {"out_root": str(tmp_path / "out"), "skill_init": ""}
+
+    adapter.setup(cfg)
+
+    assert cfg["skill_init"].endswith("gitmoot_initial_skill.md")
+    content = (tmp_path / "out" / "gitmoot_initial_skill.md").read_text(encoding="utf-8")
+    assert content == adapter.dataloader.initial_skill_content
+    assert content.startswith("---\n")
+
+
+def test_adapter_rollout_returns_skillopt_result_shape(tmp_path):
+    package_path, artifact_root = write_training_package(tmp_path)
+    adapter = GitmootAdapter(str(package_path), str(artifact_root))
+    adapter.setup({})
+    env = adapter.build_train_env(batch_size=1, seed=1)
+
+    results = adapter.rollout(env, adapter.dataloader.initial_skill_content, str(tmp_path / "out"))
+
+    assert len(results) == 1
+    assert results[0]["id"] == "train-1"
+    assert results[0]["hard"] == 1
+    assert results[0]["soft"] == 1.0
+    assert results[0]["response"] == "better plan"
+    assert results[0]["fail_reason"] == ""
+    assert (tmp_path / "out" / "predictions" / "train-1" / "conversation.json").is_file()
+
+
+def test_adapter_eval_batch_uses_fixture_evaluator(tmp_path):
+    package_path, artifact_root = write_training_package(tmp_path)
+    adapter = GitmootAdapter(str(package_path), str(artifact_root))
+    adapter.setup({})
+    env = adapter.build_eval_env(env_num=1, split="valid_seen", seed=1)
+
+    results = adapter.rollout(env, adapter.dataloader.initial_skill_content, str(tmp_path / "out"))
+
+    assert results[0]["id"] == "val-1"
+    assert results[0]["hard"] == 0
+    assert results[0]["soft"] == 0.25
+    assert results[0]["metadata"]["evaluator"] == "fixture"
+
+
+def test_adapter_reflection_uses_template_body_not_frontmatter(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_reflect(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr("skillopt.envs.gitmoot.adapter.run_minibatch_reflect", fake_reflect)
+    package_path, artifact_root = write_training_package(tmp_path)
+    adapter = GitmootAdapter(str(package_path), str(artifact_root))
+    adapter.setup({})
+
+    adapter.reflect([], adapter.dataloader.initial_skill_content, str(tmp_path / "out"))
+
+    assert captured["skill_content"].startswith("# Planner")
+    assert "kind: agent-template" not in captured["skill_content"]
+
+
+def test_full_rewrite_reflection_preserves_template_frontmatter(tmp_path, monkeypatch):
+    def fake_reflect(**kwargs):
+        return [
+            {
+                "patch": {
+                    "skill_candidates": [
+                        {"new_skill": "# Planner\n\nUse the new planning rules.\n"}
+                    ]
+                }
+            }
+        ]
+
+    monkeypatch.setattr("skillopt.envs.gitmoot.adapter.run_minibatch_reflect", fake_reflect)
+    package_path, artifact_root = write_training_package(tmp_path)
+    adapter = GitmootAdapter(str(package_path), str(artifact_root))
+    adapter.setup({"skill_update_mode": "full_rewrite_minibatch"})
+
+    patches = adapter.reflect([], adapter.dataloader.initial_skill_content, str(tmp_path / "out"))
+    new_skill = patches[0]["patch"]["skill_candidates"][0]["new_skill"]
+
+    assert new_skill.startswith("---\n")
+    assert "kind: agent-template" in new_skill.split("---", 2)[1]
+    assert "\n---\n# Planner" in new_skill
+
+
+def test_failed_agent_execution_overrides_fixture_success(tmp_path):
+    item = {
+        "id": "broken",
+        "prompt": "Prompt",
+        "metadata": {"expected_hard": True},
+        "evaluator_config": {"mode": "fixture"},
+    }
+
+    result = process_one(item=item, skill_content="skill", out_root=str(tmp_path))
+
+    assert result["agent_ok"] is False
+    assert result["hard"] == 0
+    assert result["soft"] == 0.0
+    assert result["fail_reason"]
+
+
+def test_failed_agent_execution_does_not_call_judge(tmp_path, monkeypatch):
+    def fail_evaluator(*args, **kwargs):
+        raise AssertionError("evaluator should not run after agent failure")
+
+    monkeypatch.setattr("skillopt.envs.gitmoot.rollout.evaluate_response", fail_evaluator)
+    item = {"id": "broken", "prompt": "Prompt", "metadata": {"expected_hard": True}}
+
+    result = process_one(item=item, skill_content="skill", out_root=str(tmp_path))
+
+    assert result["hard"] == 0
+    assert result["metadata"]["agent_error"] is True
+
+
+def test_empty_message_agent_exception_is_still_failure(tmp_path, monkeypatch):
+    def fail_agent(*args, **kwargs):
+        raise Exception()
+
+    monkeypatch.setattr("skillopt.envs.gitmoot.rollout._run_agent", fail_agent)
+    item = {
+        "id": "broken",
+        "prompt": "Prompt",
+        "metadata": {"expected_hard": True},
+        "evaluator_config": {"mode": "fixture"},
+    }
+
+    result = process_one(item=item, skill_content="skill", out_root=str(tmp_path))
+
+    assert result["agent_ok"] is False
+    assert result["hard"] == 0
+    assert result["fail_reason"] == "agent execution failed"
+    assert result["metadata"]["agent_error"] is True
+
+
+def test_contains_evaluator_is_deterministic():
+    item = {"metadata": {"required_text": "ship it"}}
+
+    score = evaluate_response(item, "We should ship it today.", {"mode": "contains"})
+
+    assert score["hard"] == 1
+    assert score["soft"] == 1.0
+    assert score["metadata"]["evaluator"] == "contains"
+
+
+def test_judge_evaluator_parses_string_hard_values(monkeypatch):
+    def fake_chat_optimizer(**kwargs):
+        return ('{"hard": "0", "soft": "0.2", "fail_reason": "bad", "reasoning": "No."}', {})
+
+    monkeypatch.setattr("skillopt.envs.gitmoot.evaluator.chat_optimizer", fake_chat_optimizer)
+
+    score = evaluate_response({"prompt": "Prompt"}, "Response", {})
+
+    assert score["hard"] == 0
+    assert score["soft"] == 0.2
+    assert score["fail_reason"] == "bad"

--- a/tests/test_gitmoot_artifacts.py
+++ b/tests/test_gitmoot_artifacts.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import pytest
+
+from gitmoot_skillopt.artifacts import (
+    ArtifactError,
+    GitmootArtifactResolver,
+    OutputArtifactWriter,
+    content_hash,
+    normalize_hash,
+)
+
+
+def write_gitmoot_blob(root, content: bytes) -> str:
+    hash_value = content_hash(content)
+    hex_hash = hash_value.removeprefix("sha256:")
+    path = root / "sha256" / hex_hash[:2] / hex_hash
+    path.parent.mkdir(parents=True)
+    path.write_bytes(content)
+    return hash_value
+
+
+def test_resolver_reads_gitmoot_sha256_blob(tmp_path):
+    content = b"hello artifact\n"
+    hash_value = write_gitmoot_blob(tmp_path, content)
+
+    resolved = GitmootArtifactResolver(tmp_path).read(hash_value, expected_size=len(content))
+
+    assert resolved.hash == hash_value
+    assert resolved.content == content
+    assert resolved.path.name == hash_value.removeprefix("sha256:")
+
+
+def test_resolver_rejects_missing_blob(tmp_path):
+    missing = "sha256:" + "a" * 64
+
+    with pytest.raises(ArtifactError, match="not found"):
+        GitmootArtifactResolver(tmp_path).read(missing)
+
+
+def test_resolver_rejects_empty_root():
+    with pytest.raises(ArtifactError, match="artifact root is required"):
+        GitmootArtifactResolver("")
+
+
+def test_resolver_rejects_hash_mismatch(tmp_path):
+    expected = "sha256:" + "b" * 64
+    hex_hash = expected.removeprefix("sha256:")
+    path = tmp_path / "sha256" / hex_hash[:2] / hex_hash
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"wrong")
+
+    with pytest.raises(ArtifactError, match="content hash mismatch"):
+        GitmootArtifactResolver(tmp_path).read(expected)
+
+
+def test_normalize_hash_accepts_prefixed_and_plain_hashes():
+    assert normalize_hash("C" * 64) == "sha256:" + "c" * 64
+    assert normalize_hash("sha256:" + "D" * 64) == "sha256:" + "d" * 64
+
+
+def test_output_writer_writes_under_artifacts_and_returns_manifest(tmp_path):
+    writer = OutputArtifactWriter(tmp_path)
+
+    entry = writer.write_bytes(
+        "reports/diff.md",
+        b"# diff\n",
+        artifact_id="candidate-diff",
+        media_type="text/markdown",
+        driver="gitmoot-skillopt",
+    )
+
+    assert (tmp_path / "artifacts" / "reports" / "diff.md").read_bytes() == b"# diff\n"
+    assert entry.to_dict() == {
+        "id": "candidate-diff",
+        "hash": content_hash(b"# diff\n"),
+        "media_type": "text/markdown",
+        "size_bytes": 7,
+        "driver": "gitmoot-skillopt",
+        "path": "reports/diff.md",
+    }
+
+
+def test_output_writer_rejects_empty_root():
+    with pytest.raises(ArtifactError, match="output root is required"):
+        OutputArtifactWriter("")
+
+
+@pytest.mark.parametrize("relative_path", ["../escape.md", "/tmp/escape.md", "nested/../../escape.md"])
+def test_output_writer_rejects_escaping_paths(tmp_path, relative_path):
+    writer = OutputArtifactWriter(tmp_path)
+
+    with pytest.raises(ArtifactError, match="path"):
+        writer.write_bytes(
+            relative_path,
+            b"bad",
+            artifact_id="bad",
+            media_type="text/plain",
+            driver="test",
+        )
+
+
+def test_output_writer_rejects_symlink_parent_without_outside_mutation(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    artifacts = tmp_path / "out" / "artifacts"
+    artifacts.mkdir(parents=True)
+    (artifacts / "link").symlink_to(outside, target_is_directory=True)
+    writer = OutputArtifactWriter(tmp_path / "out")
+
+    with pytest.raises(ArtifactError, match="symlink"):
+        writer.write_bytes(
+            "link/new/diff.md",
+            b"bad",
+            artifact_id="bad",
+            media_type="text/plain",
+            driver="test",
+        )
+
+    assert not (outside / "new").exists()

--- a/tests/test_gitmoot_dataloader.py
+++ b/tests/test_gitmoot_dataloader.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from gitmoot_skillopt.artifacts import ArtifactError, content_hash
+from gitmoot_skillopt.contracts import CONTRACT_VERSION, TRAINING_PACKAGE_KIND
+from skillopt.envs.gitmoot.dataloader import GitmootDataLoader
+
+
+def template_content() -> str:
+    return """---
+id: planner
+name: Planner
+description: Plans work.
+kind: agent-template
+version: 1
+capabilities:
+  - ask
+runtime_compatibility:
+  - codex
+tags:
+  - planning
+inputs:
+  - request
+outputs:
+  - plan
+---
+# Planner
+
+Plan carefully.
+"""
+
+
+def metadata() -> dict[str, object]:
+    return {
+        "id": "planner",
+        "name": "Planner",
+        "description": "Plans work.",
+        "kind": "agent-template",
+        "version": 1,
+        "capabilities": ["ask"],
+        "runtime_compatibility": ["codex"],
+        "tags": ["planning"],
+        "inputs": ["request"],
+        "outputs": ["plan"],
+    }
+
+
+def write_blob(root, content: bytes) -> str:
+    hash_value = content_hash(content)
+    hex_hash = hash_value.removeprefix("sha256:")
+    path = root / "sha256" / hex_hash[:2] / hex_hash
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return hash_value
+
+
+def write_training_package(tmp_path, *, artifact_driver: str = "text"):
+    artifact_root = tmp_path / "blobs"
+    baseline = b"Baseline plan\n"
+    candidate = b"Candidate plan\n"
+    baseline_hash = write_blob(artifact_root, baseline)
+    candidate_hash = write_blob(artifact_root, candidate)
+    content = template_content()
+    package = {
+        "kind": TRAINING_PACKAGE_KIND,
+        "contract_version": CONTRACT_VERSION,
+        "template": {
+            "id": "planner",
+            "version_id": "planner@v1",
+            "version_number": 1,
+            "version_state": "current",
+            "content_hash": content_hash(content.encode()),
+            "source_repo": "jerryfane/gitmoot",
+            "source_ref": "main",
+            "source_path": "skills/gitmoot/agent-templates/planner.md",
+            "resolved_commit": "abc123",
+            "metadata": metadata(),
+            "content": content,
+        },
+        "eval_run": {
+            "id": "run-1",
+            "template_id": "planner",
+            "template_version_id": "planner@v1",
+            "target_repo": "owner/repo",
+            "state": "completed",
+            "metadata": {"metric": "preference"},
+        },
+        "items": [
+            {
+                "id": "train-1",
+                "title": "Train item",
+                "baseline_artifact_id": "baseline",
+                "candidate_artifact_id": "candidate",
+                "metadata": {"split": "train", "mock_response": "better plan", "expected_hard": True},
+            },
+            {
+                "id": "val-1",
+                "title": "Val item",
+                "baseline_artifact_id": "baseline",
+                "candidate_artifact_id": "candidate",
+                "metadata": {"split": "val", "mock_response": "better val", "expected_hard": False, "expected_soft": 0.25},
+            },
+            {
+                "id": "test-1",
+                "title": "Test item",
+                "baseline_artifact_id": "baseline",
+                "candidate_artifact_id": "candidate",
+                "metadata": {"split": "test", "mock_response": "better test", "expected_hard": True},
+            },
+        ],
+        "artifacts": [
+            {
+                "id": "baseline",
+                "hash": baseline_hash,
+                "media_type": "text/markdown",
+                "size_bytes": len(baseline),
+                "driver": artifact_driver,
+            },
+            {
+                "id": "candidate",
+                "hash": candidate_hash,
+                "media_type": "text/markdown",
+                "size_bytes": len(candidate),
+                "driver": "text",
+            },
+        ],
+        "feedback_events": [
+            {
+                "run_id": "run-1",
+                "item_id": "train-1",
+                "choice": "b",
+                "reasoning": "Candidate is clearer.",
+                "reviewer": "alice",
+                "source": "markdown",
+                "source_url": "",
+                "created_at": "2026-05-31T00:00:00Z",
+            }
+        ],
+        "evaluator_config": {"mode": "fixture"},
+    }
+    package_path = tmp_path / "training.json"
+    package_path.write_text(json.dumps(package), encoding="utf-8")
+    return package_path, artifact_root
+
+
+def test_dataloader_loads_package_and_builds_splits(tmp_path):
+    package_path, artifact_root = write_training_package(tmp_path)
+    loader = GitmootDataLoader(str(package_path), str(artifact_root))
+
+    loader.setup({})
+    train_batch = loader.build_train_batch(batch_size=2, seed=1)
+    val_batch = loader.build_eval_batch(env_num=10, split="valid_seen", seed=1)
+    test_batch = loader.build_eval_batch(env_num=1, split="valid_unseen", seed=1)
+
+    assert loader.get_train_size() == 1
+    assert "# Planner" in loader.initial_skill_body
+    assert [item["id"] for item in train_batch.payload] == ["train-1"]
+    assert [item["id"] for item in val_batch.payload] == ["val-1"]
+    assert [item["id"] for item in test_batch.payload] == ["test-1"]
+    prompt = train_batch.payload[0]["prompt"]
+    assert "Baseline plan" in prompt
+    assert "Candidate plan" in prompt
+    assert "Candidate is clearer" in prompt
+
+
+def test_dataloader_creates_disjoint_splits_when_metadata_split_is_absent(tmp_path):
+    package_path, artifact_root = write_training_package(tmp_path)
+    package = json.loads(package_path.read_text(encoding="utf-8"))
+    for item in package["items"]:
+        item["metadata"].pop("split")
+    package_path.write_text(json.dumps(package), encoding="utf-8")
+    loader = GitmootDataLoader(str(package_path), str(artifact_root))
+
+    loader.setup({})
+    train_ids = {item["id"] for item in loader.build_train_batch(batch_size=10, seed=1).payload}
+    val_ids = {item["id"] for item in loader.build_eval_batch(env_num=10, split="valid_seen", seed=1).payload}
+    test_ids = {item["id"] for item in loader.build_eval_batch(env_num=10, split="valid_unseen", seed=1).payload}
+
+    assert train_ids
+    assert val_ids
+    assert test_ids
+    assert train_ids.isdisjoint(val_ids)
+    assert train_ids.isdisjoint(test_ids)
+    assert val_ids.isdisjoint(test_ids)
+    assert train_ids | val_ids | test_ids == {"train-1", "val-1", "test-1"}
+
+
+def test_dataloader_rejects_incomplete_explicit_splits(tmp_path):
+    package_path, artifact_root = write_training_package(tmp_path)
+    package = json.loads(package_path.read_text(encoding="utf-8"))
+    for item in package["items"]:
+        item["metadata"]["split"] = "train"
+    package_path.write_text(json.dumps(package), encoding="utf-8")
+    loader = GitmootDataLoader(str(package_path), str(artifact_root))
+
+    with pytest.raises(ValueError, match="non-empty train, val, and test"):
+        loader.setup({})
+
+
+def test_dataloader_rejects_unknown_explicit_split_label(tmp_path):
+    package_path, artifact_root = write_training_package(tmp_path)
+    package = json.loads(package_path.read_text(encoding="utf-8"))
+    package["items"][1]["metadata"]["split"] = "validation"
+    package_path.write_text(json.dumps(package), encoding="utf-8")
+    loader = GitmootDataLoader(str(package_path), str(artifact_root))
+
+    with pytest.raises(ValueError, match="metadata.split"):
+        loader.setup({})
+
+
+def test_dataloader_limit_applies_after_split_assignment(tmp_path):
+    package_path, artifact_root = write_training_package(tmp_path)
+    loader = GitmootDataLoader(str(package_path), str(artifact_root), limit=1)
+
+    loader.setup({})
+
+    assert [item["id"] for item in loader.build_train_batch(batch_size=10, seed=1).payload] == ["train-1"]
+    assert [item["id"] for item in loader.build_eval_batch(env_num=10, split="valid_seen", seed=1).payload] == ["val-1"]
+    assert [item["id"] for item in loader.build_eval_batch(env_num=10, split="valid_unseen", seed=1).payload] == ["test-1"]
+
+
+def test_dataloader_train_epoch_covers_train_split_without_replacement(tmp_path):
+    package_path, artifact_root = write_training_package(tmp_path)
+    package = json.loads(package_path.read_text(encoding="utf-8"))
+    train_template = package["items"][0]
+    package["items"] = [
+        {
+            **train_template,
+            "id": f"train-{index}",
+            "title": f"Train item {index}",
+            "metadata": {**train_template["metadata"], "split": "train"},
+        }
+        for index in range(1, 6)
+    ] + package["items"][1:]
+    package["feedback_events"] = []
+    package_path.write_text(json.dumps(package), encoding="utf-8")
+    loader = GitmootDataLoader(str(package_path), str(artifact_root))
+
+    loader.setup({})
+    batches = loader.plan_train_epoch(epoch=1, steps_per_epoch=3, accumulation=1, batch_size=2, seed=7)
+    seen_ids = [item["id"] for batch in batches for item in batch.payload]
+
+    assert len(seen_ids) == 5
+    assert set(seen_ids) == {f"train-{index}" for index in range(1, 6)}
+
+
+def test_dataloader_rejects_unsupported_artifact_driver(tmp_path):
+    package_path, artifact_root = write_training_package(tmp_path, artifact_driver="xlsx")
+    loader = GitmootDataLoader(str(package_path), str(artifact_root))
+
+    with pytest.raises(ArtifactError, match="driver not supported yet"):
+        loader.setup({})
+
+
+def test_dataloader_rejects_item_ids_that_are_unsafe_paths(tmp_path):
+    package_path, artifact_root = write_training_package(tmp_path)
+    package = json.loads(package_path.read_text(encoding="utf-8"))
+    package["items"][0]["id"] = "../escape"
+    package["feedback_events"][0]["item_id"] = "../escape"
+    package_path.write_text(json.dumps(package), encoding="utf-8")
+    loader = GitmootDataLoader(str(package_path), str(artifact_root))
+
+    with pytest.raises(ValueError, match="not safe"):
+        loader.setup({})

--- a/tests/test_gitmoot_examples.py
+++ b/tests/test_gitmoot_examples.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gitmoot_skillopt.artifacts import content_hash
+from gitmoot_skillopt.cli import main
+from gitmoot_skillopt.contracts import CandidatePackage, TrainingPackage
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_ROOT = REPO_ROOT / "examples" / "gitmoot" / "mvp-fixture"
+
+
+def test_gitmoot_mvp_fixture_dry_run_contract(tmp_path):
+    package_path = FIXTURE_ROOT / "training.json"
+    artifact_root = FIXTURE_ROOT / "blobs"
+    out_root = tmp_path / "out"
+    candidate_output = out_root / "candidate.json"
+
+    training = TrainingPackage.load(package_path)
+    assert training.template.id == "planner"
+    assert training.eval_run.id == "fixture-run-1"
+
+    result = main(
+        [
+            "optimize",
+            "--training-package",
+            str(package_path),
+            "--artifact-root",
+            str(artifact_root),
+            "--out-root",
+            str(out_root),
+            "--candidate-output",
+            str(candidate_output),
+            "--dry-run",
+        ]
+    )
+
+    assert result == 0
+    candidate = CandidatePackage.load(candidate_output)
+    assert candidate.template_id == "planner"
+    assert candidate.summary.diff_artifact_id == "candidate-diff"
+    assert candidate.summary.metadata["artifact_ids"] == [
+        "candidate-diff",
+        "eval-report",
+        "preference-summary",
+    ]
+
+    for artifact in candidate.artifacts:
+        artifact_path = out_root / "artifacts" / artifact.path
+        assert artifact_path.is_file()
+        assert content_hash(artifact_path.read_bytes()) == artifact.hash

--- a/tests/test_gitmoot_examples.py
+++ b/tests/test_gitmoot_examples.py
@@ -6,7 +6,6 @@ from gitmoot_skillopt.artifacts import content_hash
 from gitmoot_skillopt.cli import main
 from gitmoot_skillopt.contracts import CandidatePackage, TrainingPackage
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_ROOT = REPO_ROOT / "examples" / "gitmoot" / "mvp-fixture"
 
@@ -18,7 +17,7 @@ def test_gitmoot_mvp_fixture_dry_run_contract(tmp_path):
     candidate_output = out_root / "candidate.json"
 
     training = TrainingPackage.load(package_path)
-    assert training.template.id == "planner"
+    assert training.template.id == "planner-fixture"
     assert training.eval_run.id == "fixture-run-1"
 
     result = main(
@@ -38,7 +37,7 @@ def test_gitmoot_mvp_fixture_dry_run_contract(tmp_path):
 
     assert result == 0
     candidate = CandidatePackage.load(candidate_output)
-    assert candidate.template_id == "planner"
+    assert candidate.template_id == "planner-fixture"
     assert candidate.summary.diff_artifact_id == "candidate-diff"
     assert candidate.summary.metadata["artifact_ids"] == [
         "candidate-diff",

--- a/tests/test_gitmoot_examples.py
+++ b/tests/test_gitmoot_examples.py
@@ -38,11 +38,11 @@ def test_gitmoot_mvp_fixture_dry_run_contract(tmp_path):
     assert result == 0
     candidate = CandidatePackage.load(candidate_output)
     assert candidate.template_id == "planner-fixture"
-    assert candidate.summary.diff_artifact_id == "candidate-diff"
+    assert candidate.summary.diff_artifact_id == "fixture-run-1/candidate-diff"
     assert candidate.summary.metadata["artifact_ids"] == [
-        "candidate-diff",
-        "eval-report",
-        "preference-summary",
+        "fixture-run-1/candidate-diff",
+        "fixture-run-1/eval-report",
+        "fixture-run-1/preference-summary",
     ]
 
     for artifact in candidate.artifacts:

--- a/tests/test_gitmoot_optimize_cli.py
+++ b/tests/test_gitmoot_optimize_cli.py
@@ -138,3 +138,31 @@ def test_optimize_threads_optional_reasoning_effort(tmp_path, monkeypatch):
 
     assert result == 0
     assert captured["reasoning_effort"] == "medium"
+
+
+def test_optimize_threads_gate_metric(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_run_optimize(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr("gitmoot_skillopt.optimize.run_optimize", fake_run_optimize)
+
+    result = main(
+        [
+            "optimize",
+            "--training-package",
+            "training.json",
+            "--artifact-root",
+            "blobs",
+            "--out-root",
+            "out",
+            "--candidate-output",
+            "out/candidate.json",
+            "--gate-metric",
+            "soft",
+        ]
+    )
+
+    assert result == 0
+    assert captured["gate_metric"] == "soft"

--- a/tests/test_gitmoot_optimize_cli.py
+++ b/tests/test_gitmoot_optimize_cli.py
@@ -93,3 +93,48 @@ def test_optimize_dry_run_does_not_start_trainer(tmp_path, monkeypatch):
     )
 
     assert result == 0
+
+
+def test_optimize_threads_optional_reasoning_effort(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_run_optimize(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr("gitmoot_skillopt.optimize.run_optimize", fake_run_optimize)
+
+    result = main(
+        [
+            "optimize",
+            "--training-package",
+            "training.json",
+            "--artifact-root",
+            "blobs",
+            "--out-root",
+            "out",
+            "--candidate-output",
+            "out/candidate.json",
+        ]
+    )
+
+    assert result == 0
+    assert captured["reasoning_effort"] == ""
+
+    result = main(
+        [
+            "optimize",
+            "--training-package",
+            "training.json",
+            "--artifact-root",
+            "blobs",
+            "--out-root",
+            "out",
+            "--candidate-output",
+            "out/candidate.json",
+            "--reasoning-effort",
+            "medium",
+        ]
+    )
+
+    assert result == 0
+    assert captured["reasoning_effort"] == "medium"

--- a/tests/test_gitmoot_optimize_cli.py
+++ b/tests/test_gitmoot_optimize_cli.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from gitmoot_skillopt.cli import main
+from gitmoot_skillopt.contracts import CANDIDATE_PACKAGE_KIND, CandidatePackage
+from tests.test_gitmoot_dataloader import write_training_package
+
+
+def test_optimize_requires_flags():
+    with pytest.raises(SystemExit):
+        main(["optimize"])
+
+
+def test_optimize_rejects_invalid_package_path(tmp_path):
+    with pytest.raises(FileNotFoundError, match="training package"):
+        main(
+            [
+                "optimize",
+                "--training-package",
+                str(tmp_path / "missing.json"),
+                "--artifact-root",
+                str(tmp_path),
+                "--out-root",
+                str(tmp_path / "out"),
+                "--candidate-output",
+                str(tmp_path / "out" / "candidate.json"),
+                "--dry-run",
+            ]
+        )
+
+
+def test_optimize_dry_run_writes_candidate_package_and_artifacts(tmp_path):
+    package_path, artifact_root = write_training_package(tmp_path)
+    out_root = tmp_path / "out"
+    candidate_output = out_root / "candidate.json"
+
+    result = main(
+        [
+            "optimize",
+            "--training-package",
+            str(package_path),
+            "--artifact-root",
+            str(artifact_root),
+            "--out-root",
+            str(out_root),
+            "--candidate-output",
+            str(candidate_output),
+            "--dry-run",
+        ]
+    )
+
+    assert result == 0
+    data = json.loads(candidate_output.read_text(encoding="utf-8"))
+    loaded = CandidatePackage.from_dict(data)
+    assert loaded.kind == CANDIDATE_PACKAGE_KIND
+    assert loaded.template_id == "planner"
+    assert loaded.candidate.content.startswith("---\n")
+    assert loaded.summary.diff_artifact_id == "candidate-diff"
+    assert {artifact.id for artifact in loaded.artifacts} == {
+        "candidate-diff",
+        "eval-report",
+        "preference-summary",
+    }
+    for artifact in loaded.artifacts:
+        assert (out_root / "artifacts" / artifact.path).is_file()
+
+
+def test_optimize_dry_run_does_not_start_trainer(tmp_path, monkeypatch):
+    class FailingTrainer:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("dry-run must not initialize trainer")
+
+    monkeypatch.setattr("gitmoot_skillopt.optimize.ReflACTTrainer", FailingTrainer)
+    package_path, artifact_root = write_training_package(tmp_path)
+    out_root = tmp_path / "out"
+
+    result = main(
+        [
+            "optimize",
+            "--training-package",
+            str(package_path),
+            "--artifact-root",
+            str(artifact_root),
+            "--out-root",
+            str(out_root),
+            "--candidate-output",
+            str(out_root / "candidate.json"),
+            "--dry-run",
+        ]
+    )
+
+    assert result == 0

--- a/tests/test_gitmoot_optimize_cli.py
+++ b/tests/test_gitmoot_optimize_cli.py
@@ -58,14 +58,45 @@ def test_optimize_dry_run_writes_candidate_package_and_artifacts(tmp_path):
     assert loaded.kind == CANDIDATE_PACKAGE_KIND
     assert loaded.template_id == "planner"
     assert loaded.candidate.content.startswith("---\n")
-    assert loaded.summary.diff_artifact_id == "candidate-diff"
+    assert loaded.summary.diff_artifact_id == "run-1/candidate-diff"
     assert {artifact.id for artifact in loaded.artifacts} == {
-        "candidate-diff",
-        "eval-report",
-        "preference-summary",
+        "run-1/candidate-diff",
+        "run-1/eval-report",
+        "run-1/preference-summary",
     }
     for artifact in loaded.artifacts:
         assert (out_root / "artifacts" / artifact.path).is_file()
+
+
+def test_optimize_dry_run_accepts_explicit_artifact_dir(tmp_path):
+    package_path, artifact_root = write_training_package(tmp_path)
+    out_root = tmp_path / "out"
+    artifact_dir = tmp_path / "candidate-artifacts"
+    candidate_output = out_root / "candidate.json"
+
+    result = main(
+        [
+            "optimize",
+            "--training-package",
+            str(package_path),
+            "--artifact-root",
+            str(artifact_root),
+            "--out-root",
+            str(out_root),
+            "--candidate-output",
+            str(candidate_output),
+            "--artifact-dir",
+            str(artifact_dir),
+            "--dry-run",
+        ]
+    )
+
+    assert result == 0
+    data = json.loads(candidate_output.read_text(encoding="utf-8"))
+    loaded = CandidatePackage.from_dict(data)
+    for artifact in loaded.artifacts:
+        assert (artifact_dir / artifact.path).is_file()
+    assert not (out_root / "artifacts").exists()
 
 
 def test_optimize_dry_run_does_not_start_trainer(tmp_path, monkeypatch):

--- a/tests/test_gitmoot_package.py
+++ b/tests/test_gitmoot_package.py
@@ -129,6 +129,16 @@ def candidate_package_dict() -> dict[str, object]:
             "content": template_content(),
             "metadata": metadata(),
         },
+        "artifacts": [
+            {
+                "id": "diff",
+                "hash": "sha256:" + "4" * 64,
+                "media_type": "text/markdown",
+                "size_bytes": 7,
+                "driver": "gitmoot-skillopt",
+                "path": "candidate.diff.md",
+            }
+        ],
         "eval_report": {"score": 0.8},
         "summary": {
             "diff_artifact_id": "diff",
@@ -206,7 +216,55 @@ def test_candidate_package_validates_content_metadata_consistency():
     package = CandidatePackage.from_dict(candidate_package_dict())
 
     assert package.template_id == "planner"
+    assert package.artifacts[0].path == "candidate.diff.md"
     assert package.to_dict()["candidate"]["metadata"] == metadata()
+
+
+def test_candidate_package_rejects_duplicate_artifact_ids():
+    data = candidate_package_dict()
+    artifact = data["artifacts"][0]  # type: ignore[index]
+    data["artifacts"] = [artifact, {**artifact, "path": "other.diff.md"}]  # type: ignore[misc]
+
+    with pytest.raises(ContractError, match="duplicated"):
+        CandidatePackage.from_dict(data)
+
+
+def test_candidate_package_rejects_missing_diff_artifact_reference():
+    data = candidate_package_dict()
+    data["summary"] = {**data["summary"], "diff_artifact_id": "missing"}  # type: ignore[arg-type]
+
+    with pytest.raises(ContractError, match="diff_artifact_id"):
+        CandidatePackage.from_dict(data)
+
+
+def test_candidate_package_accepts_absent_artifacts_for_legacy_packages():
+    data = candidate_package_dict()
+    data.pop("artifacts")
+
+    package = CandidatePackage.from_dict(data)
+
+    assert package.artifacts == []
+
+
+def test_candidate_package_accepts_artifact_without_size_bytes():
+    data = candidate_package_dict()
+    artifact = dict(data["artifacts"][0])  # type: ignore[index]
+    artifact.pop("size_bytes")
+    data["artifacts"] = [artifact]
+
+    package = CandidatePackage.from_dict(data)
+
+    assert package.artifacts[0].size_bytes is None
+    assert "size_bytes" not in package.to_dict()["artifacts"][0]
+
+
+@pytest.mark.parametrize("artifacts", ["", 0, False, None])
+def test_candidate_package_rejects_malformed_artifacts_field(artifacts):
+    data = candidate_package_dict()
+    data["artifacts"] = artifacts
+
+    with pytest.raises(ContractError, match="artifacts must be a list"):
+        CandidatePackage.from_dict(data)
 
 
 def test_candidate_package_rejects_mismatched_template_id():

--- a/tests/test_gitmoot_package.py
+++ b/tests/test_gitmoot_package.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import pytest
+
+from gitmoot_skillopt.artifacts import content_hash
+from gitmoot_skillopt.contracts import (
+    CANDIDATE_PACKAGE_KIND,
+    CONTRACT_VERSION,
+    TRAINING_PACKAGE_KIND,
+    CandidatePackage,
+    ContractError,
+    TrainingPackage,
+)
+
+
+def template_content(template_id: str = "planner", name: str = "Planner") -> str:
+    return f"""---
+id: {template_id}
+name: {name}
+description: Plans work.
+kind: agent-template
+version: 1
+capabilities:
+  - ask
+runtime_compatibility:
+  - codex
+tags:
+  - planning
+inputs:
+  - request
+outputs:
+  - plan
+---
+# {name}
+
+Plan carefully.
+"""
+
+
+def metadata(template_id: str = "planner", name: str = "Planner") -> dict[str, object]:
+    return {
+        "id": template_id,
+        "name": name,
+        "description": "Plans work.",
+        "kind": "agent-template",
+        "version": 1,
+        "capabilities": ["ask"],
+        "runtime_compatibility": ["codex"],
+        "tags": ["planning"],
+        "inputs": ["request"],
+        "outputs": ["plan"],
+    }
+
+
+def training_package_dict() -> dict[str, object]:
+    content = template_content()
+    return {
+        "kind": TRAINING_PACKAGE_KIND,
+        "contract_version": CONTRACT_VERSION,
+        "template": {
+            "id": "planner",
+            "version_id": "planner@v1",
+            "version_number": 1,
+            "version_state": "current",
+            "content_hash": content_hash(content.encode()),
+            "source_repo": "jerryfane/gitmoot",
+            "source_ref": "main",
+            "source_path": "skills/gitmoot/agent-templates/planner.md",
+            "resolved_commit": "abc123",
+            "metadata": metadata(),
+            "content": content,
+        },
+        "eval_run": {
+            "id": "run-1",
+            "template_id": "planner",
+            "template_version_id": "planner@v1",
+            "target_repo": "owner/repo",
+            "state": "completed",
+            "metadata": {"metric": "preference"},
+        },
+        "items": [
+            {
+                "id": "item-1",
+                "title": "Item 1",
+                "baseline_artifact_id": "baseline",
+                "candidate_artifact_id": "candidate",
+                "metadata": {"difficulty": "easy"},
+            }
+        ],
+        "artifacts": [
+            {
+                "id": "baseline",
+                "hash": "sha256:" + "2" * 64,
+                "media_type": "text/markdown",
+                "size_bytes": 8,
+                "driver": "text",
+            },
+            {
+                "id": "candidate",
+                "hash": "3" * 64,
+                "media_type": "text/markdown",
+                "size_bytes": 9,
+                "driver": "text",
+            },
+        ],
+        "feedback_events": [
+            {
+                "run_id": "run-1",
+                "item_id": "item-1",
+                "choice": "b",
+                "reasoning": "More concrete.",
+                "reviewer": "alice",
+                "source": "markdown",
+                "source_url": "",
+                "created_at": "2026-05-31T00:00:00Z",
+            }
+        ],
+        "evaluator_config": {"mode": "pairwise"},
+    }
+
+
+def candidate_package_dict() -> dict[str, object]:
+    return {
+        "kind": CANDIDATE_PACKAGE_KIND,
+        "contract_version": CONTRACT_VERSION,
+        "template_id": "planner",
+        "base_version_id": "planner@v1",
+        "candidate": {
+            "content": template_content(),
+            "metadata": metadata(),
+        },
+        "eval_report": {"score": 0.8},
+        "summary": {
+            "diff_artifact_id": "diff",
+            "score": 0.8,
+            "preference_summary": "More actionable.",
+            "metadata": {"items": 3},
+        },
+    }
+
+
+def test_training_package_loads_and_round_trips(tmp_path):
+    package_path = tmp_path / "training.json"
+    package = TrainingPackage.from_dict(training_package_dict())
+    package.dump(package_path)
+
+    loaded = TrainingPackage.load(package_path)
+
+    assert loaded.to_dict() == package.to_dict()
+    assert loaded.artifacts[1].hash == "sha256:" + "3" * 64
+
+
+def test_training_package_rejects_wrong_kind():
+    data = training_package_dict()
+    data["kind"] = "wrong"
+
+    with pytest.raises(ContractError, match="kind must be"):
+        TrainingPackage.from_dict(data)
+
+
+def test_training_package_rejects_boolean_contract_version():
+    data = training_package_dict()
+    data["contract_version"] = True
+
+    with pytest.raises(ContractError, match="contract_version must be an integer"):
+        TrainingPackage.from_dict(data)
+
+
+def test_training_package_rejects_boolean_size():
+    data = training_package_dict()
+    artifacts = list(data["artifacts"])  # type: ignore[arg-type]
+    artifacts[0] = {**artifacts[0], "size_bytes": True}  # type: ignore[index]
+    data["artifacts"] = artifacts
+
+    with pytest.raises(ContractError, match="artifact.size_bytes must be an integer"):
+        TrainingPackage.from_dict(data)
+
+
+def test_training_package_rejects_missing_artifact_reference():
+    data = training_package_dict()
+    data["artifacts"] = []
+
+    with pytest.raises(ContractError, match="references missing artifact"):
+        TrainingPackage.from_dict(data)
+
+
+def test_training_package_rejects_bad_hash():
+    data = training_package_dict()
+    artifacts = list(data["artifacts"])  # type: ignore[arg-type]
+    artifacts[0] = {**artifacts[0], "hash": "sha256:not-hex"}  # type: ignore[index]
+    data["artifacts"] = artifacts
+
+    with pytest.raises(ValueError, match="artifact hash"):
+        TrainingPackage.from_dict(data)
+
+
+def test_training_package_rejects_template_content_hash_mismatch():
+    data = training_package_dict()
+    data["template"] = {**data["template"], "content_hash": "sha256:" + "1" * 64}  # type: ignore[arg-type]
+
+    with pytest.raises(ContractError, match="content_hash mismatch"):
+        TrainingPackage.from_dict(data)
+
+
+def test_candidate_package_validates_content_metadata_consistency():
+    package = CandidatePackage.from_dict(candidate_package_dict())
+
+    assert package.template_id == "planner"
+    assert package.to_dict()["candidate"]["metadata"] == metadata()
+
+
+def test_candidate_package_rejects_mismatched_template_id():
+    data = candidate_package_dict()
+    data["template_id"] = "reviewer"
+
+    with pytest.raises(ContractError, match="does not match package template_id"):
+        CandidatePackage.from_dict(data)
+
+
+def test_candidate_package_rejects_mismatched_metadata():
+    data = candidate_package_dict()
+    candidate = dict(data["candidate"])  # type: ignore[arg-type]
+    candidate["metadata"] = {**metadata(), "name": "Different"}
+    data["candidate"] = candidate
+
+    with pytest.raises(ContractError, match="metadata does not match"):
+        CandidatePackage.from_dict(data)
+
+
+def test_candidate_package_rejects_incomplete_frontmatter():
+    data = candidate_package_dict()
+    data["candidate"] = {
+        "content": "---\nid: planner\n---\n# Planner\n",
+        "metadata": {"id": "planner"},
+    }
+
+    with pytest.raises(ContractError, match="template frontmatter missing name"):
+        CandidatePackage.from_dict(data)
+
+
+@pytest.mark.parametrize(
+    ("content", "metadata_value"),
+    [
+        (template_content().replace("  - ask\n", "  - ask\n  - 123\n"), ["ask", 123]),
+        (template_content().replace("  - ask\n", "  - ask\n  - ''\n"), ["ask", ""]),
+    ],
+)
+def test_candidate_package_rejects_invalid_metadata_list_items(content, metadata_value):
+    data = candidate_package_dict()
+    candidate = dict(data["candidate"])  # type: ignore[arg-type]
+    candidate["content"] = content
+    candidate["metadata"] = {**metadata(), "capabilities": metadata_value}
+    data["candidate"] = candidate
+
+    with pytest.raises(ContractError, match="capabilities must contain strings"):
+        CandidatePackage.from_dict(data)
+
+
+def test_candidate_package_rejects_invalid_evaluation_metadata():
+    data = candidate_package_dict()
+    content = template_content().replace("outputs:\n  - plan\n", "outputs:\n  - plan\nevaluation:\n  metric: 123\n")
+    candidate = dict(data["candidate"])  # type: ignore[arg-type]
+    candidate["content"] = content
+    candidate["metadata"] = {**metadata(), "evaluation": {"metric": 123}}
+    data["candidate"] = candidate
+
+    with pytest.raises(ContractError, match="metadata does not match|evaluation"):
+        CandidatePackage.from_dict(data)
+
+
+def test_candidate_package_rejects_boolean_summary_score():
+    data = candidate_package_dict()
+    summary = dict(data["summary"])  # type: ignore[arg-type]
+    summary["score"] = True
+    data["summary"] = summary
+
+    with pytest.raises(ContractError, match="summary.score must be numeric"):
+        CandidatePackage.from_dict(data)


### PR DESCRIPTION
## Summary
- accept Gitmoot's --artifact-dir optimize argument and write candidate artifacts there
- keep the old OUT_ROOT/artifacts default when --artifact-dir is omitted
- scope candidate artifact ids by eval run id so imports do not collide in the shared Gitmoot artifact table

## Tests
- /root/gitmoot-skillopt/.venv/bin/python -m pytest tests/test_gitmoot_optimize_cli.py tests/test_gitmoot_examples.py -q
- git diff --check