### PR TITLE
docs(readme): remove Acknowledgements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,16 +94,6 @@ python -m skillopt_webui.app
 
 ---
 
-## Acknowledgements
-
-We thank the community contributors who help improve SkillOpt. In particular:
-
-- [@samuelgoofus-boop](https://github.com/samuelgoofus-boop) — Windows robustness for the Claude/Codex backends (argv-overflow / `WinError 206`, subprocess UTF-8 encoding, tolerant JSON parsing, and test-eval directory creation) in [#77](https://github.com/microsoft/SkillOpt/pull/77).
-
-Contributions of all sizes are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md).
-
----
-
 ## Citation
 
 ```bibtex


### PR DESCRIPTION
## Summary
Removes the README **Acknowledgements** section added in #80. The contributor is already credited via the `Co-authored-by` trailer carried into `main` by #79, so a dedicated section is unnecessary.

README-only, +0/−10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)