### PR TITLE
fix(skillopt-sleep): surface Claude CLI spawn failures instead of silent zero scores

### DIFF
--- a/skillopt_sleep/backend.py
+++ b/skillopt_sleep/backend.py
@@ -620,7 +620,12 @@ class ClaudeCliBackend(CliBackend):
             proc = subprocess.run(
                 cmd, capture_output=True, text=True, timeout=self.timeout, cwd=clean_cwd,
             )
-        except Exception:
+        except Exception as exc:
+            import logging
+            self.last_call_error = f"Claude CLI spawn failed: {exc}"
+            logging.getLogger("skillopt_sleep").warning(
+                "Claude CLI could not be executed: %s", exc,
+            )
             return ""
         finally:
             try:
@@ -684,7 +689,12 @@ class ClaudeCliBackend(CliBackend):
                 )
                 resp = (proc.stdout or "").strip()
                 self._detect_cli_error(resp, proc.stderr or "")
-            except Exception:
+            except Exception as exc:
+                import logging
+                self.last_call_error = f"Claude CLI spawn failed: {exc}"
+                logging.getLogger("skillopt_sleep").warning(
+                    "Claude CLI could not be executed: %s", exc,
+                )
                 resp = ""
             self._tokens += len(prompt) // 4 + len(resp) // 4
             called: List[str] = []

--- a/tests/test_sleep_engine.py
+++ b/tests/test_sleep_engine.py
@@ -1118,6 +1118,36 @@ class TestClaudeCliBackendBare(unittest.TestCase):
         # But it's also recorded for detection
         self.assertIn("Not logged in", getattr(be, "last_call_error", ""))
 
+    def test_spawn_failure_sets_last_call_error(self):
+        """When subprocess.run raises FileNotFoundError, _call must set
+        last_call_error and log a warning instead of silently returning ''."""
+        from skillopt_sleep.backend import ClaudeCliBackend
+        be = ClaudeCliBackend(
+            claude_path="/nonexistent/claude-binary",
+            timeout=3,
+        )
+        result = be._call("test prompt")
+        self.assertEqual(result, "")
+        self.assertIn("Claude CLI spawn failed", be.last_call_error)
+
+    def test_attempt_tools_spawn_failure_sets_last_call_error(self):
+        """When subprocess.run raises in attempt_with_tools, last_call_error
+        must be set and a warning logged."""
+        from skillopt_sleep.backend import ClaudeCliBackend
+        from skillopt_sleep.types import TaskRecord
+        be = ClaudeCliBackend(
+            claude_path="/nonexistent/claude-binary",
+            timeout=3,
+        )
+        task = TaskRecord(
+            id="t1", project="/p", intent="test",
+            reference="ref", reference_kind="exact",
+            tags=[], split="train",
+        )
+        resp, called = be.attempt_with_tools(task, "", "", tools=["search"])
+        self.assertEqual(resp, "")
+        self.assertIn("Claude CLI spawn failed", be.last_call_error)
+
 
 
 


### PR DESCRIPTION
## Summary

Make `ClaudeCliBackend` report subprocess spawn failures (e.g. `FileNotFoundError` on Windows) instead of silently swallowing them and returning an empty string that scores 0.0 everywhere.

## Motivation

Two stacked problems (detailed in #121):

1. **Path resolution.** On Windows, `claude` installed via npm is a `.cmd` shim. `subprocess.run(["claude", ...])` raises `FileNotFoundError` because `CreateProcess` doesn't resolve `.cmd` by bare name. (PR #98 addresses this with `shutil.which()`.)

2. **Silent swallow.** Regardless of *why* the CLI fails to spawn, both `_call` and `attempt_with_tools` wrap the subprocess call in a bare `except Exception: return ""` that never sets `last_call_error` or logs a warning. The empty string is then treated as a legitimate model answer, so the run proceeds and all scores come back 0.0 — indistinguishable from "nothing to optimize".

This PR fixes **problem 2**, following the same pattern established in #92 for the codex backend.

## Changes

### Engine

- **`_call`** (line 623): Catch the exception explicitly, set `last_call_error`, log a warning, then return `""`. Control flow preserved.
- **`attempt_with_tools`** (line 687): Same treatment.

Both ensure that a dead or broken CLI can never masquerade as a 0.0-scoring model.

### Tests

- **`test_spawn_failure_sets_last_call_error`** (new): Verifies `_call` sets `last_call_error` and returns `""` when `subprocess.run` raises `FileNotFoundError`.
- **`test_attempt_tools_spawn_failure_sets_last_call_error`** (new): Same for `attempt_with_tools`.

## Testing

```
uv run python -m pytest tests/test_sleep_engine.py::TestClaudeCliBackendBare -v --tb=short
```

All 5 tests pass (3 pre-existing + 2 new).

Full suite:
```
uv run python -m pytest tests/test_sleep_engine.py -v --tb=short
```
- 62 passed, 1 skipped, 3 failed
- The 3 failures are pre-existing Windows path separator issues (`\` vs `/`), completely unrelated to this change.

## Related issue

Closes #121
