### PR TITLE
feat: wire documented --preferences flag through CLI/config into the backend

### DIFF
--- a/skillopt_sleep/__main__.py
+++ b/skillopt_sleep/__main__.py
@@ -91,6 +91,8 @@ def _add_common(p: argparse.ArgumentParser) -> None:
     p.add_argument("--progress", action="store_true",
                    help="print phase progress to stderr")
     p.add_argument("--auto-adopt", action="store_true")
+    p.add_argument("--preferences", default="",
+                   help="free-text house rules injected into the optimizer's reflect step")
     p.add_argument("--json", action="store_true")
 
 
@@ -118,6 +120,8 @@ def _cfg_from_args(args, task_meta: Dict[str, Any] | None = None) -> Any:
         overrides["lookback_hours"] = lh
     if getattr(args, "edit_budget", 0):
         overrides["edit_budget"] = args.edit_budget
+    if getattr(args, "preferences", ""):
+        overrides["preferences"] = args.preferences
     if getattr(args, "max_sessions", 0):
         overrides["max_sessions_per_night"] = args.max_sessions
     if getattr(args, "max_tasks", 0):

--- a/skillopt_sleep/config.py
+++ b/skillopt_sleep/config.py
@@ -41,6 +41,7 @@ DEFAULTS: Dict[str, Any] = {
     "gate_mode": "on",            # "on" (validation-gated) | "off" (greedy, no hard filter)
     "codex_path": "",             # "" => auto-detect the real @openai/codex binary
     "edit_budget": 4,             # textual learning rate (max edits/night)
+    "preferences": "",            # free-text house rules injected into reflect as a prior
     "gate_metric": "mixed",       # hard | soft | mixed (mixed best for tiny holdouts)
     "gate_mixed_weight": 0.5,
     "replay_mode": "mock",        # "mock" (sandboxed prompt) | "fresh" (worktree)

--- a/skillopt_sleep/cycle.py
+++ b/skillopt_sleep/cycle.py
@@ -120,6 +120,7 @@ def run_sleep_cycle(
         codex_path=cfg.get("codex_path", ""),
         project_dir=project,
     )
+    backend.preferences = cfg.get("preferences", "")
     _progress(cfg, f"night {night}: project={project} backend={backend.name}")
 
     # ── live skill/memory docs ───────────────────────────────────────────

--- a/tests/test_sleep_engine.py
+++ b/tests/test_sleep_engine.py
@@ -199,6 +199,7 @@ class TestHarvest(unittest.TestCase):
                 "max_sessions": 5,
                 "max_tasks": 3,
                 "target_skill_path": ".agents/skills/taste-skill/SKILL.md",
+                "preferences": "Always use async/await",
                 "progress": True,
                 "auto_adopt": False,
             })
@@ -206,6 +207,7 @@ class TestHarvest(unittest.TestCase):
             cfg = _cfg_from_args(Args())
 
             self.assertEqual(cfg.get("backend"), "codex")
+            self.assertEqual(cfg.get("preferences"), "Always use async/await")
             self.assertEqual(cfg.get("max_sessions_per_night"), 5)
             self.assertEqual(cfg.get("max_tasks_per_night"), 3)
             self.assertTrue(cfg.get("progress"))


### PR DESCRIPTION
## Problem

`--preferences` is documented but not wired up:

- `plugins/README.md` advertises it (`### --preferences "..." — tell it your house rules`, flag table row, three examples)
- `skillopt_sleep/backend.py` already supports it: `preferences: str = ""` attribute, injected into the reflect prompt as a "User preferences" prior block

But the plumbing between the CLI and the backend is missing, so:

```console
$ skillopt-sleep run --preferences "no emoji"
skillopt_sleep run: error: unrecognized arguments: --preferences no emoji
# exit code 2
```

Setting `"preferences"` in the config file is silently ignored for the same reason — nothing copies it onto the backend.

Real-world use: my cron-driven cycle sets `"preferences": "caveman-terse; keep why/gotcha/SHA; no emoji"` in the config file — without it, every night's learned rules come out verbose and get hand-edited back; with it, the optimiser writes rules in house style on the first pass.

## Fix

6 lines, following the existing pattern used by `--edit-budget` / `--max-sessions`:

- `__main__.py` — add `--preferences` to the common args, map it into overrides in `_cfg_from_args`
- `config.py` — add `"preferences": ""` default (so config-file usage works too)
- `cycle.py` — set `backend.preferences = cfg.get("preferences", "")` when the backend is constructed in `run_sleep_cycle`

## Testing

- Updated `test_cli_exposes_limits_progress_and_target_skill_path` to assert the flag lands in config
- Running nightly with this patch since 2026-07-07 (config-file `preferences`); the reflect step honours the prior