### PR TITLE
docs: align benchmark guide and template with dataloader.py naming

### DIFF
--- a/docs/guide/new-benchmark.md
+++ b/docs/guide/new-benchmark.md
@@ -36,7 +36,7 @@ touch skillopt/envs/docfaithful/__init__.py
 
 ## Step 2 — Implement the data loader
 
-`skillopt/envs/docfaithful/loader.py`:
+`skillopt/envs/docfaithful/dataloader.py`:
 
 ```python
 from __future__ import annotations
@@ -165,7 +165,7 @@ import os
 
 from skillopt.datasets.base import BatchSpec
 from skillopt.envs.base import EnvAdapter
-from skillopt.envs.docfaithful.loader import DocFaithfulDataLoader
+from skillopt.envs.docfaithful.dataloader import DocFaithfulDataLoader
 from skillopt.envs.docfaithful.rollout import run_batch
 from skillopt.gradient.reflect import run_minibatch_reflect
 

--- a/skillopt/envs/_template/README.md
+++ b/skillopt/envs/_template/README.md
@@ -21,14 +21,14 @@ This directory provides scaffold files for adding a new benchmark to SkillOpt.
    ```bash
    cd skillopt/envs/your_benchmark
    mv env_template.py    adapter.py
-   mv loader_template.py loader.py
+   mv loader_template.py dataloader.py
    ```
    …and inside each file rename the classes
    (`TemplateBenchmarkEnv → YourBenchmarkAdapter`,
    `TemplateBenchmarkLoader → YourBenchmarkLoader`)
    and fix the cross-import in `adapter.py`.
 3. **Implement the TODO blocks** inside `adapter.py:rollout` and the
-   `_normalize_item` helper in `loader.py`. If you want real reflection,
+   `_normalize_item` helper in `dataloader.py`. If you want real reflection,
    uncomment the `run_minibatch_reflect` block in `adapter.py:reflect`.
 4. **Register** the adapter — add a `try / except ImportError` block in
    `scripts/train.py`'s `_register_builtins()` mapping the registry key


### PR DESCRIPTION
## Summary

The "Add a New Benchmark" guide (`docs/guide/new-benchmark.md`) and the env
template README (`skillopt/envs/_template/README.md`) refer to the data-loader
file as `loader.py`, but all six built-in benchmarks name it `dataloader.py`
(`skillopt/envs/<name>/dataloader.py`). This aligns the docs with the actual
convention so a new contributor following the guide produces a filename
consistent with the existing benchmarks.

Note the template was even internally inconsistent: the docstring in
`skillopt/envs/_template/loader_template.py` already points to
`skillopt/envs/officeqa/dataloader.py`, while `_template/README.md` told you to
rename the file to `loader.py`.

## Changes (docs only, no code changes)

- `docs/guide/new-benchmark.md`: Step 2 file path and the adapter import now use `dataloader.py`.
- `skillopt/envs/_template/README.md`: the rename step (`mv loader_template.py dataloader.py`) and the TODO reference now use `dataloader.py`.
