### PR TITLE
[codex] Preserve fractional rollout hard scores

### DIFF
--- a/skillopt/types.py
+++ b/skillopt/types.py
@@ -11,12 +11,12 @@ BatchSpec              — from skillopt.datasets.base
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field, fields as dc_fields
+from dataclasses import dataclass, field
+from dataclasses import fields as dc_fields
 from typing import Any, Literal
 
-from skillopt.evaluation.gate import GateAction, GateResult  # noqa: F401
 from skillopt.datasets.base import BatchSpec  # noqa: F401
-
+from skillopt.evaluation.gate import GateAction, GateResult  # noqa: F401
 
 # ── Atomic types ─────────────────────────────────────────────────────────
 
@@ -109,7 +109,7 @@ class RolloutResult:
     """
 
     id: str
-    hard: int
+    hard: float
     soft: float
     n_turns: int = 0
     fail_reason: str = ""
@@ -142,7 +142,7 @@ class RolloutResult:
         extras = {k: v for k, v in d.items() if k not in known}
         return cls(
             id=str(d.get("id", "")),
-            hard=int(d.get("hard", 0)),
+            hard=float(d.get("hard", 0)),
             soft=float(d.get("soft", 0.0)),
             n_turns=int(d.get("n_turns", 0)),
             fail_reason=str(d.get("fail_reason", "")),

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 import pytest
 
-from skillopt.types import Edit, Patch
-
+from skillopt.types import Edit, Patch, RolloutResult
 
 # ── Edit ────────────────────────────────────────────────────────────────────
 
@@ -247,3 +246,17 @@ class TestPatchEdgeCases:
         assert isinstance(p.edits[0], Edit)
         assert p.edits[0].op == "append"
         assert p.edits[0].content == "hello"
+
+
+# ── RolloutResult ────────────────────────────────────────────────────────────
+
+
+class TestRolloutResultRoundTrip:
+    """RolloutResult.to_dict() / RolloutResult.from_dict() round-trip."""
+
+    def test_preserves_fractional_hard_score(self) -> None:
+        """Hard can be a continuous reward and must not be truncated."""
+        result = RolloutResult.from_dict({"id": "episode-1", "hard": 0.75, "soft": 0.5})
+
+        assert result.hard == pytest.approx(0.75)
+        assert result.to_dict()["hard"] == pytest.approx(0.75)


### PR DESCRIPTION
## Summary
- Store `RolloutResult.hard` as a float instead of truncating through `int()`.
- Preserve continuous hard rewards such as `0.75` through `from_dict()` and `to_dict()`.
- Add a regression test covering fractional hard score round-tripping.

## Test plan
- `uv run --with pytest pytest tests/test_types.py tests/test_scoring.py -q`
- `uv run --with ruff ruff check skillopt/types.py tests/test_types.py`