### PR TITLE
feat(sleep): add OpenCode integration and backend

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,9 +1,10 @@
 # Publishing SkillOpt-Sleep — how people install and use it
 
 This is the open-source SkillOpt-Sleep tool: a nightly offline "sleep cycle" for
-local coding agents, shipped as plugins for **Claude Code**, **Codex**, and
-**Copilot**. One engine ([`skillopt_sleep/`](skillopt_sleep)), three thin shells
-([`plugins/`](plugins)), decoupled from the research code.
+local coding agents, shipped as plugins for **Claude Code**, **Codex**,
+**Copilot**, and **OpenCode**. One engine
+([`skillopt_sleep/`](skillopt_sleep)), four thin shells ([`plugins/`](plugins)),
+decoupled from the research code.
 
 ## How end users install it
 
@@ -41,8 +42,17 @@ git clone https://github.com/microsoft/SkillOpt.git
 # the clone. Then ask Copilot to "run the sleep cycle".
 ```
 
-Requirements for all three: Python ≥ 3.10, and the corresponding agent CLI on
-PATH. The default backend is `mock` (no API spend); `--backend claude|codex`
+### OpenCode
+
+```bash
+git clone https://github.com/microsoft/SkillOpt.git
+cd SkillOpt
+bash plugins/opencode/install.sh          # installs /sleep, skill, and MCP server
+# then restart OpenCode and run:  /sleep status
+```
+
+Requirements for all four: Python >= 3.10, and the corresponding agent CLI on
+PATH. The default backend is `mock` (no API spend); `--backend claude|codex|opencode`
 uses the user's own budget.
 
 ## Wider distribution (optional, maintainer steps)
@@ -50,7 +60,7 @@ uses the user's own budget.
 1. **GitHub Release.** Tag the milestone so users can pin a version:
    ```bash
    gh release create sleep-v0.1.0 --title "SkillOpt-Sleep v0.1.0" \
-     --notes "Nightly offline self-evolution plugins for Claude Code, Codex, Copilot."
+      --notes "Nightly offline self-evolution plugins for Claude Code, Codex, Copilot, OpenCode."
    ```
 
 2. **Official Claude Code plugin marketplace.** To appear in the public

--- a/README.md
+++ b/README.md
@@ -72,13 +72,14 @@ harvest session transcripts → mine recurring tasks → replay offline
    → stage proposal → (you) adopt
 ```
 
-**Plugins for three agents** (one engine, three thin shells — see [`plugins/`](plugins/)):
+**Plugins for four agents** (one engine, four thin shells - see [`plugins/`](plugins/)):
 
 | Platform | Folder | Install |
 |---|---|---|
 | **Claude Code** | [`plugins/claude-code`](plugins/claude-code) | `/plugin marketplace add ./plugins/claude-code` → `/sleep` |
 | **Codex** | [`plugins/codex`](plugins/codex) | `bash plugins/codex/install.sh` → `/sleep` |
 | **Copilot** | [`plugins/copilot`](plugins/copilot) | register `plugins/copilot/mcp_server.py` as an MCP server |
+| **OpenCode** | [`plugins/opencode`](plugins/opencode) | `bash plugins/opencode/install.sh` → `/sleep` + MCP tools |
 
 **Validated on real models.** On the public
 [gbrain-evals](https://github.com/garrytan/gbrain-evals) `skillopt-v1` benchmark,

--- a/docs/sleep/PR_DRAFT.md
+++ b/docs/sleep/PR_DRAFT.md
@@ -1,5 +1,5 @@
 TITLE:
-Add SkillOpt-Sleep: nightly offline self-evolution plugins (Claude Code, Codex, Copilot)
+Add SkillOpt-Sleep: nightly offline self-evolution plugins (Claude Code, Codex, Copilot, OpenCode)
 
 BODY:
 ## Summary
@@ -12,11 +12,12 @@ Synthesizes SkillOpt (validation-gated bounded text edits), Claude Dreams
 (offline consolidation; review-then-adopt), and the agent-sleep idea
 (short-term experience -> long-term competence).
 
-Shipped as plugins for **three agents**, one engine + three thin shells:
+Shipped as plugins for **four agents**, one engine + four thin shells:
 
 - **Claude Code** — `.claude-plugin` + `/sleep` command + skill + hooks
 - **Codex** — `~/.codex/prompts/sleep.md` + `~/.agents/skills` + `install.sh`
 - **Copilot** — a stdlib-only MCP server exposing `sleep_*` tools
+- **OpenCode** — `/sleep` command + skill + MCP server with native SQLite transcript mining
 
 ## Design notes
 
@@ -40,14 +41,15 @@ and `docs/sleep/plugin_load_test.md`.
 
 ## Tests
 
-- 29 deterministic unit tests (`tests/test_sleep_engine.py`), no API key required.
+- 30 deterministic unit tests (`tests/test_sleep_engine.py`), no API key required.
 - `python -m skillopt_sleep.experiments.run_experiment --persona researcher --assert-improves`
   proves held-out lift and that the gate blocks a harmful edit.
 
 ## Test plan
 
-- [ ] `python -m unittest tests.test_sleep_engine` (29 pass)
+- [ ] `python -m unittest tests.test_sleep_engine` (30 pass)
 - [ ] `python -m skillopt_sleep.experiments.run_experiment --persona researcher --assert-improves`
 - [ ] Claude Code: `/plugin marketplace add ./plugins/claude-code` -> `/sleep status`
 - [ ] Codex: `bash plugins/codex/install.sh`
 - [ ] Copilot: MCP server `tools/list` returns the `sleep_*` tools
+- [ ] OpenCode: `bash plugins/opencode/install.sh` then `/sleep status`

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,6 +1,6 @@
-# SkillOpt-Sleep — plugins for Claude Code, Codex, and Copilot
+# SkillOpt-Sleep — plugins for Claude Code, Codex, Copilot, and OpenCode
 
-One engine, three thin shells. **SkillOpt-Sleep** gives a local coding agent a
+One engine, four thin shells. **SkillOpt-Sleep** gives a local coding agent a
 nightly **sleep cycle**: it reviews your past sessions offline, replays your
 recurring tasks on your own API budget, and consolidates what it learns into
 **validated** long-term memory and skills — behind a held-out gate, staged for
@@ -17,15 +17,16 @@ literature (short-term experience → long-term competence).
 > **zero dependency** on the paper's `skillopt/` experiment package (the
 > validation gate is vendored). You can ship/use it without the research stack.
 
-## The three integrations
+## The integrations
 
 | Platform | Folder | Mechanism | Status |
 |---|---|---|---|
 | **Claude Code** | [`claude-code/`](claude-code) | `.claude-plugin` + `/sleep` command + skill + hooks | full, installable |
 | **Codex** | [`codex/`](codex) | `~/.codex/prompts/sleep.md` + `~/.agents/skills` + `AGENTS.md` | full |
 | **Copilot** | [`copilot/`](copilot) | MCP server (`sleep_*` tools) + `copilot-instructions` | full (MCP) |
+| **OpenCode** | [`opencode/`](opencode) | `/sleep` command + skill + MCP server (`sleep_*` tools) | full, native SQLite transcript mining |
 
-All three call the **same** [`plugins/run-sleep.sh`](run-sleep.sh) → `python -m
+All integrations call the **same** [`plugins/run-sleep.sh`](run-sleep.sh) → `python -m
 skillopt_sleep`, so behaviour is identical everywhere. Per-platform setup is in
 each folder's README.
 
@@ -40,11 +41,12 @@ git clone <repo-url> && cd SkillOpt-Sleep
 ```
 Codex: `bash plugins/codex/install.sh`.
 Copilot: register `plugins/copilot/mcp_server.py` as an MCP server.
+OpenCode: `bash plugins/opencode/install.sh`.
 
 ## What one "night" does
 
 ```
-harvest ~/.claude (or session) transcripts → mine recurring tasks → replay offline
+harvest Claude/OpenCode transcripts → mine recurring tasks → replay offline
    → consolidate (reflect → bounded edit → GATE on real held-out tasks)
    → stage proposal → (you) adopt
 ```

--- a/plugins/copilot/README.md
+++ b/plugins/copilot/README.md
@@ -45,8 +45,8 @@ Ask Copilot things like *"run the sleep cycle"*, *"what did the last sleep
 propose?"*, *"adopt the staged sleep proposal"*. Copilot calls the MCP tools:
 `sleep_status`, `sleep_dry_run`, `sleep_run`, `sleep_adopt`, `sleep_harvest`.
 
-Each tool takes optional `project`, `backend` (`mock`/`claude`/`codex`), and
-`scope` arguments. Default backend is `mock` (no API spend).
+Each tool takes optional `project`, `backend` (`mock`/`claude`/`codex`/`opencode`),
+`model`, `source`, and `scope` arguments. Default backend is `mock` (no API spend).
 
 ## Verify the server directly (no Copilot needed)
 

--- a/plugins/copilot/mcp_server.py
+++ b/plugins/copilot/mcp_server.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 
@@ -45,8 +46,13 @@ _TOOL_SCHEMA = {
     "type": "object",
     "properties": {
         "project": {"type": "string", "description": "Project dir to evolve (default: cwd)."},
-        "backend": {"type": "string", "enum": ["mock", "claude", "codex"],
-                     "description": "mock = no API spend (default); claude/codex = real."},
+        "backend": {"type": "string", "enum": ["mock", "claude", "codex", "opencode"],
+                     "description": "mock = no API spend (default); claude/codex/opencode = real."},
+        "model": {"type": "string", "description": "Backend-specific model override."},
+        "source": {"type": "string", "enum": ["claude", "opencode"],
+                    "description": "Transcript source to harvest."},
+        "opencode_db": {"type": "string", "description": "Override path to opencode.db."},
+        "opencode_path": {"type": "string", "description": "Override path to the OpenCode CLI binary."},
         "scope": {"type": "string", "enum": ["invoked", "all"]},
     },
     "additionalProperties": False,
@@ -54,12 +60,20 @@ _TOOL_SCHEMA = {
 
 
 def _run_engine(action: str, args: dict) -> str:
-    py = sys.executable or "python3"
+    py = _python_executable()
     cmd = [py, "-m", "skillopt_sleep", action]
     if args.get("project"):
         cmd += ["--project", str(args["project"])]
     if args.get("backend"):
         cmd += ["--backend", str(args["backend"])]
+    if args.get("model"):
+        cmd += ["--model", str(args["model"])]
+    if args.get("source"):
+        cmd += ["--source", str(args["source"])]
+    if args.get("opencode_db"):
+        cmd += ["--opencode-db", str(args["opencode_db"])]
+    if args.get("opencode_path"):
+        cmd += ["--opencode-path", str(args["opencode_path"])]
     if args.get("scope"):
         cmd += ["--scope", str(args["scope"])]
     try:
@@ -69,6 +83,30 @@ def _run_engine(action: str, args: dict) -> str:
     out = (proc.stdout or "").strip()
     err = (proc.stderr or "").strip()
     return out + (("\n[stderr]\n" + err) if err else "")
+
+
+def _python_executable() -> str:
+    candidates = [sys.executable, "python3.12", "python3.11", "python3.10", "python3"]
+    seen = set()
+    for cand in candidates:
+        if not cand or cand in seen:
+            continue
+        seen.add(cand)
+        exe = cand if os.path.isabs(cand) else shutil.which(cand)
+        if not exe:
+            continue
+        try:
+            proc = subprocess.run(
+                [exe, "-c", "import sys; print('%d%d' % sys.version_info[:2])"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except Exception:
+            continue
+        if proc.returncode == 0 and int((proc.stdout or "0").strip() or "0") >= 310:
+            return exe
+    return sys.executable or "python3"
 
 
 def _result(id_, result):

--- a/plugins/opencode/README.md
+++ b/plugins/opencode/README.md
@@ -1,0 +1,82 @@
+# SkillOpt-Sleep - OpenCode integration
+
+Give **OpenCode** access to the SkillOpt-Sleep cycle through two OpenCode-native surfaces:
+
+| Surface | Purpose |
+|---|---|
+| `/sleep` command | Guided command for `status`, `dry-run`, `run`, `adopt`, and `harvest` |
+| `skillopt-sleep` skill | Teaches OpenCode when and how to use the sleep cycle |
+| MCP server | Exposes `sleep_status`, `sleep_dry_run`, `sleep_run`, `sleep_adopt`, and `sleep_harvest` tools |
+
+All three call the same shared engine used by the Claude Code, Codex, and Copilot integrations: `plugins/run-sleep.sh` -> `python -m skillopt_sleep`.
+
+## Install
+
+Requires Python >= 3.10 and OpenCode.
+
+```bash
+git clone https://github.com/microsoft/SkillOpt.git
+cd SkillOpt
+bash plugins/opencode/install.sh
+```
+
+The installer writes:
+
+| File | Purpose |
+|---|---|
+| `~/.config/opencode/commands/sleep.md` | Adds `/sleep` |
+| `~/.config/opencode/skills/skillopt-sleep/SKILL.md` | Adds the project skill |
+| `~/.config/opencode/opencode.json` | Adds the `skillopt-sleep` MCP server when the file is absent or parseable JSON |
+
+If your global OpenCode config is JSONC with comments, the installer leaves it untouched and prints a snippet to merge manually.
+
+Restart OpenCode after installation. OpenCode loads config, skills, commands, and MCP servers only at startup.
+
+## Use
+
+```text
+/sleep status      # show nights so far and the latest staged proposal
+/sleep dry-run     # preview a sleep cycle without staging anything
+/sleep run         # full cycle, stages a reviewed proposal
+/sleep adopt       # apply the staged proposal, with backup
+/sleep harvest     # show mined recurring tasks
+```
+
+Use a real backend when you want model-backed replay and reflection:
+
+```text
+/sleep run --backend opencode
+/sleep run --backend claude
+/sleep run --backend codex
+```
+
+Default backend is `mock`, which is deterministic and spends no API budget. `--backend opencode` mines OpenCode sessions and uses `opencode run` for model-backed replay, judging, mining, and reflection. Use `--model provider/model-id` to force a specific OpenCode model.
+
+The OpenCode backend runs in an isolated temporary config/data/cache directory. It copies your OpenCode auth file into that temp data directory so provider credentials work, but replay sessions do not get written into your real `~/.local/share/opencode/opencode.db`.
+
+## Manual MCP config
+
+If you prefer to configure MCP yourself, add this to your OpenCode config and replace `/abs/path/SkillOpt`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "skillopt-sleep": {
+      "type": "local",
+      "command": ["python3", "/abs/path/SkillOpt/plugins/copilot/mcp_server.py"],
+      "environment": { "SKILLOPT_SLEEP_REPO": "/abs/path/SkillOpt" },
+      "enabled": true,
+      "timeout": 3600000
+    }
+  }
+}
+```
+
+## Transcript mining
+
+OpenCode sessions are mined directly from `~/.local/share/opencode/opencode.db` via read-only SQLite access. The harvester reads session metadata, message roles, text parts, tool parts, and file path-like tool inputs, then converts them into the same training records used by the rest of SkillOpt-Sleep.
+
+If your database lives elsewhere, use the MCP `opencode_db` argument or the shell fallback with `--opencode-db /path/to/opencode.db`.
+
+If the OpenCode binary is not on `PATH`, use the MCP `opencode_path` argument, shell `--opencode-path /path/to/opencode`, or `SKILLOPT_SLEEP_OPENCODE_PATH`.

--- a/plugins/opencode/commands/sleep.md.in
+++ b/plugins/opencode/commands/sleep.md.in
@@ -1,0 +1,34 @@
+---
+description: Run SkillOpt-Sleep for this project
+agent: build
+---
+
+Use the `skillopt-sleep` skill to handle this request.
+
+User arguments: $ARGUMENTS
+
+Interpret the first argument as the action:
+
+- Empty or `status`: show current SkillOpt-Sleep state.
+- `dry-run`: preview a cycle without staging a proposal.
+- `run`: run a full cycle and stage a reviewed proposal.
+- `adopt`: apply the latest staged proposal, with backup.
+- `harvest`: list mined recurring tasks for debugging.
+
+If the `skillopt-sleep` MCP tools are available, prefer them:
+
+- `sleep_status` for `status`
+- `sleep_dry_run` for `dry-run`
+- `sleep_run` for `run`
+- `sleep_adopt` for `adopt`
+- `sleep_harvest` for `harvest`
+
+Always pass the current workspace path as `project` and `source: "opencode"`. If the user includes `--backend opencode`, `--backend claude`, `--backend codex`, or `--backend mock`, pass that backend through. If the user asks for real/model-backed learning in OpenCode, use `backend: "opencode"`. If the user provides `--model provider/model-id`, pass it as `model`. Otherwise use the tool default.
+
+If MCP tools are unavailable, run the shared shell runner from this installed SkillOpt repo:
+
+```bash
+SKILLOPT_SLEEP_REPO="@REPO_ROOT@" bash "@REPO_ROOT@/plugins/run-sleep.sh" <action> --source opencode --project "$(pwd)" [--backend <mock|opencode|claude|codex>]
+```
+
+Report the held-out baseline -> candidate score and staged proposal path when present. Do not adopt a staged proposal unless the user explicitly requested `adopt`.

--- a/plugins/opencode/install.sh
+++ b/plugins/opencode/install.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Install the SkillOpt-Sleep OpenCode integration into ~/.config/opencode.
+# Idempotent; preserves existing config when it cannot safely merge JSON.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OPENCODE_HOME="${OPENCODE_HOME:-$HOME/.config/opencode}"
+COMMANDS_DIR="$OPENCODE_HOME/commands"
+SKILLS_DIR="$OPENCODE_HOME/skills/skillopt-sleep"
+CONFIG_PATH="$OPENCODE_HOME/opencode.json"
+
+echo "[install] repo: $REPO_ROOT"
+echo "[install] opencode home: $OPENCODE_HOME"
+
+mkdir -p "$COMMANDS_DIR" "$SKILLS_DIR"
+
+python3 - "$REPO_ROOT" "$COMMANDS_DIR/sleep.md" <<'PY'
+from __future__ import annotations
+
+import pathlib
+import sys
+
+repo = pathlib.Path(sys.argv[1])
+out = pathlib.Path(sys.argv[2])
+template = (repo / "plugins" / "opencode" / "commands" / "sleep.md.in").read_text()
+out.write_text(template.replace("@REPO_ROOT@", str(repo)), encoding="utf-8")
+PY
+echo "[install] /sleep command -> $COMMANDS_DIR/sleep.md"
+
+cp "$REPO_ROOT/plugins/opencode/skills/skillopt-sleep/SKILL.md" "$SKILLS_DIR/SKILL.md"
+echo "[install] skill          -> $SKILLS_DIR/SKILL.md"
+
+python3 - "$CONFIG_PATH" "$REPO_ROOT" <<'PY'
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+repo = pathlib.Path(sys.argv[2])
+server = {
+    "type": "local",
+    "command": ["python3", str(repo / "plugins" / "copilot" / "mcp_server.py")],
+    "environment": {"SKILLOPT_SLEEP_REPO": str(repo)},
+    "enabled": True,
+    "timeout": 3600000,
+}
+
+created = False
+try:
+    if path.exists():
+        data = json.loads(path.read_text(encoding="utf-8"))
+    else:
+        data = {"$schema": "https://opencode.ai/config.json"}
+        created = True
+except Exception as exc:
+    print(f"[install] skipped MCP config merge: {path} is not plain JSON ({exc})")
+    print("[install] add this snippet manually:")
+    print(json.dumps({"mcp": {"skillopt-sleep": server}}, indent=2))
+    raise SystemExit(0)
+
+if not isinstance(data, dict):
+    print(f"[install] skipped MCP config merge: {path} does not contain a JSON object")
+    raise SystemExit(0)
+
+data.setdefault("$schema", "https://opencode.ai/config.json")
+mcp = data.setdefault("mcp", {})
+if not isinstance(mcp, dict):
+    print(f"[install] skipped MCP config merge: existing 'mcp' is not an object in {path}")
+    raise SystemExit(0)
+mcp["skillopt-sleep"] = server
+
+path.parent.mkdir(parents=True, exist_ok=True)
+if path.exists() and not created:
+    backup = path.with_suffix(path.suffix + ".bak")
+    backup.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
+    print(f"[install] backup config -> {backup}")
+path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+print(f"[install] MCP server    -> {path}")
+PY
+
+cat <<EOF
+
+[install] Optional shell profile line:
+    export SKILLOPT_SLEEP_REPO="$REPO_ROOT"
+
+Done. Restart OpenCode, then try:
+    /sleep status
+EOF

--- a/plugins/opencode/skills/skillopt-sleep/SKILL.md
+++ b/plugins/opencode/skills/skillopt-sleep/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: skillopt-sleep
+description: OpenCode integration for SkillOpt-Sleep. Use when the user asks OpenCode to run a sleep/dream cycle, learn from past sessions, inspect staged sleep proposals, or adopt validated memory/skill updates.
+---
+
+# SkillOpt-Sleep (OpenCode skill)
+
+This skill drives the `skillopt_sleep` engine from OpenCode. A sleep cycle reviews past sessions, mines recurring tasks, replays them offline, proposes bounded memory/skill edits, validates them behind a held-out gate, and stages the result for review.
+
+## When to use
+
+Use this skill when the user asks to:
+
+- run `/sleep`, `sleep`, or a `dream` cycle
+- inspect SkillOpt-Sleep status
+- preview a sleep cycle without changes
+- stage validated long-term memory or skill updates
+- adopt a staged SkillOpt-Sleep proposal
+
+## Preferred OpenCode path
+
+Use the MCP tools when the `skillopt-sleep` MCP server is configured:
+
+| User intent | MCP tool |
+|---|---|
+| status | `sleep_status` |
+| dry run / preview | `sleep_dry_run` |
+| full cycle / stage proposal | `sleep_run` |
+| adopt proposal | `sleep_adopt` |
+| harvest debug | `sleep_harvest` |
+
+Pass the current workspace path as `project` and `source: "opencode"`. Use `backend: "mock"` unless the user requests real/model-backed learning. For real OpenCode-backed learning, pass `backend: "opencode"`. Also pass through explicit `claude` or `codex` backend requests, and pass `model` when the user names a specific model.
+
+## Shell fallback
+
+If MCP tools are unavailable, call the shared runner:
+
+```bash
+bash "$SKILLOPT_SLEEP_REPO/plugins/run-sleep.sh" <status|dry-run|run|adopt|harvest> --source opencode --project "$(pwd)"
+```
+
+For real OpenCode-backed learning:
+
+```bash
+bash "$SKILLOPT_SLEEP_REPO/plugins/run-sleep.sh" run --source opencode --project "$(pwd)" --backend opencode
+```
+
+If `SKILLOPT_SLEEP_REPO` is unset, use the absolute repo path from the installed `/sleep` command or ask the user to set it.
+
+## Safety rules
+
+- Default backend is `mock`, which spends no API budget.
+- `backend: "opencode"` spends the user's OpenCode-configured model budget through `opencode run`.
+- `run` stages a proposal only; it does not modify live files.
+- Only `adopt` applies a staged proposal, and it backs up first.
+- Never hand-edit the user's adopted memory or managed skill as a shortcut; use the sleep engine so the gate and backups are preserved.
+- Show the user the baseline score, candidate score, gate decision, and staged path when available.
+
+## Transcript source
+
+This integration mines native OpenCode sessions from `~/.local/share/opencode/opencode.db`. Use the MCP `opencode_db` argument or `--opencode-db /path/to/opencode.db` with the shell fallback when the database lives elsewhere.
+
+## OpenCode backend
+
+When `backend: "opencode"` is used, SkillOpt-Sleep runs replay, judge, mining, and reflection through the OpenCode CLI. It isolates each replay in a temporary OpenCode config/data/cache directory and copies OpenCode auth there, so model credentials work without writing replay sessions into the user's real OpenCode database. Use `model: "provider/model-id"` or `--model provider/model-id` when the user requests a specific model.

--- a/skillopt_sleep/__main__.py
+++ b/skillopt_sleep/__main__.py
@@ -9,8 +9,10 @@
 Common flags:
     --project PATH      project to evolve (default: cwd)
     --scope all|invoked harvest scope (default: invoked)
-    --backend mock|anthropic
+    --source claude|opencode session source to harvest
+    --backend mock|claude|codex|opencode
     --model NAME
+    --opencode-db PATH  OpenCode SQLite database override
     --lookback-hours N
     --auto-adopt
     --json              machine-readable output
@@ -26,6 +28,7 @@ from typing import Any, Dict
 from skillopt_sleep.config import load_config
 from skillopt_sleep.cycle import run_sleep_cycle
 from skillopt_sleep.harvest import harvest
+from skillopt_sleep.harvest_opencode import harvest_opencode
 from skillopt_sleep.mine import mine
 from skillopt_sleep.state import SleepState
 from skillopt_sleep.staging import latest_staging, adopt as adopt_staging
@@ -34,10 +37,13 @@ from skillopt_sleep.staging import latest_staging, adopt as adopt_staging
 def _add_common(p: argparse.ArgumentParser) -> None:
     p.add_argument("--project", default="")
     p.add_argument("--scope", default="", choices=["", "all", "invoked"])
-    p.add_argument("--backend", default="", choices=["", "mock", "claude", "codex"])
+    p.add_argument("--source", default="", choices=["", "claude", "opencode"], help="session source to harvest")
+    p.add_argument("--backend", default="", choices=["", "mock", "claude", "codex", "opencode"])
     p.add_argument("--model", default="")
     p.add_argument("--codex-path", default="", help="path to the real @openai/codex binary")
+    p.add_argument("--opencode-path", default="", help="path to the OpenCode CLI binary")
     p.add_argument("--claude-home", default="", help="override ~/.claude (also isolates state)")
+    p.add_argument("--opencode-db", default="", help="override ~/.local/share/opencode/opencode.db")
     p.add_argument("--lookback-hours", type=int, default=0)
     p.add_argument("--edit-budget", type=int, default=0)
     p.add_argument("--auto-adopt", action="store_true")
@@ -51,14 +57,20 @@ def _cfg_from_args(args) -> Any:
         overrides["projects"] = "invoked"
     if args.scope:
         overrides["projects"] = args.scope
+    if getattr(args, "source", ""):
+        overrides["transcript_source"] = args.source
     if args.backend:
         overrides["backend"] = args.backend
     if args.model:
         overrides["model"] = args.model
     if getattr(args, "codex_path", ""):
         overrides["codex_path"] = os.path.abspath(args.codex_path)
+    if getattr(args, "opencode_path", ""):
+        overrides["opencode_path"] = os.path.abspath(args.opencode_path)
     if getattr(args, "claude_home", ""):
         overrides["claude_home"] = os.path.abspath(args.claude_home)
+    if getattr(args, "opencode_db", ""):
+        overrides["opencode_db"] = os.path.abspath(args.opencode_db)
     if getattr(args, "lookback_hours", 0):
         overrides["lookback_hours"] = args.lookback_hours
     if getattr(args, "edit_budget", 0):
@@ -143,12 +155,20 @@ def cmd_adopt(args) -> int:
 
 def cmd_harvest(args) -> int:
     cfg = _cfg_from_args(args)
-    digests = harvest(
-        cfg.transcripts_dir,
-        scope=cfg.get("projects", "invoked"),
-        invoked_project=cfg.get("invoked_project", ""),
-        limit=cfg.get("max_tasks_per_night", 40) * 3,
-    )
+    if cfg.get("transcript_source", "claude") == "opencode":
+        digests = harvest_opencode(
+            cfg.opencode_db_path,
+            scope=cfg.get("projects", "invoked"),
+            invoked_project=cfg.get("invoked_project", ""),
+            limit=cfg.get("max_tasks_per_night", 40) * 3,
+        )
+    else:
+        digests = harvest(
+            cfg.transcripts_dir,
+            scope=cfg.get("projects", "invoked"),
+            invoked_project=cfg.get("invoked_project", ""),
+            limit=cfg.get("max_tasks_per_night", 40) * 3,
+        )
     tasks = mine(digests, max_tasks=cfg.get("max_tasks_per_night", 40),
                  holdout_fraction=cfg.get("holdout_fraction", 0.34), seed=cfg.get("seed", 42))
     if args.json:

--- a/skillopt_sleep/backend.py
+++ b/skillopt_sleep/backend.py
@@ -12,8 +12,7 @@ Two implementations:
                       Reads optional `reference` exact answers and a tiny
                       rule-table so the loop provably improves and the gate
                       provably blocks regressions.
-  * AnthropicBackend — uses the user's ANTHROPIC_API_KEY via the `claude`
-                       CLI or the anthropic SDK (lazy-imported). Real lift.
+  * CLI backends    — drive Claude, Codex, or OpenCode CLIs for real lift.
 
 The backend never touches live config; it only returns text/edits that the
 consolidation stage gates and stages.
@@ -23,6 +22,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import subprocess
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -254,7 +254,7 @@ def _extract_json(raw: str, kind: str):
 
 
 class CliBackend(Backend):
-    """Common logic for real CLI-driven backends (claude / codex).
+    """Common logic for real CLI-driven backends (claude / codex / opencode).
 
     Subclasses implement only ``_call(prompt) -> str``. This base owns the
     prompts (attempt / judge / reflect), JSON parsing, a response cache (so
@@ -698,6 +698,146 @@ class CodexCliBackend(CliBackend):
             except Exception:
                 pass
 
+
+def resolve_opencode_path(explicit: str = "") -> str:
+    """Find the OpenCode CLI binary."""
+    if explicit:
+        return explicit
+    env = os.environ.get("SKILLOPT_SLEEP_OPENCODE_PATH")
+    if env:
+        return env
+    return shutil.which("opencode") or "opencode"
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", text or "")
+
+
+class OpenCodeCliBackend(CliBackend):
+    """Drives OpenCode non-interactively via `opencode run`."""
+
+    name = "opencode"
+
+    def __init__(self, model: str = "", opencode_path: str = "", timeout: int = 240) -> None:
+        super().__init__(model=model or os.environ.get("SKILLOPT_SLEEP_OPENCODE_MODEL", ""), timeout=timeout)
+        self.opencode_path = resolve_opencode_path(opencode_path)
+
+    def _isolated_env(self, root: str, *, allow_bash: bool = False) -> Dict[str, str]:
+        """Isolate replay sessions while preserving OpenCode auth credentials."""
+        env = dict(os.environ)
+        config_dir = os.path.join(root, "config")
+        data_home = os.path.join(root, "data")
+        cache_home = os.path.join(root, "cache")
+        os.makedirs(config_dir, exist_ok=True)
+        os.makedirs(os.path.join(data_home, "opencode"), exist_ok=True)
+        os.makedirs(cache_home, exist_ok=True)
+
+        auth_src = os.path.expanduser("~/.local/share/opencode/auth.json")
+        auth_dst = os.path.join(data_home, "opencode", "auth.json")
+        if os.path.exists(auth_src):
+            try:
+                shutil.copy2(auth_src, auth_dst)
+            except Exception:
+                pass
+
+        env.update({
+            "OPENCODE_CONFIG_DIR": config_dir,
+            "XDG_DATA_HOME": data_home,
+            "XDG_CACHE_HOME": cache_home,
+            "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
+            "OPENCODE_DISABLE_DEFAULT_PLUGINS": "1",
+            "OPENCODE_DISABLE_CLAUDE_CODE": "1",
+            "OPENCODE_DISABLE_CLAUDE_CODE_PROMPT": "1",
+            "OPENCODE_DISABLE_CLAUDE_CODE_SKILLS": "1",
+            "OPENCODE_DISABLE_AUTOCOMPACT": "1",
+            "OPENCODE_PERMISSION": json.dumps({
+                "edit": "deny",
+                "bash": "allow" if allow_bash else "deny",
+                "webfetch": "deny",
+                "websearch": "deny",
+            }),
+        })
+        return env
+
+    def _run_opencode(self, prompt: str, workdir: str, *, allow_bash: bool = False) -> str:
+        cmd = [
+            self.opencode_path,
+            "run",
+            "--pure",
+            "--format", "default",
+            "--dir", workdir,
+            "--title", "SkillOpt-Sleep replay",
+        ]
+        if allow_bash:
+            cmd.append("--dangerously-skip-permissions")
+        if self.model:
+            cmd += ["--model", self.model]
+        cmd.append(prompt)
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+                cwd=workdir,
+                env=self._isolated_env(os.path.dirname(workdir), allow_bash=allow_bash),
+            )
+        except Exception:
+            return ""
+        return _strip_ansi(proc.stdout or "").strip()
+
+    def _call(self, prompt: str, *, max_tokens: int = 1024) -> str:
+        import tempfile
+        root = tempfile.mkdtemp(prefix="skillopt_sleep_opencode_")
+        work = os.path.join(root, "work")
+        os.makedirs(work, exist_ok=True)
+        try:
+            return self._run_opencode(prompt, work)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def attempt_with_tools(self, task, skill, memory, tools):
+        import tempfile, stat
+        root = tempfile.mkdtemp(prefix="skillopt_sleep_opencode_tools_")
+        work = os.path.join(root, "work")
+        os.makedirs(work, exist_ok=True)
+        calllog = os.path.join(work, "_tool_calls.log")
+        try:
+            for tname in (tools or ["search"]):
+                shim = os.path.join(work, tname)
+                with open(shim, "w") as f:
+                    f.write(
+                        "#!/usr/bin/env bash\n"
+                        f'echo "{tname}" >> "{calllog}"\n'
+                        'echo "(search results: 3 relevant notes found; use them to answer)"\n'
+                    )
+                os.chmod(shim, os.stat(shim).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+            tool_hint = (
+                "Shell tools are available in the working directory: "
+                + ", ".join(f"./{t}" for t in (tools or ["search"]))
+                + ". When the skill says to look something up or search before "
+                "answering, you MUST actually run the tool before giving your final answer."
+            )
+            prompt = (
+                "Complete the task. Apply the skill and memory rules EXACTLY, "
+                "including any rule about searching before answering. Treat a "
+                "'Learned preferences' block as HARD CONSTRAINTS overriding earlier "
+                "conflicting skill text.\n\n"
+                f"{tool_hint}\n\n# Skill\n{skill or '(none)'}\n\n# Memory\n{memory or '(none)'}\n\n"
+                f"# Task\n{task.intent}\n\n{task.context_excerpt}\n\nReturn ONLY the final answer."
+            )
+            resp = self._run_opencode(prompt, work, allow_bash=True)
+            self._tokens += len(prompt) // 4 + len(resp) // 4
+            called: List[str] = []
+            if os.path.exists(calllog):
+                with open(calllog) as f:
+                    logged = {ln.strip() for ln in f if ln.strip()}
+                called = [t for t in (tools or ["search"]) if t in logged]
+            return resp, called
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+
 class DualBackend(Backend):
     """Route operations to two backends, à la SkillOpt's target vs optimizer.
 
@@ -747,12 +887,15 @@ def get_backend(
     model: str = "",
     claude_path: str = "claude",
     codex_path: str = "",
+    opencode_path: str = "",
 ) -> Backend:
     n = (name or "mock").strip().lower()
     if n in {"claude", "anthropic", "claude_cli", "claude_code"}:
         return ClaudeCliBackend(model=model, claude_path=claude_path)
     if n in {"codex", "codex_cli", "openai_codex"}:
         return CodexCliBackend(model=model, codex_path=codex_path)
+    if n in {"opencode", "opencode_cli"}:
+        return OpenCodeCliBackend(model=model, opencode_path=opencode_path)
     return MockBackend()
 
 
@@ -765,6 +908,7 @@ def build_backend(
     target_backend: str = "",
     target_model: str = "",
     codex_path: str = "",
+    opencode_path: str = "",
     preferences: str = "",
 ) -> Backend:
     """Build a single or dual backend.
@@ -776,11 +920,21 @@ def build_backend(
     """
     has_split = any([optimizer_backend, optimizer_model, target_backend, target_model])
     if not has_split:
-        be = get_backend(backend, model=model, codex_path=codex_path)
+        be = get_backend(backend, model=model, codex_path=codex_path, opencode_path=opencode_path)
         be.preferences = preferences
         return be
-    tgt = get_backend(target_backend or backend, model=target_model or model, codex_path=codex_path)
-    opt = get_backend(optimizer_backend or backend, model=optimizer_model or model, codex_path=codex_path)
+    tgt = get_backend(
+        target_backend or backend,
+        model=target_model or model,
+        codex_path=codex_path,
+        opencode_path=opencode_path,
+    )
+    opt = get_backend(
+        optimizer_backend or backend,
+        model=optimizer_model or model,
+        codex_path=codex_path,
+        opencode_path=opencode_path,
+    )
     opt.preferences = preferences  # reflect runs on the optimizer
     dual = DualBackend(target=tgt, optimizer=opt)
     dual.preferences = preferences

--- a/skillopt_sleep/config.py
+++ b/skillopt_sleep/config.py
@@ -19,11 +19,14 @@ from typing import Any, Dict, List, Optional
 
 HOME_STATE_DIR = os.path.expanduser("~/.skillopt-sleep")
 CLAUDE_HOME = os.path.expanduser("~/.claude")
+OPENCODE_DB = os.path.expanduser("~/.local/share/opencode/opencode.db")
 
 
 DEFAULTS: Dict[str, Any] = {
     # ── scope ──────────────────────────────────────────────────────────────
     "claude_home": CLAUDE_HOME,
+    "opencode_db": OPENCODE_DB,
+    "transcript_source": "claude",  # "claude" | "opencode"
     "projects": "invoked",        # "invoked" | "all" | [list of abs paths]
     "invoked_project": "",        # filled at runtime (cwd) when projects == "invoked"
     "lookback_hours": 72,         # harvest window when no prior sleep recorded
@@ -34,10 +37,11 @@ DEFAULTS: Dict[str, Any] = {
     "val_fraction": 0.34,         # real tasks reserved to gate updates
     "test_fraction": 0.0,         # real tasks reserved as the final held-out measure
     # ── optimizer ──────────────────────────────────────────────────────────
-    "backend": "mock",            # "mock" | "claude" | "codex"
+    "backend": "mock",            # "mock" | "claude" | "codex" | "opencode"
     "model": "",                  # backend-specific; "" => backend default
     "gate_mode": "on",            # "on" (validation-gated) | "off" (greedy, no hard filter)
     "codex_path": "",             # "" => auto-detect the real @openai/codex binary
+    "opencode_path": "",          # "" => PATH/SKILLOPT_SLEEP_OPENCODE_PATH
     "edit_budget": 4,             # textual learning rate (max edits/night)
     "gate_metric": "mixed",       # hard | soft | mixed (mixed best for tiny holdouts)
     "gate_mixed_weight": 0.5,
@@ -93,6 +97,10 @@ class SleepConfig:
     @property
     def transcripts_dir(self) -> str:
         return os.path.join(self.data["claude_home"], "projects")
+
+    @property
+    def opencode_db_path(self) -> str:
+        return self.data.get("opencode_db", OPENCODE_DB)
 
     @property
     def history_path(self) -> str:

--- a/skillopt_sleep/cycle.py
+++ b/skillopt_sleep/cycle.py
@@ -18,6 +18,7 @@ from skillopt_sleep.backend import get_backend
 from skillopt_sleep.config import SleepConfig, load_config
 from skillopt_sleep.consolidate import consolidate
 from skillopt_sleep.harvest import harvest
+from skillopt_sleep.harvest_opencode import harvest_opencode
 from skillopt_sleep.memory import ensure_skill_scaffold
 from skillopt_sleep.mine import mine
 from skillopt_sleep.state import SleepState, _now_iso
@@ -108,6 +109,7 @@ def run_sleep_cycle(
         cfg.get("backend", "mock"),
         model=cfg.get("model", ""),
         codex_path=cfg.get("codex_path", ""),
+        opencode_path=cfg.get("opencode_path", ""),
     )
 
     # ── 1+2. harvest + mine (unless seed_tasks injected) ─────────────────
@@ -117,13 +119,22 @@ def run_sleep_cycle(
         n_sessions = 0
     else:
         since = state.last_harvest_for(project)
-        digests = harvest(
-            cfg.transcripts_dir,
-            scope=cfg.get("projects", "invoked"),
-            invoked_project=cfg.get("invoked_project", ""),
-            since_iso=since,
-            limit=cfg.get("max_tasks_per_night", 40) * 3,
-        )
+        if cfg.get("transcript_source", "claude") == "opencode":
+            digests = harvest_opencode(
+                cfg.opencode_db_path,
+                scope=cfg.get("projects", "invoked"),
+                invoked_project=cfg.get("invoked_project", ""),
+                since_iso=since,
+                limit=cfg.get("max_tasks_per_night", 40) * 3,
+            )
+        else:
+            digests = harvest(
+                cfg.transcripts_dir,
+                scope=cfg.get("projects", "invoked"),
+                invoked_project=cfg.get("invoked_project", ""),
+                since_iso=since,
+                limit=cfg.get("max_tasks_per_night", 40) * 3,
+            )
         n_sessions = len(digests)
         # When a real backend is configured, use it to mine checkable tasks from
         # the transcripts (rubric/rule judges); otherwise fall back to the

--- a/skillopt_sleep/experiments/run_experiment.py
+++ b/skillopt_sleep/experiments/run_experiment.py
@@ -51,7 +51,7 @@ def _score_holdout(backend, tasks: List[TaskRecord], skill: str, memory: str,
 
 def run(persona: str = "researcher", nights: int = 4, backend_name: str = "mock",
         edit_budget: int = 4, seed: int = 42, model: str = "", codex_path: str = "",
-        limit_tasks: int = 0) -> dict:
+        opencode_path: str = "", limit_tasks: int = 0) -> dict:
     from skillopt_sleep.mine import assign_splits
 
     make = PERSONAS.get(persona, researcher_persona)
@@ -59,7 +59,7 @@ def run(persona: str = "researcher", nights: int = 4, backend_name: str = "mock"
     if limit_tasks and limit_tasks < len(items):
         items = items[:limit_tasks]
     tasks = assign_splits(items, holdout_fraction=0.34, seed=seed)
-    backend = get_backend(backend_name, model=model, codex_path=codex_path)
+    backend = get_backend(backend_name, model=model, codex_path=codex_path, opencode_path=opencode_path)
     is_mock = (backend.name == "mock")
 
     # start from an empty managed skill + empty memory
@@ -134,9 +134,10 @@ def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description="SkillOpt-Sleep validation experiment")
     ap.add_argument("--persona", default="researcher", choices=list(PERSONAS.keys()))
     ap.add_argument("--nights", type=int, default=4)
-    ap.add_argument("--backend", default="mock", choices=["mock", "claude", "codex"])
+    ap.add_argument("--backend", default="mock", choices=["mock", "claude", "codex", "opencode"])
     ap.add_argument("--model", default="", help="backend model override")
     ap.add_argument("--codex-path", default="", help="path to the real @openai/codex binary")
+    ap.add_argument("--opencode-path", default="", help="path to the OpenCode CLI binary")
     ap.add_argument("--edit-budget", type=int, default=4)
     ap.add_argument("--limit-tasks", type=int, default=0, help="cap #tasks (control API cost)")
     ap.add_argument("--json", action="store_true")
@@ -146,7 +147,7 @@ def main(argv=None) -> int:
 
     res = run(args.persona, nights=args.nights, backend_name=args.backend,
               edit_budget=args.edit_budget, model=args.model,
-              codex_path=args.codex_path, limit_tasks=args.limit_tasks)
+              codex_path=args.codex_path, opencode_path=args.opencode_path, limit_tasks=args.limit_tasks)
 
     if args.json:
         print(json.dumps(res, ensure_ascii=False, indent=2))

--- a/skillopt_sleep/experiments/run_gbrain.py
+++ b/skillopt_sleep/experiments/run_gbrain.py
@@ -124,13 +124,14 @@ def run_seed(backend, seed: str, skill: str, tasks: List, *,
 
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description="Run gbrain-evals skillopt-v1 with SkillOpt-Sleep")
-    ap.add_argument("--backend", default="mock", choices=["mock", "claude", "codex"])
+    ap.add_argument("--backend", default="mock", choices=["mock", "claude", "codex", "opencode"])
     ap.add_argument("--model", default="")
     ap.add_argument("--optimizer-backend", default="", help="route reflect/judge here (dual)")
     ap.add_argument("--optimizer-model", default="")
     ap.add_argument("--target-backend", default="", help="route attempt here (dual)")
     ap.add_argument("--target-model", default="")
     ap.add_argument("--codex-path", default="")
+    ap.add_argument("--opencode-path", default="")
     ap.add_argument("--data-root", default="", help="path to eval/data/skillopt-v1")
     ap.add_argument("--seeds", default="", help="comma list; default = all available")
     ap.add_argument("--nights", type=int, default=3)
@@ -159,7 +160,7 @@ def main(argv=None) -> int:
         backend=args.backend, model=args.model,
         optimizer_backend=args.optimizer_backend, optimizer_model=args.optimizer_model,
         target_backend=args.target_backend, target_model=args.target_model,
-        codex_path=args.codex_path, preferences=args.preferences,
+        codex_path=args.codex_path, opencode_path=args.opencode_path, preferences=args.preferences,
     )
 
     results = []

--- a/skillopt_sleep/experiments/run_transfer.py
+++ b/skillopt_sleep/experiments/run_transfer.py
@@ -100,6 +100,7 @@ def main(argv=None) -> int:
     ap.add_argument("--target-backend", default="claude")
     ap.add_argument("--target-model", default="sonnet")
     ap.add_argument("--codex-path", default="")
+    ap.add_argument("--opencode-path", default="")
     ap.add_argument("--data-root", default="")
     ap.add_argument("--seeds", default="brief-writer")
     ap.add_argument("--nights", type=int, default=2)
@@ -115,8 +116,18 @@ def main(argv=None) -> int:
         print("ERROR: gbrain-evals skillopt-v1 data not found; pass --data-root", file=sys.stderr)
         return 2
 
-    source = get_backend(args.source_backend, model=args.source_model, codex_path=args.codex_path)
-    target = get_backend(args.target_backend, model=args.target_model, codex_path=args.codex_path)
+    source = get_backend(
+        args.source_backend,
+        model=args.source_model,
+        codex_path=args.codex_path,
+        opencode_path=args.opencode_path,
+    )
+    target = get_backend(
+        args.target_backend,
+        model=args.target_model,
+        codex_path=args.codex_path,
+        opencode_path=args.opencode_path,
+    )
 
     seeds = [s.strip() for s in args.seeds.split(",") if s.strip()] or available_seeds(data_root)
     results = []

--- a/skillopt_sleep/experiments/sweep.py
+++ b/skillopt_sleep/experiments/sweep.py
@@ -106,16 +106,32 @@ def run_one(cfg: Dict[str, Any], data_root: str, codex_path: str,
                 optimizer_backend=cfg["optimizer_backend"], optimizer_model=cfg.get("optimizer_model", ""),
                 target_backend=cfg["target_backend"], target_model=cfg.get("target_model", ""),
                 codex_path=codex_path,
+                opencode_path=cfg.get("opencode_path", ""),
             )
         else:
-            be = get_backend(cfg["backend"], model=cfg.get("model", ""), codex_path=codex_path)
+            be = get_backend(
+                cfg["backend"],
+                model=cfg.get("model", ""),
+                codex_path=codex_path,
+                opencode_path=cfg.get("opencode_path", ""),
+            )
         r = bench_seed(be, seed, skill, tasks, nights=cfg["nights"],
                        limit_replay=limit_replay, limit_holdout=limit_holdout)
         out = {"baseline": r["held_out_before"], "after": r["held_out_after"],
                "improved": r["improved"], "tokens": be.tokens_used()}
     else:
-        src = get_backend(cfg["source_backend"], model=cfg.get("source_model", ""), codex_path=codex_path)
-        tgt = get_backend(cfg["target_backend"], model=cfg.get("target_model", ""), codex_path=codex_path)
+        src = get_backend(
+            cfg["source_backend"],
+            model=cfg.get("source_model", ""),
+            codex_path=codex_path,
+            opencode_path=cfg.get("opencode_path", ""),
+        )
+        tgt = get_backend(
+            cfg["target_backend"],
+            model=cfg.get("target_model", ""),
+            codex_path=codex_path,
+            opencode_path=cfg.get("opencode_path", ""),
+        )
         r = transfer_seed(seed, skill, tasks, source=src, target=tgt, nights=cfg["nights"],
                           edit_budget=4, limit_replay=limit_replay, limit_holdout=limit_holdout,
                           do_direct=False)

--- a/skillopt_sleep/harvest.py
+++ b/skillopt_sleep/harvest.py
@@ -108,6 +108,10 @@ def _is_meta_prompt(text: str) -> bool:
         return True
     if t.startswith("[Pasted text") or t.startswith("Caveat:"):
         return True
+    if t.startswith("[Compressed conversation section]") or t.startswith("▣ DCP"):
+        return True
+    if "\n▣ DCP" in t or "\n▣ Compression #" in t:
+        return True
     return False
 
 

--- a/skillopt_sleep/harvest_opencode.py
+++ b/skillopt_sleep/harvest_opencode.py
@@ -1,0 +1,256 @@
+"""SkillOpt-Sleep - OpenCode transcript harvest.
+
+OpenCode stores conversations in ``~/.local/share/opencode/opencode.db``.
+This module reads that SQLite database in read-only mode and normalizes
+``session`` + ``message`` + ``part`` rows into :class:`SessionDigest` objects.
+It performs no writes and no network calls.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+from skillopt_sleep.harvest import _detect_feedback, _is_meta_prompt
+from skillopt_sleep.types import SessionDigest
+
+
+def _connect_readonly(path: str) -> sqlite3.Connection:
+    uri = "file:" + os.path.abspath(path) + "?mode=ro"
+    return sqlite3.connect(uri, uri=True)
+
+
+def _loads(raw: Any) -> Dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if not isinstance(raw, str):
+        return {}
+    try:
+        obj = json.loads(raw)
+    except Exception:
+        return {}
+    return obj if isinstance(obj, dict) else {}
+
+
+def _text_from_part(data: Dict[str, Any]) -> str:
+    if data.get("type") != "text":
+        return ""
+    text = data.get("text")
+    return text if isinstance(text, str) else ""
+
+
+def _tool_name_from_part(data: Dict[str, Any]) -> str:
+    if data.get("type") != "tool":
+        return ""
+    tool = data.get("tool")
+    return str(tool) if tool else ""
+
+
+def _iter_strings(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for v in value.values():
+            yield from _iter_strings(v)
+    elif isinstance(value, list):
+        for v in value:
+            yield from _iter_strings(v)
+
+
+def _looks_like_path(value: str) -> bool:
+    if not value or len(value) > 500:
+        return False
+    if value.startswith(("/", "~/", "./", "../")):
+        return True
+    return any(sep in value for sep in ("/", "\\")) and "." in os.path.basename(value)
+
+
+def _files_from_tool_part(data: Dict[str, Any]) -> List[str]:
+    if data.get("type") != "tool":
+        return []
+    state = data.get("state") if isinstance(data.get("state"), dict) else {}
+    inputs = state.get("input") if isinstance(state.get("input"), dict) else {}
+    found: List[str] = []
+    for value in _iter_strings(inputs):
+        if _looks_like_path(value):
+            found.append(value)
+    return found
+
+
+def _dedup(xs: List[str]) -> List[str]:
+    seen = set()
+    out = []
+    for x in xs:
+        if x not in seen:
+            seen.add(x)
+            out.append(x)
+    return out
+
+
+def _ms_to_iso(ms: int | None) -> str:
+    if not ms:
+        return ""
+    return datetime.fromtimestamp(ms / 1000, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _iso_to_ms(value: str | None) -> int:
+    if not value:
+        return 0
+    try:
+        normalized = value.replace("Z", "+00:00")
+        return int(datetime.fromisoformat(normalized).timestamp() * 1000)
+    except Exception:
+        return 0
+
+
+def _project_matches(project: str, scope: Any, invoked: str) -> bool:
+    if scope == "all":
+        return True
+    if isinstance(scope, (list, tuple)):
+        return any(os.path.abspath(project) == os.path.abspath(p) for p in scope)
+    if not invoked:
+        return True
+    a = os.path.abspath(project)
+    b = os.path.abspath(invoked)
+    return a == b or a.startswith(b + os.sep) or b.startswith(a + os.sep)
+
+
+def digest_opencode_session(conn: sqlite3.Connection, session_id: str) -> Optional[SessionDigest]:
+    """Build a digest from one OpenCode session id."""
+    cur = conn.execute(
+        """
+        select s.id, s.directory, s.title, s.time_created, s.time_updated,
+               s.path, s.metadata, p.worktree
+        from session s
+        left join project p on p.id = s.project_id
+        where s.id = ?
+        """,
+        (session_id,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+
+    (_sid, directory, _title, created, updated, path_raw, metadata_raw, worktree) = row
+    project = directory or worktree or ""
+    git_branch = ""
+    metadata = _loads(metadata_raw)
+    if isinstance(metadata.get("gitBranch"), str):
+        git_branch = metadata["gitBranch"]
+    path_data = _loads(path_raw)
+    if not project and isinstance(path_data.get("cwd"), str):
+        project = path_data["cwd"]
+
+    user_prompts: List[str] = []
+    assistant_finals: List[str] = []
+    tools: List[str] = []
+    files: List[str] = []
+    feedback: List[str] = []
+    n_user = 0
+    n_asst = 0
+
+    rows = conn.execute(
+        """
+        select m.id, m.data, p.data
+        from message m
+        left join part p on p.message_id = m.id
+        where m.session_id = ?
+        order by m.time_created, m.id, p.time_created, p.id
+        """,
+        (session_id,),
+    )
+    message_parts: Dict[str, Dict[str, Any]] = {}
+    for message_id, message_raw, part_raw in rows:
+        msg = _loads(message_raw)
+        mid = str(message_id or msg.get("id") or id(message_raw))
+        entry = message_parts.setdefault(mid, {"role": msg.get("role"), "texts": [], "tools": [], "files": []})
+        part = _loads(part_raw)
+        text = _text_from_part(part)
+        if text:
+            entry["texts"].append(text)
+        tool = _tool_name_from_part(part)
+        if tool:
+            entry["tools"].append(tool)
+        entry["files"].extend(_files_from_tool_part(part))
+
+    for entry in message_parts.values():
+        role = entry.get("role")
+        texts = [str(t).strip() for t in entry.get("texts", []) if str(t).strip()]
+        if role == "user":
+            usable = [t for t in texts if not _is_meta_prompt(t)]
+            if usable:
+                n_user += 1
+                joined = "\n".join(usable).strip()
+                user_prompts.append(joined)
+                feedback.extend(_detect_feedback(joined))
+        elif role == "assistant":
+            n_asst += 1
+            tools.extend(entry.get("tools", []))
+            files.extend(entry.get("files", []))
+            if texts:
+                assistant_finals.append("\n".join(texts).strip())
+
+    if n_user == 0 and n_asst == 0:
+        return None
+
+    return SessionDigest(
+        session_id=session_id,
+        project=project,
+        git_branch=git_branch,
+        started_at=_ms_to_iso(created),
+        ended_at=_ms_to_iso(updated),
+        user_prompts=user_prompts,
+        assistant_finals=assistant_finals[-5:],
+        tools_used=_dedup(tools),
+        files_touched=_dedup(files)[:20],
+        feedback_signals=feedback,
+        n_user_turns=n_user,
+        n_assistant_turns=n_asst,
+        raw_path=f"opencode://{session_id}",
+    )
+
+
+def harvest_opencode(
+    db_path: str,
+    *,
+    scope: Any = "all",
+    invoked_project: str = "",
+    since_iso: Optional[str] = None,
+    limit: int = 0,
+) -> List[SessionDigest]:
+    """Read OpenCode sessions from SQLite and return matching digests."""
+    if not os.path.exists(db_path):
+        return []
+
+    since_ms = _iso_to_ms(since_iso)
+    digests: List[SessionDigest] = []
+    try:
+        conn = _connect_readonly(db_path)
+    except sqlite3.Error:
+        return []
+    try:
+        query = "select id from session"
+        params: List[Any] = []
+        if since_ms:
+            query += " where time_updated >= ?"
+            params.append(since_ms)
+        query += " order by time_updated desc"
+        if limit:
+            query += " limit ?"
+            params.append(limit * 4)
+        for (session_id,) in conn.execute(query, params):
+            digest = digest_opencode_session(conn, session_id)
+            if digest is None:
+                continue
+            if not _project_matches(digest.project or "", scope, invoked_project):
+                continue
+            digests.append(digest)
+            if limit and len(digests) >= limit:
+                break
+    except sqlite3.Error:
+        return []
+    finally:
+        conn.close()
+    return digests

--- a/tests/test_sleep_engine.py
+++ b/tests/test_sleep_engine.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import tempfile
 import unittest
+from unittest import mock
 
-from skillopt_sleep.backend import MockBackend, exact_score, keyword_soft_score
+from skillopt_sleep.backend import MockBackend, OpenCodeCliBackend, exact_score, get_backend, keyword_soft_score
 from skillopt_sleep.config import load_config
 from skillopt_sleep.consolidate import consolidate
 from skillopt_sleep.cycle import run_sleep_cycle
@@ -66,6 +68,8 @@ class TestHarvest(unittest.TestCase):
     def test_meta_prompt_filter(self):
         self.assertTrue(_is_meta_prompt("/clear"))
         self.assertTrue(_is_meta_prompt("<system-reminder>x</system-reminder>"))
+        self.assertTrue(_is_meta_prompt("[Compressed conversation section]\nold context"))
+        self.assertTrue(_is_meta_prompt("follow-up\n▣ DCP | compacted context"))
         self.assertFalse(_is_meta_prompt("please refactor the auth module"))
 
     def test_digest_real_transcript_if_present(self):
@@ -88,6 +92,154 @@ class TestHarvest(unittest.TestCase):
         if d is not None:
             self.assertIsInstance(d.session_id, str)
             self.assertGreaterEqual(d.n_user_turns + d.n_assistant_turns, 0)
+
+
+class TestOpenCodeHarvest(unittest.TestCase):
+    def _make_db(self, path: str, project: str) -> None:
+        conn = sqlite3.connect(path)
+        try:
+            conn.executescript(
+                """
+                create table project (id text primary key, worktree text);
+                create table session (
+                    id text primary key,
+                    project_id text,
+                    directory text,
+                    title text,
+                    time_created integer,
+                    time_updated integer,
+                    path text,
+                    metadata text
+                );
+                create table message (
+                    id text primary key,
+                    session_id text,
+                    time_created integer,
+                    time_updated integer,
+                    data text
+                );
+                create table part (
+                    id text primary key,
+                    message_id text,
+                    session_id text,
+                    time_created integer,
+                    time_updated integer,
+                    data text
+                );
+                """
+            )
+            conn.execute("insert into project values (?, ?)", ("p1", project))
+            conn.execute(
+                "insert into session values (?, ?, ?, ?, ?, ?, ?, ?)",
+                ("s1", "p1", project, "Fix parser", 1_700_000_000_000, 1_700_000_100_000,
+                 json.dumps({"cwd": project}), json.dumps({"gitBranch": "main"})),
+            )
+            messages = [
+                ("m1", "user", 1_700_000_000_100),
+                ("m2", "assistant", 1_700_000_000_200),
+            ]
+            for mid, role, ts in messages:
+                conn.execute(
+                    "insert into message values (?, ?, ?, ?, ?)",
+                    (mid, "s1", ts, ts, json.dumps({"role": role})),
+                )
+            parts = [
+                ("pt1", "m1", 1_700_000_000_101, {"type": "text", "text": "Please fix the parser"}),
+                ("pt2", "m1", 1_700_000_000_102, {"type": "text", "text": "still broken"}),
+                ("pt3", "m2", 1_700_000_000_201, {"type": "tool", "tool": "edit", "state": {"input": {"filePath": "skillopt_sleep/parser.py"}}}),
+                ("pt4", "m2", 1_700_000_000_202, {"type": "text", "text": "Fixed it."}),
+            ]
+            for pid, mid, ts, data in parts:
+                conn.execute(
+                    "insert into part values (?, ?, ?, ?, ?, ?)",
+                    (pid, mid, "s1", ts, ts, json.dumps(data)),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_harvest_opencode_digest(self):
+        from skillopt_sleep.harvest_opencode import harvest_opencode
+
+        with tempfile.TemporaryDirectory() as tmp:
+            project = os.path.join(tmp, "proj")
+            os.mkdir(project)
+            db = os.path.join(tmp, "opencode.db")
+            self._make_db(db, project)
+
+            digests = harvest_opencode(db, scope="invoked", invoked_project=project)
+            self.assertEqual(len(digests), 1)
+            d = digests[0]
+            self.assertEqual(d.session_id, "s1")
+            self.assertEqual(d.project, project)
+            self.assertEqual(d.git_branch, "main")
+            self.assertEqual(d.n_user_turns, 1)
+            self.assertEqual(d.n_assistant_turns, 1)
+            self.assertEqual(d.user_prompts, ["Please fix the parser\nstill broken"])
+            self.assertIn("neg:still broken", d.feedback_signals)
+            self.assertEqual(d.assistant_finals, ["Fixed it."])
+            self.assertEqual(d.tools_used, ["edit"])
+            self.assertEqual(d.files_touched, ["skillopt_sleep/parser.py"])
+            self.assertEqual(d.raw_path, "opencode://s1")
+
+            self.assertEqual(harvest_opencode(db, since_iso="2023-11-20T00:00:00Z"), [])
+
+
+class TestOpenCodeBackend(unittest.TestCase):
+    def test_get_backend_opencode(self):
+        backend = get_backend("opencode", model="anthropic/claude-sonnet-4-6", opencode_path="/bin/opencode")
+        self.assertIsInstance(backend, OpenCodeCliBackend)
+        self.assertEqual(backend.name, "opencode")
+        self.assertEqual(backend.model, "anthropic/claude-sonnet-4-6")
+        self.assertEqual(backend.opencode_path, "/bin/opencode")
+
+    def test_opencode_call_uses_isolated_run(self):
+        calls = []
+
+        def fake_run(cmd, capture_output, text, timeout, cwd, env):
+            calls.append({"cmd": cmd, "cwd": cwd, "env": env, "timeout": timeout})
+            return type("Proc", (), {"stdout": "\x1b[31mfinal answer\x1b[0m\n", "stderr": "", "returncode": 0})()
+
+        backend = OpenCodeCliBackend(model="anthropic/claude-sonnet-4-6", opencode_path="/bin/opencode", timeout=7)
+        with mock.patch("subprocess.run", side_effect=fake_run):
+            out = backend._call("hello")
+
+        self.assertEqual(out, "final answer")
+        self.assertEqual(len(calls), 1)
+        cmd = calls[0]["cmd"]
+        self.assertEqual(cmd[:5], ["/bin/opencode", "run", "--pure", "--format", "default"])
+        self.assertIn("--dir", cmd)
+        self.assertIn("--title", cmd)
+        self.assertIn("--model", cmd)
+        self.assertIn("anthropic/claude-sonnet-4-6", cmd)
+        self.assertEqual(cmd[-1], "hello")
+        self.assertEqual(calls[0]["timeout"], 7)
+        self.assertEqual(calls[0]["env"]["OPENCODE_DISABLE_CLAUDE_CODE"], "1")
+        self.assertEqual(calls[0]["env"]["OPENCODE_DISABLE_DEFAULT_PLUGINS"], "1")
+        self.assertIn("skillopt_sleep_opencode_", calls[0]["env"]["XDG_DATA_HOME"])
+        permission = json.loads(calls[0]["env"]["OPENCODE_PERMISSION"])
+        self.assertEqual(permission["edit"], "deny")
+        self.assertEqual(permission["bash"], "deny")
+
+    def test_opencode_tool_attempt_allows_temp_bash(self):
+        calls = []
+
+        def fake_run(cmd, capture_output, text, timeout, cwd, env):
+            calls.append({"cmd": cmd, "cwd": cwd, "env": env})
+            with open(os.path.join(cwd, "_tool_calls.log"), "w") as f:
+                f.write("search\n")
+            return type("Proc", (), {"stdout": "answer", "stderr": "", "returncode": 0})()
+
+        task = TaskRecord(id="t1", project="/p", intent="look this up", context_excerpt="")
+        backend = OpenCodeCliBackend(opencode_path="/bin/opencode")
+        with mock.patch("subprocess.run", side_effect=fake_run):
+            out, called = backend.attempt_with_tools(task, "Use search first", "", ["search"])
+
+        self.assertEqual(out, "answer")
+        self.assertEqual(called, ["search"])
+        self.assertIn("--dangerously-skip-permissions", calls[0]["cmd"])
+        permission = json.loads(calls[0]["env"]["OPENCODE_PERMISSION"])
+        self.assertEqual(permission["bash"], "allow")
 
 
 class TestMine(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add an OpenCode integration with /sleep command, skill, installer, and MCP wiring
- mine native OpenCode sessions from ~/.local/share/opencode/opencode.db via read-only SQLite
- add --backend opencode using opencode run for model-backed replay, judging, mining, and reflection
- wire OpenCode path/model/source options through CLI, MCP, experiments, docs, and tests

## Validation
- python3 -m py_compile skillopt_sleep/backend.py skillopt_sleep/__main__.py skillopt_sleep/cycle.py skillopt_sleep/experiments/run_experiment.py skillopt_sleep/experiments/run_gbrain.py skillopt_sleep/experiments/run_transfer.py skillopt_sleep/experiments/sweep.py plugins/copilot/mcp_server.py
- python3 -m pytest -q

Note: I did not run a live opencode model call to avoid spending user budget; subprocess behavior is covered with mocked tests.