### PR TITLE
feat(devin): expose handoff backend in MCP server enum

### DIFF
--- a/plugins/devin/README.md
+++ b/plugins/devin/README.md
@@ -62,9 +62,12 @@ Requires Python ≥ 3.10. No third-party packages — the server is pure stdlib.
 | `sleep_unschedule` | remove the nightly cron entry |
 
 Default backend is `mock` (no API spend); the `claude`, `codex`, and `copilot`
-backends use the corresponding authenticated CLI and budget. The seven tools
-call the same `python -m skillopt_sleep` actions as the other shared-engine
-integrations.
+backends use the corresponding authenticated CLI and budget. The `handoff`
+backend runs the cycle with no model subprocess or API key — the engine writes
+pending model calls to `.skillopt-sleep-handoff/PROMPTS.md` + `pending.json`
+(exit code 3) and resumes after answers are placed in `answers/<id>.md`; re-run
+`sleep_run` with the same arguments to resume. The seven tools call the same
+`python -m skillopt_sleep` actions as the other shared-engine integrations.
 
 ## Data boundary
 

--- a/plugins/devin/devin-rules.snippet.md
+++ b/plugins/devin/devin-rules.snippet.md
@@ -24,7 +24,10 @@ Always pass the absolute Devin workspace as `project`, especially for
 `sleep_adopt`. Default backend is `mock` (no provider calls). The `claude`,
 `codex`, and `copilot` backend values use the corresponding installed and
 authenticated CLI; they do not require this plugin to implement a separate
-API-key flow.
+API-key flow. The `handoff` backend runs the cycle with no model subprocess
+or API key — the engine writes pending model calls to
+`.skillopt-sleep-handoff/` and exits; answer each prompt in a fresh context
+and re-run `sleep_run` to resume (typically 3–6 rounds).
 
 The Devin conversion and mock workflow stay local. A real backend sends
 truncated transcript excerpts and derived tasks to the selected provider for

--- a/plugins/devin/mcp_server.py
+++ b/plugins/devin/mcp_server.py
@@ -62,8 +62,8 @@ _TOOL_SCHEMA = {
     "properties": {
         "project": {"type": "string",
                     "description": "Project dir to evolve (default: cwd)."},
-        "backend": {"type": "string", "enum": ["mock", "claude", "codex", "copilot"],
-                    "description": "mock = no API spend (default); claude/codex/copilot = real."},
+        "backend": {"type": "string", "enum": ["mock", "claude", "codex", "copilot", "handoff"],
+                    "description": "mock = no API spend (default); claude/codex/copilot = real; handoff = session answers prompts, no API subprocess."},
         "scope": {"type": "string", "enum": ["invoked", "all"],
                   "description": "Harvest scope (default: invoked project only)."},
         "source": {"type": "string", "enum": ["claude", "codex", "auto"],

--- a/tests/test_devin_plugin.py
+++ b/tests/test_devin_plugin.py
@@ -46,7 +46,7 @@ class TestDevinMcpSchema(unittest.TestCase):
 
     def test_backends_in_enum(self):
         backends = mcp_server._TOOL_SCHEMA["properties"]["backend"]["enum"]
-        for b in ["mock", "claude", "codex", "copilot"]:
+        for b in ["mock", "claude", "codex", "copilot", "handoff"]:
             self.assertIn(b, backends)
 
     def test_schema_has_key_engine_params(self):
@@ -64,6 +64,10 @@ class TestClaudeHomeExpansion(unittest.TestCase):
     (the documented mcp-config sets SKILLOPT_DEVIN_CLAUDE_HOME="~/...")."""
 
     def test_env_tilde_is_expanded(self):
+        # Re-insert the devin plugin path at position 0 so importlib.reload
+        # picks up this module, not plugins/copilot/mcp_server.py when both
+        # test modules are loaded in the same process.
+        sys.path.insert(0, PLUGIN)
         os.environ["SKILLOPT_DEVIN_CLAUDE_HOME"] = "~/.skillopt-sleep-devin"
         try:
             importlib.reload(mcp_server)


### PR DESCRIPTION
## Summary
- Add `handoff` to the Devin MCP server's backend enum so `sleep_run` accepts `backend: "handoff"`
- The engine already supports handoff (merged in #125), but the Devin MCP schema excluded it — making the subscription-friendly, no-API-key path unavailable to Devin users while Claude Code had a dedicated `/skillopt-sleep-handoff` command
- Update README, rules snippet, and test_backends_in_enum accordingly
- Fix a pre-existing test isolation bug: `importlib.reload(mcp_server)` in `test_devin_plugin.py` picks up copilot's `mcp_server.py` when `test_mcp_schema.py` is loaded in the same process (both insert their plugin path at sys.path[0]). Re-insert the devin path before reload.

#### Test plan
- [x] `python -m unittest tests.test_devin_plugin tests.test_mcp_schema` — all 9 tests pass
- [x] Macroscope review clean (0 issues on the 4-file diff)