### PR TITLE
fix: SKILLOPT_SLEEP_PYTHON override + lookback_hours first-run fallback

### DIFF
--- a/plugins/claude-code/scripts/run-sleep.sh
+++ b/plugins/claude-code/scripts/run-sleep.sh
@@ -30,12 +30,17 @@ if [ -z "${REPO_ROOT:-}" ]; then
 fi
 
 PY=""
-for cand in python3.12 python3.11 python3.10 python3; do
-  if command -v "$cand" >/dev/null 2>&1; then
-    ver="$("$cand" -c 'import sys; print("%d%d" % sys.version_info[:2])' 2>/dev/null || echo 0)"
-    if [ "${ver:-0}" -ge 310 ]; then PY="$cand"; break; fi
-  fi
-done
+# Allow explicit Python override (useful on macOS with old system Python).
+if [ -n "${SKILLOPT_SLEEP_PYTHON:-}" ]; then
+  PY="$SKILLOPT_SLEEP_PYTHON"
+else
+  for cand in python3.12 python3.11 python3.10 python3; do
+    if command -v "$cand" >/dev/null 2>&1; then
+      ver="$("$cand" -c 'import sys; print("%d%d" % sys.version_info[:2])' 2>/dev/null || echo 0)"
+      if [ "${ver:-0}" -ge 310 ]; then PY="$cand"; break; fi
+    fi
+  done
+fi
 if [ -z "$PY" ]; then
   echo "[sleep] ERROR: need Python >= 3.10 (found none)." >&2
   exit 1

--- a/plugins/run-sleep.sh
+++ b/plugins/run-sleep.sh
@@ -30,12 +30,17 @@ if [ -z "${REPO_ROOT:-}" ]; then
 fi
 
 PY=""
-for cand in python3.12 python3.11 python3.10 python3; do
-  if command -v "$cand" >/dev/null 2>&1; then
-    ver="$("$cand" -c 'import sys; print("%d%d" % sys.version_info[:2])' 2>/dev/null || echo 0)"
-    if [ "${ver:-0}" -ge 310 ]; then PY="$cand"; break; fi
-  fi
-done
+# Allow explicit Python override (useful on macOS with old system Python).
+if [ -n "${SKILLOPT_SLEEP_PYTHON:-}" ]; then
+  PY="$SKILLOPT_SLEEP_PYTHON"
+else
+  for cand in python3.12 python3.11 python3.10 python3; do
+    if command -v "$cand" >/dev/null 2>&1; then
+      ver="$("$cand" -c 'import sys; print("%d%d" % sys.version_info[:2])' 2>/dev/null || echo 0)"
+      if [ "${ver:-0}" -ge 310 ]; then PY="$cand"; break; fi
+    fi
+  done
+fi
 if [ -z "$PY" ]; then
   echo "[sleep] ERROR: need Python >= 3.10 (found none)." >&2
   exit 1

--- a/skillopt_sleep/__main__.py
+++ b/skillopt_sleep/__main__.py
@@ -111,8 +111,10 @@ def _cfg_from_args(args, task_meta: Dict[str, Any] | None = None) -> Any:
         overrides["codex_home"] = os.path.abspath(args.codex_home)
     if getattr(args, "source", ""):
         overrides["transcript_source"] = args.source
-    if getattr(args, "lookback_hours", 0):
+    if getattr(args, "lookback_hours", None) is not None and args.lookback_hours != 0:
         overrides["lookback_hours"] = args.lookback_hours
+    elif getattr(args, "lookback_hours", None) == 0:
+        overrides["lookback_hours"] = 0  # explicit opt-out: scan full history
     if getattr(args, "edit_budget", 0):
         overrides["edit_budget"] = args.edit_budget
     if getattr(args, "max_sessions", 0):

--- a/skillopt_sleep/__main__.py
+++ b/skillopt_sleep/__main__.py
@@ -76,7 +76,8 @@ def _add_common(p: argparse.ArgumentParser) -> None:
     p.add_argument("--codex-home", default="", help="override ~/.codex for archived session harvest")
     p.add_argument("--source", default="", choices=["", "claude", "codex", "auto"],
                    help="session transcript source")
-    p.add_argument("--lookback-hours", type=int, default=0)
+    p.add_argument("--lookback-hours", type=int, default=None,
+                   help="harvest window in hours; 0 = scan full history")
     p.add_argument("--edit-budget", type=int, default=0)
     p.add_argument("--max-sessions", type=int, default=0,
                    help="cap harvested sessions before mining; default derives from max tasks")
@@ -111,10 +112,9 @@ def _cfg_from_args(args, task_meta: Dict[str, Any] | None = None) -> Any:
         overrides["codex_home"] = os.path.abspath(args.codex_home)
     if getattr(args, "source", ""):
         overrides["transcript_source"] = args.source
-    if getattr(args, "lookback_hours", None) is not None and args.lookback_hours != 0:
-        overrides["lookback_hours"] = args.lookback_hours
-    elif getattr(args, "lookback_hours", None) == 0:
-        overrides["lookback_hours"] = 0  # explicit opt-out: scan full history
+    lh = getattr(args, "lookback_hours", None)
+    if lh is not None:  # --lookback-hours was explicitly passed (0 = full history)
+        overrides["lookback_hours"] = lh
     if getattr(args, "edit_budget", 0):
         overrides["edit_budget"] = args.edit_budget
     if getattr(args, "max_sessions", 0):

--- a/skillopt_sleep/cycle.py
+++ b/skillopt_sleep/cycle.py
@@ -148,7 +148,7 @@ def run_sleep_cycle(
         # scan the entire transcript history and trigger massive LLM mining.
         if since is None:
             lookback_hours = cfg.get("lookback_hours", 72)
-            if lookback_hours and lookback_hours > 0:
+            if lookback_hours is not None and lookback_hours > 0:
                 import time
                 ref_time = clock if clock is not None else time.time()
                 cutoff = ref_time - lookback_hours * 3600

--- a/skillopt_sleep/cycle.py
+++ b/skillopt_sleep/cycle.py
@@ -144,6 +144,14 @@ def run_sleep_cycle(
         _progress(cfg, f"using {len(tasks)} seeded tasks")
     else:
         since = state.last_harvest_for(project)
+        # On first run (no prior harvest), apply lookback_hours so we don't
+        # scan the entire transcript history and trigger massive LLM mining.
+        if since is None:
+            lookback_hours = cfg.get("lookback_hours", 72)
+            if lookback_hours and lookback_hours > 0:
+                import time
+                cutoff = time.time() - lookback_hours * 3600
+                since = _now_iso(cutoff)
         max_tasks = cfg.get("max_tasks_per_night", 40)
         max_sessions = cfg.get("max_sessions_per_night", 0) or max_tasks * 3
         candidate_limit = max_tasks

--- a/skillopt_sleep/cycle.py
+++ b/skillopt_sleep/cycle.py
@@ -150,7 +150,8 @@ def run_sleep_cycle(
             lookback_hours = cfg.get("lookback_hours", 72)
             if lookback_hours and lookback_hours > 0:
                 import time
-                cutoff = time.time() - lookback_hours * 3600
+                ref_time = clock if clock is not None else time.time()
+                cutoff = ref_time - lookback_hours * 3600
                 since = _now_iso(cutoff)
         max_tasks = cfg.get("max_tasks_per_night", 40)
         max_sessions = cfg.get("max_sessions_per_night", 0) or max_tasks * 3

--- a/skillopt_sleep/harvest.py
+++ b/skillopt_sleep/harvest.py
@@ -294,9 +294,10 @@ def harvest(
         if not _project_matches(d.project or "", scope, invoked_project):
             continue
         if since_iso and d.ended_at and d.ended_at < since_iso:
-            # Files are sorted newest-first by mtime; once we see one that
-            # is older than the cutoff, all remaining files are older too.
-            break
+            # Note: files are sorted by mtime but we compare the embedded
+            # ended_at timestamp — mtime can diverge (copy/touch), so we
+            # cannot break here; we must continue to check all files.
+            continue
         digests.append(d)
         if limit and len(digests) >= limit:
             break

--- a/skillopt_sleep/harvest.py
+++ b/skillopt_sleep/harvest.py
@@ -294,7 +294,9 @@ def harvest(
         if not _project_matches(d.project or "", scope, invoked_project):
             continue
         if since_iso and d.ended_at and d.ended_at < since_iso:
-            continue
+            # Files are sorted newest-first by mtime; once we see one that
+            # is older than the cutoff, all remaining files are older too.
+            break
         digests.append(d)
         if limit and len(digests) >= limit:
             break


### PR DESCRIPTION
## Summary

Two fixes from issue #57 community feedback:

### 1. `SKILLOPT_SLEEP_PYTHON` env var (issue #57 point 4)

macOS users with system Python 3.9 but a newer Python available elsewhere (e.g. Codex Desktop's bundled 3.12) had no way to tell the runner which Python to use.

Now: `export SKILLOPT_SLEEP_PYTHON=/path/to/python3.12` overrides auto-detection. Applied to both `plugins/run-sleep.sh` and the bundled Claude Code plugin copy.

### 2. `lookback_hours` first-run fallback (issue #57 point 10)

Previously, the first run (no prior harvest recorded) scanned the **entire** transcript history — users with months of data triggered massive LLM mining. Now applies `lookback_hours` (default 72h) as a time cutoff on first run.

`--lookback-hours 0` explicitly opts out (full history scan). Omitting the flag preserves the config default (72h).

## Codex + GPT-5.5 review (4 rounds)

| Round | Finding | Fix |
|-------|---------|-----|
| 1 | Use supplied `clock` for cutoff (not wall time) | ✅ Fixed |
| 1 | Harvest early-exit on old files | ✅ Fixed → then reverted in round 2 |
| 2 | mtime vs ended_at ordering mismatch — can't `break` | ✅ Reverted to `continue` |
| 2 | `--lookback-hours 0` clobbered by config default | ✅ Use `is not None and > 0` |
| 3 | argparse default=0 makes omitted indistinguishable from explicit 0 | ✅ Changed default to `None` |
| 4 | Clean pass — no issues found | ✅ |

## Test plan
- [x] 139 tests pass
- [x] `SKILLOPT_SLEEP_PYTHON=/usr/bin/python3 bash plugins/run-sleep.sh status` works
- [x] First run with default config applies 72h lookback
- [x] `--lookback-hours 0` scans full history
- [x] Deterministic test with `clock` parameter gets reproducible cutoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)