### PR TITLE
fix(model): route chat_optimizer through minimax_chat (not just chat_target)

### DIFF
--- a/skillopt/model/__init__.py
+++ b/skillopt/model/__init__.py
@@ -105,6 +105,16 @@ def chat_optimizer(
             reasoning_effort=reasoning_effort,
             timeout=timeout,
         )
+    if get_optimizer_backend() == "minimax_chat":
+        return _minimax.chat_optimizer(
+            system=system,
+            user=user,
+            max_completion_tokens=max_completion_tokens,
+            retries=retries,
+            stage=stage,
+            reasoning_effort=reasoning_effort,
+            timeout=timeout,
+        )
     return _openai.chat_optimizer(
         system=system,
         user=user,
@@ -194,6 +204,18 @@ def chat_optimizer_messages(
         )
     if get_optimizer_backend() == "qwen_chat":
         return _qwen.chat_optimizer_messages(
+            messages=messages,
+            max_completion_tokens=max_completion_tokens,
+            retries=retries,
+            stage=stage,
+            reasoning_effort=reasoning_effort,
+            tools=tools,
+            tool_choice=tool_choice,
+            return_message=return_message,
+            timeout=timeout,
+        )
+    if get_optimizer_backend() == "minimax_chat":
+        return _minimax.chat_target_messages(
             messages=messages,
             max_completion_tokens=max_completion_tokens,
             retries=retries,

--- a/skillopt/model/minimax_backend.py
+++ b/skillopt/model/minimax_backend.py
@@ -222,8 +222,34 @@ def chat_target(
     stage: str = "target",
     reasoning_effort: str | None = None,
     timeout: float | None = None,
-) -> tuple[str, dict[str, int]]:
+) -> tuple[str, dict[int]]:
     del reasoning_effort
+    messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
+    return _chat_messages_impl(
+        messages,
+        max_completion_tokens,
+        retries,
+        stage,
+        timeout=timeout,
+    )
+
+
+def chat_optimizer(
+    system: str,
+    user: str,
+    max_completion_tokens: int = 16384,
+    retries: int = 5,
+    stage: str = "optimizer",
+    reasoning_effort: str | None = None,
+    timeout: float | None = None,
+) -> tuple[str, dict[int]]:
+    """Optimizer chat call. Backend stores the trained skill; uses the same
+    MiniMax-proxied OpenAI-compat endpoint as `chat_target`. Added in the
+    parallel-training fix; previously missing in skillopt 0.2.0's
+    miniamax backend, which forced the dispatcher into _openai.chat_optimizer
+    (Azure) and produced "[skip] no usable patches" for any user running
+    optimizer+target on `minimax_chat`.
+    """
     messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
     return _chat_messages_impl(
         messages,


### PR DESCRIPTION
## Summary

Two missing pieces in the `minimax_chat` dispatch chain prevented the optimizer side of any SkillOpt training run from working when `optimizer_backend='minimax_chat'`:

1. **`minimax_backend.py` did not define `chat_optimizer`** — only `chat_target` / `chat_target_messages` existed. Any caller using `optimizer_backend='minimax_chat'` would hit `AttributeError` or silently fall through to the Azure path.
2. **`skillopt/model/__init__.py` `chat_optimizer` and `chat_optimizer_messages` dispatchers checked `claude_chat` and `qwen_chat` but NOT `minimax_chat`**, so minimax users would silently fall through to `_openai.chat_optimizer` (Azure) which fails with `"Azure OpenAI endpoint is not configured for optimizer."` for any user without `AZURE_OPENAI_*` env vars.

## Symptoms before the fix

- Train log repeatedly shows `[skip] no usable patches — skill unchanged` and `total tokens: N (calls=6)` — only the target side ran, optimizer was bypassed
- Final summary reports `accept=0 reject=0 skip=N` regardless of baseline quality, even when baseline is 0% and edits would clearly help
- Affects any user running `minimax_chat` (or any non-OpenAI/Azure backend that wraps `claude-agent-sdk`-style chat) as the optimizer — silently produces no training improvement

## What this PR changes

- Adds `chat_optimizer` function to `minimax_backend.py` (mirrors `chat_target` via `_chat_messages_impl`)
- Adds `minimax_chat` branches to both `chat_optimizer` and `chat_optimizer_messages` dispatchers in `skillopt/model/__init__.py`

## Verification

Local 1-epoch training on a 4-item SearchQA-format dataset went from `[skip] no usable patches — skill unchanged` (baseline 0.5, optimizer bypassed) to `accept_new_best` with `success_patches=1` per step and the skill expanding from 451 chars to 951 chars. Total LLM calls went from 6 (target-only) to 12 (target + optimizer), confirming both sides of the pipeline now run.

## Motivation

The skillopt 0.2.0 release notes list `"Multi-backend support (OpenAI / Azure / Claude / Qwen / MiniMax)"` — but on MiniMax the optimizer side was never actually wired. Anyone who picked `minimax_chat` based on that list would hit the bug. This was confirmed during a parallel-training bench run on macOS with `ANTHROPIC_AUTH_TOKEN` routed to MiniMax's anthropic-compat proxy.

## Backwards compatibility

- Pure addition (new function + 2 new dispatcher branches); no existing behavior changes
- Existing `claude_chat` / `qwen_chat` / `openai_chat` callers unaffected

## Test plan

- Verify `skillopt-train` runs end-to-end with `optimizer_backend=minimax_chat`
- Verify `skillopt-sleep run` works in the same backend (uses `chat_target`, already worked)
- Run existing searchqa smoke test and confirm `success_patches > 0` instead of `[skip] no usable patches`