### PR TITLE
fix(sleep): isolate Cursor backend environment

### DIFF
--- a/plugins/cursor/README.md
+++ b/plugins/cursor/README.md
@@ -146,7 +146,10 @@ counts before the first stateful run; neither action advances the checkpoint.
 `--cursor-path /path/to/cursor-agent` or `SKILLOPT_SLEEP_CURSOR_PATH` if it is
 not on PATH, and `--model` or `SKILLOPT_SLEEP_CURSOR_MODEL` to override its
 model. Check available identifiers with `cursor-agent --list-models` and verify
-the billed variant in Cursor's usage reporting when cost matters.
+the billed variant in Cursor's usage reporting when cost matters. The child
+process receives only an explicit runtime/authentication/locale/proxy/CA
+environment allowlist; unrelated cloud and model-provider credentials are not
+forwarded.
 
 ## What Cursor replay evaluates
 

--- a/skillopt_sleep/backend.py
+++ b/skillopt_sleep/backend.py
@@ -1258,6 +1258,21 @@ class CursorCliBackend(CliBackend):
         "invalid configuration",
     )
     _ASK_DENY = ["Read(**)", "Write(**)", "Mcp(*:*)"]
+    # Keep the Cursor child usable across shells, credential stores, proxies,
+    # and enterprise CA setups without forwarding unrelated provider or cloud
+    # credentials from the host process.
+    _ENV_ALLOWLIST = (
+        "PATH", "HOME", "USER", "LOGNAME", "SHELL",
+        "USERPROFILE", "HOMEDRIVE", "HOMEPATH",
+        "SYSTEMROOT", "SystemRoot", "WINDIR", "COMSPEC", "PATHEXT",
+        "TMPDIR", "TMP", "TEMP",
+        "LANG", "LANGUAGE", "LC_ALL", "LC_CTYPE", "TERM", "NO_COLOR",
+        "CURSOR_API_KEY",
+        "DBUS_SESSION_BUS_ADDRESS", "XDG_RUNTIME_DIR",
+        "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
+        "http_proxy", "https_proxy", "all_proxy", "no_proxy",
+        "SSL_CERT_FILE", "SSL_CERT_DIR", "NODE_EXTRA_CA_CERTS",
+    )
 
     def __init__(self, model: str = "", cursor_path: str = "", timeout: int = 240) -> None:
         super().__init__(model=model or os.environ.get("SKILLOPT_SLEEP_CURSOR_MODEL", ""), timeout=timeout)
@@ -1343,7 +1358,11 @@ class CursorCliBackend(CliBackend):
                 f,
                 indent=2,
             )
-        env = os.environ.copy()
+        env = {
+            key: os.environ[key]
+            for key in CursorCliBackend._ENV_ALLOWLIST
+            if key in os.environ
+        }
         env["CURSOR_CONFIG_DIR"] = config_dir
         env["CURSOR_DATA_DIR"] = data_dir
         return env

--- a/tests/test_sleep_engine.py
+++ b/tests/test_sleep_engine.py
@@ -1604,6 +1604,34 @@ class TestCursorBackend(unittest.TestCase):
             "",
         )
 
+    def test_cursor_environment_keeps_runtime_auth_and_drops_unrelated_secrets(self):
+        from skillopt_sleep.backend import CursorCliBackend
+
+        host_env = {
+            "PATH": "/usr/bin",
+            "LANG": "en_US.UTF-8",
+            "CURSOR_API_KEY": "cursor-auth",
+            "HTTPS_PROXY": "https://proxy.example",
+            "AWS_SECRET_ACCESS_KEY": "aws-secret",
+            "OPENAI_API_KEY": "openai-secret",
+            "ANTHROPIC_API_KEY": "anthropic-secret",
+            "GITHUB_TOKEN": "github-secret",
+        }
+        with tempfile.TemporaryDirectory() as runtime_dir:
+            with mock.patch.dict(os.environ, host_env, clear=True):
+                env = CursorCliBackend._isolated_environment(runtime_dir)
+
+            self.assertEqual(env["PATH"], "/usr/bin")
+            self.assertEqual(env["LANG"], "en_US.UTF-8")
+            self.assertEqual(env["CURSOR_API_KEY"], "cursor-auth")
+            self.assertEqual(env["HTTPS_PROXY"], "https://proxy.example")
+            self.assertNotIn("AWS_SECRET_ACCESS_KEY", env)
+            self.assertNotIn("OPENAI_API_KEY", env)
+            self.assertNotIn("ANTHROPIC_API_KEY", env)
+            self.assertNotIn("GITHUB_TOKEN", env)
+            self.assertTrue(env["CURSOR_CONFIG_DIR"].startswith(runtime_dir))
+            self.assertTrue(env["CURSOR_DATA_DIR"].startswith(runtime_dir))
+
     def test_nonzero_and_error_results_fail_once_with_redacted_diagnostics(self):
         from skillopt_sleep.backend import CursorBackendError, CursorCliBackend
 


### PR DESCRIPTION
## Summary

- replace full host environment inheritance in Cursor Ask-mode calls with an explicit runtime/auth/locale/proxy/CA allowlist
- retain CURSOR_API_KEY and cross-platform process requirements
- prevent unrelated AWS, OpenAI, Anthropic, and GitHub credentials from reaching Cursor subprocesses
- document the boundary and add regression coverage

## Validation

- focused Sleep/plugin suite: 99 passed, 1 skipped
- full suite: 352 passed, 6 skipped
- git diff --check: passed
- Claude Code Opus 4.8 independent review: no merge blocker