### PR TITLE
fix(harvest): exclude sub-agent transcripts and agent-generated sessions from task mining

### DIFF
--- a/skillopt_sleep/harvest.py
+++ b/skillopt_sleep/harvest.py
@@ -109,6 +109,13 @@ def _is_meta_prompt(text: str) -> bool:
         return True
     if t.startswith("[Pasted text") or t.startswith("Caveat:"):
         return True
+    # Expanded slash-command prompts (Claude Code injects the full command
+    # body as a user message, wrapped in <command-message>/<command-name>
+    # tags or rendered as "# /<name> — ..." headers). Not a user intent.
+    if "<command-message>" in t[:200] or "<command-name>" in t[:200]:
+        return True
+    if t.startswith("# /"):
+        return True
     return False
 
 
@@ -129,6 +136,31 @@ _REPLAY_PROMPT_MARKERS = (
     "## TASK\n",
     "## SKILL\n",
 )
+
+
+# Sessions written by OTHER tools' sub-agents (memory observers, critic
+# sub-agents, plugin self-invocations). These are multi-turn, so the
+# single-turn heuristic in _is_headless_replay never catches them. If the
+# FIRST user prompt matches any marker, the whole session is
+# machine-generated, not a real user task.
+_AGENT_SESSION_MARKERS = (
+    "You are a Claude-Mem",              # claude-mem observer agent
+    "Hello memory agent",                # claude-mem observer continuation
+    "You are driving **SkillOpt-Sleep**",  # this plugin's own command body
+) + tuple(
+    # users can add markers for their own tools' agent prompts
+    p.strip()
+    for p in os.environ.get("SKILLOPT_SLEEP_AGENT_MARKERS", "").split(",")
+    if p.strip()
+)
+
+
+def _is_agent_session(digest: "SessionDigest") -> bool:
+    """Detect transcripts written by other tools' sub-agents (see markers)."""
+    if not digest.user_prompts:
+        return False
+    first = digest.user_prompts[0]
+    return any(marker in first for marker in _AGENT_SESSION_MARKERS)
 
 
 def _is_headless_replay(digest: "SessionDigest") -> bool:
@@ -279,8 +311,12 @@ def harvest(
 
     paths: List[str] = []
     for root, _dirs, files in os.walk(transcripts_dir):
+        # Sub-agent sidechain transcripts (<session>/subagents/agent-*.jsonl)
+        # are Claude-authored prompts, not user tasks — never harvest them.
+        if os.path.basename(root) == "subagents":
+            continue
         for fn in files:
-            if fn.endswith(".jsonl"):
+            if fn.endswith(".jsonl") and not fn.startswith("agent-"):
                 paths.append(os.path.join(root, fn))
     # newest first by mtime
     paths.sort(key=lambda p: os.path.getmtime(p), reverse=True)
@@ -291,6 +327,8 @@ def harvest(
             continue
         if _is_headless_replay(d):
             continue  # Issue #62: skip engine's own headless replay sessions
+        if _is_agent_session(d):
+            continue  # skip other tools' sub-agent transcripts (claude-mem etc.)
         if not _project_matches(d.project or "", scope, invoked_project):
             continue
         if since_iso and d.ended_at and d.ended_at < since_iso:


### PR DESCRIPTION
## Problem

Harvest mines machine-generated prompts as if they were user tasks. On a machine with memory/observer plugins installed (e.g. claude-mem) and regular Agent-tool use, ~80% of mined tasks were not authored by the user:

1. **Sub-agent sidechain transcripts** — Claude Code stores them at `<session>/subagents/agent-*.jsonl`; `os.walk` sweeps them in, so every Task/Agent spawn's prompt becomes a "recurring user task" (one session contributed 19 near-duplicate tasks).
2. **Other tools' agent sessions** — plugins like claude-mem run their own observer agents whose transcripts look like normal multi-turn sessions, so the single-turn heuristic from #62 never catches them.
3. **Expanded slash-command bodies** — Claude Code injects the full command markdown as a user message; `_is_meta_prompt` only skips short `/cmd` forms, so the plugin's own `/skillopt-sleep` command body got mined as a task (self-harvest).

Downstream effect: the optimizer trains and gates on prompts the user never wrote.

## Fix

- Skip `subagents/` directories and `agent-*.jsonl` files in the transcript walk (structural, no heuristics).
- New `_AGENT_SESSION_MARKERS` + `_is_agent_session()`: drop sessions whose FIRST user prompt is a known agent brief. Ships with markers for claude-mem and this plugin's own command; user-extensible via `SKILLOPT_SLEEP_AGENT_MARKERS` (comma-separated), mirroring the existing `SKILLOPT_SLEEP_NEG_FEEDBACK` pattern.
- `_is_meta_prompt`: also skip prompts containing `<command-message>`/`<command-name>` or starting with `# /`.

## Verification

On a real ~/.claude with claude-mem installed: harvest went from 120 sessions / mostly machine-generated tasks to 55 sessions / 38 tasks, all genuinely user-authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)