### PR TITLE
docs(readme): acknowledge community contributor @samuelgoofus-boop

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ python -m skillopt_webui.app
 
 ---
 
+## Acknowledgements
+
+We thank the community contributors who help improve SkillOpt. In particular:
+
+- [@samuelgoofus-boop](https://github.com/samuelgoofus-boop) — Windows robustness for the Claude/Codex backends (argv-overflow / `WinError 206`, subprocess UTF-8 encoding, tolerant JSON parsing, and test-eval directory creation) in [#77](https://github.com/microsoft/SkillOpt/pull/77).
+
+Contributions of all sizes are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
 ## Citation
 
 ```bibtex


### PR DESCRIPTION
## Summary
Adds an **Acknowledgements** section to the README crediting [@samuelgoofus-boop](https://github.com/samuelgoofus-boop) for the Windows-robustness work on the Claude/Codex backends (originally #77, merged via #79).

This is a human-visible credit in addition to the `Co-authored-by` trailer already carried into `main` by the squash-merge of #79 (which makes him a GitHub contributor on the commit graph).

## Notes
- README-only, +10/−0.
- Feel free to tweak the wording — opened as a PR (not direct-merged) so it can be reviewed/edited first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)