### PR TITLE
fix(qwen): always send explicit enable_thinking in chat_template_kwargs

### DIFF
--- a/skillopt/model/qwen_backend.py
+++ b/skillopt/model/qwen_backend.py
@@ -191,8 +191,9 @@ def _chat_messages_impl(
         "messages": _json_safe(messages),
         "max_tokens": min(max_completion_tokens, config.max_tokens),
     }
-    if config.enable_thinking:
-        payload["chat_template_kwargs"] = {"enable_thinking": True}
+    # Always send an explicit value: omitting it leaves thinking mode to the
+    # vLLM server / chat-template default, which varies across deployments (#90).
+    payload["chat_template_kwargs"] = {"enable_thinking": bool(config.enable_thinking)}
     if config.temperature is not None:
         payload["temperature"] = config.temperature
     if tools:

--- a/tests/test_qwen_backend.py
+++ b/tests/test_qwen_backend.py
@@ -149,7 +149,7 @@ def _record_urlopen(
     return recorder
 
 
-def test_chat_target_omits_chat_template_kwargs_when_thinking_disabled(
+def test_chat_target_sends_explicit_false_when_thinking_disabled(
     monkeypatch: pytest.MonkeyPatch,
     isolate_qwen_state: tuple[Any, Any],
 ) -> None:
@@ -167,7 +167,7 @@ def test_chat_target_omits_chat_template_kwargs_when_thinking_disabled(
 
     assert text == "<answer>yes</answer>"
     assert usage["total_tokens"] == 3
-    assert "chat_template_kwargs" not in recorder.calls[0]["payload"]
+    assert recorder.calls[0]["payload"]["chat_template_kwargs"] == {"enable_thinking": False}
     assert recorder.calls[0]["timeout"] == 10.0
 
 
@@ -224,4 +224,4 @@ def test_configure_qwen_chat_runtime_toggle_controls_payload(
     model_module.chat_target("system", "user", max_completion_tokens=128, retries=1)
 
     assert recorder.calls[0]["payload"]["chat_template_kwargs"] == {"enable_thinking": True}
-    assert "chat_template_kwargs" not in recorder.calls[1]["payload"]
+    assert recorder.calls[1]["payload"]["chat_template_kwargs"] == {"enable_thinking": False}


### PR DESCRIPTION
## Problem

`skillopt/model/qwen_backend.py` only attached `chat_template_kwargs` when `enable_thinking` was true:

```python
if config.enable_thinking:
    payload["chat_template_kwargs"] = {"enable_thinking": True}
```

With `enable_thinking=false` the key was omitted entirely, so whether Qwen thinking mode ran was decided by the vLLM server / chat-template default — which varies across deployments and makes results hard to reproduce. This is exactly point 3 of #90, where @Huangzisu confirmed the reported results used client-side `enable_thinking=false` and that the code would be adjusted.

## Change

Always send an explicit boolean:

```python
payload["chat_template_kwargs"] = {"enable_thinking": bool(config.enable_thinking)}
```

This matches the MiniMax backend, which already sends the flag unconditionally (`minimax_backend.py`).

## Tests

Updated the two tests that pinned the omit-when-disabled behavior to assert an explicit `{"enable_thinking": False}` instead. Full suite: **165 passed, 5 skipped**.

Ref #90