### PR TITLE
fix(model): prevent Codex token double counting

### DIFF
--- a/skillopt/model/codex_backend.py
+++ b/skillopt/model/codex_backend.py
@@ -12,13 +12,13 @@ import uuid
 from typing import Any
 from urllib.parse import unquote, urlparse
 
+from skillopt.model.backend_config import get_codex_exec_config
 from skillopt.model.common import (
     CompatAssistantMessage,
     CompatToolCall,
     CompatToolFunction,
-    tracker,
+    TokenTracker,
 )
-from skillopt.model.backend_config import get_codex_exec_config
 
 
 CODEX_BIN = os.environ.get("CODEX_CLI_BIN", "codex")
@@ -29,6 +29,7 @@ OPTIMIZER_DEPLOYMENT = os.environ.get("OPTIMIZER_DEPLOYMENT", "gpt-4o")
 TARGET_DEPLOYMENT = os.environ.get("TARGET_DEPLOYMENT", "gpt-4o")
 
 REASONING_EFFORT: str | None = None
+tracker = TokenTracker()
 
 
 def _default_working_directory() -> str:

--- a/tests/test_codex_optimizer_backend.py
+++ b/tests/test_codex_optimizer_backend.py
@@ -251,6 +251,35 @@ def test_token_summary_merges_codex_once_with_existing_backends(
     assert summary["_total"]["total_tokens"] == 36
 
 
+def test_codex_usage_is_not_double_counted_by_shared_tracker(
+    isolate_backend_state: tuple[Any, Any, Any, Any],
+) -> None:
+    model_module, _backend_config, codex_backend, _azure_openai = isolate_backend_state
+    from skillopt.model import claude_backend
+
+    model_module.reset_token_tracker()
+    try:
+        assert codex_backend.tracker is not claude_backend.tracker
+
+        codex_backend.tracker.record("optimizer", 11, 13)
+        summary = model_module.get_token_summary()
+
+        assert summary["optimizer"] == {
+            "calls": 1,
+            "prompt_tokens": 11,
+            "completion_tokens": 13,
+            "total_tokens": 24,
+        }
+        assert summary["_total"] == {
+            "calls": 1,
+            "prompt_tokens": 11,
+            "completion_tokens": 13,
+            "total_tokens": 24,
+        }
+    finally:
+        model_module.reset_token_tracker()
+
+
 def test_reset_token_tracker_resets_codex_and_existing_backends(
     monkeypatch: pytest.MonkeyPatch,
     isolate_backend_state: tuple[Any, Any, Any, Any],


### PR DESCRIPTION
## Summary

- give the Codex backend its own TokenTracker
- prevent Claude and Codex summaries from aggregating the same shared tracker twice
- add a non-mocked regression test that records one Codex call and requires exactly one aggregate call

## Root cause

PR #112 added Codex as an optimizer and correctly aggregated its token summary, but Claude and Codex both referenced the same tracker from model.common. Aggregating both backend summaries therefore doubled calls and token totals.

## Verification

- 13 Codex optimizer tests passed
- full suite: 313 passed, 6 skipped
- git diff --check passed
- independent read-only Claude Opus review found no blockers