### PR TITLE
fix(sleep): surface silent rule-judge and edit failures

### DIFF
--- a/skillopt_sleep/consolidate.py
+++ b/skillopt_sleep/consolidate.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 from skillopt_sleep.backend import Backend
-from skillopt_sleep.memory import apply_edits
+from skillopt_sleep.memory import apply_edits_detailed
 from skillopt_sleep.replay import aggregate_scores, replay_batch
 from skillopt_sleep.types import EditRecord, ReplayResult, TaskRecord
 
@@ -37,6 +37,11 @@ class ConsolidationResult:
     holdout_baseline: float
     holdout_candidate: float
     # ── observability (so a 0.0->0.0 night is self-diagnosing, not a black box) ──
+    # Edits that changed nothing (anchor not found, or a duplicate add). They are
+    # neither applied nor gate-rejected, so without this list they would vanish
+    # from the report and the night would look like the optimizer produced less
+    # than it did.
+    unmatched_edits: List[EditRecord] = field(default_factory=list)
     holdout_detail: List[dict] = field(default_factory=list)  # per val task: hard/soft/resp/why
     reflect_raw: str = ""        # the optimizer's last raw reply (empty => reflect produced nothing)
     call_error: str = ""         # backend's last call error (timeout/auth/empty)
@@ -143,6 +148,7 @@ def consolidate(
     cand_skill, cand_memory = skill, memory
     all_applied: List[EditRecord] = []
     all_rejected: List[EditRecord] = []
+    all_unmatched: List[EditRecord] = []
 
     def _edits_payload(edits: List[EditRecord]) -> List[dict]:
         return [{"op": e.op, "content": e.content, "anchor": e.anchor,
@@ -155,7 +161,12 @@ def consolidate(
                    n_edits=len(edits), edits=_edits_payload(edits))
         if not edits:
             return doc
-        new_doc, applied = apply_edits(doc, edits)
+        new_doc, applied, unmatched = apply_edits_detailed(doc, edits)
+        if unmatched:
+            all_unmatched.extend(unmatched)
+            if ev is not None:
+                ev.log("reflect", "edits_unmatched", target=which,
+                       n_edits=len(unmatched), edits=_edits_payload(unmatched))
         if not applied:
             return doc
         # gate OFF: accept greedily with NO val scoring (the daily-use path)
@@ -277,6 +288,13 @@ def consolidate(
         else:
             action = "accept" if final_score > base_gate_score else "reject"
             accepted = bool(all_applied) and final_score > base_gate_score
+        # The gate scores documents, not edit bookkeeping: when every proposed
+        # edit was dropped during the per-target trials, `all_applied` is empty
+        # and nothing changed, yet the score comparison can still yield an
+        # accept-flavoured action. Reporting that as "accept_new_best" while
+        # `accepted` is False makes the headline contradict the outcome.
+        if not accepted and action in {"accept", "accept_new_best"}:
+            action = "reject"
 
     if ev is not None:
         w = max(0.0, min(1.0, float(gate_mixed_weight)))
@@ -297,7 +315,8 @@ def consolidate(
                candidate_hard=final_hard, candidate_soft=final_soft,
                metric=gate_metric, mixed_weight=gate_mixed_weight,
                formula=formula, n_applied=len(all_applied),
-               n_rejected=len(all_rejected), night=night)
+               n_rejected=len(all_rejected),
+               n_unmatched=len(all_unmatched), night=night)
 
     return ConsolidationResult(
         accepted=accepted,
@@ -308,6 +327,7 @@ def consolidate(
         new_memory=cand_memory if accepted else memory,
         applied_edits=all_applied,
         rejected_edits=all_rejected,
+        unmatched_edits=all_unmatched,
         holdout_baseline=base_hard,
         holdout_candidate=final_hard,
         holdout_detail=holdout_detail,

--- a/skillopt_sleep/cycle.py
+++ b/skillopt_sleep/cycle.py
@@ -96,6 +96,15 @@ def _render_report_md(report: SleepReport, cfg: SleepConfig) -> str:
         for e in report.rejected_edits:
             lines.append(f"- [{e.target}/{e.op}] {e.content}")
         lines.append("")
+    if report.unmatched_edits:
+        lines.append("## Proposed but changed nothing (never reached the gate)")
+        lines.append(
+            "_Anchor not found, duplicate/empty add, or an unknown op. "
+            "These were never scored — check the anchor text if a rule you expected is missing._")
+        for e in report.unmatched_edits:
+            anchor = f"  \n  _anchor: `{e.anchor}`_" if e.anchor else ""
+            lines.append(f"- [{e.target}/{e.op}] {e.content}{anchor}")
+        lines.append("")
     if report.notes:
         lines.append("## Notes")
         for n in report.notes:
@@ -338,7 +347,8 @@ def run_sleep_cycle(
     _progress(
         cfg,
         f"consolidate done: gate={result.gate_action} accepted={result.accepted} "
-        f"edits={len(result.applied_edits)} rejected={len(result.rejected_edits)}",
+        f"edits={len(result.applied_edits)} rejected={len(result.rejected_edits)}"
+        + (f" unmatched={len(result.unmatched_edits)}" if result.unmatched_edits else ""),
     )
 
     report.n_replayed = len(tasks)
@@ -349,6 +359,7 @@ def run_sleep_cycle(
     report.no_edits_reason = getattr(result, "no_edits_reason", "")
     report.edits = result.applied_edits
     report.rejected_edits = result.rejected_edits
+    report.unmatched_edits = result.unmatched_edits
     report.tokens_used = backend.tokens_used()
     report.ended_at = _now_iso(clock)
 
@@ -395,6 +406,7 @@ def run_sleep_cycle(
                     "accepted": result.accepted,
                     "n_applied_edits": len(result.applied_edits),
                     "n_rejected_edits": len(result.rejected_edits),
+                    "n_unmatched_edits": len(result.unmatched_edits),
                     "call_error": redact_secrets(getattr(result, "call_error", "")),
                     "reflect_raw_head": redact_secrets(
                         (getattr(result, "reflect_raw", "") or "")[:1200]
@@ -422,6 +434,7 @@ def run_sleep_cycle(
                candidate_score=report.candidate_score,
                n_applied_edits=len(report.edits),
                n_rejected_edits=len(report.rejected_edits),
+               n_unmatched_edits=len(report.unmatched_edits),
                tokens_used=report.tokens_used, adopted=adopted)
 
     return CycleOutcome(report, staging_dir, adopted, adopted_paths)

--- a/skillopt_sleep/judges.py
+++ b/skillopt_sleep/judges.py
@@ -35,29 +35,76 @@ def _section_present(response: str, name: str) -> bool:
     return bool(label.search(response or ""))
 
 
-def _check(op: str, arg: Any, response: str, tools_called: List[str]) -> bool:
+def _check(op: str, arg: Any, response: str,
+           tools_called: List[str]) -> Tuple[bool, str]:
+    """Evaluate one check.
+
+    Returns ``(passed, problem)``. ``problem`` is non-empty only when the check
+    itself is malformed (e.g. an unparseable regex) rather than simply unmet —
+    the two need opposite fixes, so they must not look alike in the rationale.
+    """
     r = response or ""
     if op == "section_present":
-        return _section_present(r, str(arg))
+        return _section_present(r, str(arg)), ""
     if op == "regex":
         try:
-            return bool(re.search(str(arg), r))
-        except re.error:
-            return False
+            return bool(re.search(str(arg), r)), ""
+        except re.error as exc:
+            # A malformed pattern can never match, so it would fail every
+            # rollout forever and read exactly like a model that never
+            # complies. Surface it instead of hiding it behind a False.
+            return False, f"invalid regex ({exc})"
     if op == "max_chars":
-        return len(r) <= int(arg)
+        return len(r) <= int(arg), ""
     if op == "min_chars":
-        return len(r) >= int(arg)
+        return len(r) >= int(arg), ""
     if op == "contains":
-        return str(arg).lower() in r.lower()
+        return str(arg).lower() in r.lower(), ""
     if op == "tool_called":
         name = str(arg).lower()
         if any(name == t.lower() for t in tools_called):
-            return True
+            return True, ""
         # single-shot approximation: the agent emits an explicit marker
-        return bool(re.search(r"(?i)\btool_call\s*:\s*%s\b" % re.escape(name), r))
+        return bool(re.search(r"(?i)\btool_call\s*:\s*%s\b" % re.escape(name), r)), ""
     # unknown op: do not block
-    return True
+    return True, ""
+
+
+KNOWN_OPS = frozenset({
+    "section_present", "regex", "max_chars", "min_chars", "contains", "tool_called",
+})
+
+
+def validate_checks(judge: Dict[str, Any]) -> Tuple[List[str], List[str]]:
+    """Return ``(errors, warnings)`` for a rule judge's checks.
+
+    An *error* means the check can never behave as written — a regex that does
+    not compile always scores 0.0, which is indistinguishable from a model that
+    never complies. A *warning* means the check is accepted but toothless, e.g.
+    an unknown op, which :func:`_check` deliberately lets pass.
+    """
+    errors: List[str] = []
+    warnings: List[str] = []
+    checks = (judge or {}).get("checks", []) or []
+    for i, c in enumerate(checks):
+        if not isinstance(c, dict):
+            errors.append(f"check #{i} is not an object")
+            continue
+        op = c.get("op", "")
+        arg = c.get("arg")
+        if op == "regex":
+            try:
+                re.compile(str(arg))
+            except re.error as exc:
+                errors.append(f"check #{i} regex does not compile ({exc}): {arg!r}")
+        elif op in {"max_chars", "min_chars"}:
+            try:
+                int(arg)
+            except (TypeError, ValueError):
+                errors.append(f"check #{i} {op} needs an integer arg, got {arg!r}")
+        elif op not in KNOWN_OPS:
+            warnings.append(f"check #{i} has unknown op {op!r} — it always passes")
+    return errors, warnings
 
 
 def score_rule_judge(
@@ -73,11 +120,14 @@ def score_rule_judge(
     passed = 0
     failed_desc: List[str] = []
     for c in checks:
-        ok = _check(c.get("op", ""), c.get("arg"), response, tools_called)
+        ok, problem = _check(c.get("op", ""), c.get("arg"), response, tools_called)
         if ok:
             passed += 1
         else:
-            failed_desc.append(f"{c.get('op')}={c.get('arg')}")
+            desc = f"{c.get('op')}={c.get('arg')}"
+            if problem:
+                desc += f" [{problem}]"
+            failed_desc.append(desc)
     soft = passed / len(checks)
     hard = 1.0 if passed == len(checks) else 0.0
     rationale = "all checks passed" if hard else "failed: " + ", ".join(failed_desc)

--- a/skillopt_sleep/judges.py
+++ b/skillopt_sleep/judges.py
@@ -85,7 +85,11 @@ def validate_checks(judge: Dict[str, Any]) -> Tuple[List[str], List[str]]:
     """
     errors: List[str] = []
     warnings: List[str] = []
+    if judge and not isinstance(judge, dict):
+        return [f"judge must be an object, got {type(judge).__name__}"], warnings
     checks = (judge or {}).get("checks", []) or []
+    if not isinstance(checks, list):
+        return [f"judge 'checks' must be an array, got {type(checks).__name__}"], warnings
     for i, c in enumerate(checks):
         if not isinstance(c, dict):
             errors.append(f"check #{i} is not an object")

--- a/skillopt_sleep/memory.py
+++ b/skillopt_sleep/memory.py
@@ -90,11 +90,16 @@ def apply_edits_detailed(
     """Apply edits and also report the ones that matched nothing.
 
     Returns ``(new_doc, applied, unmatched)``. An edit lands in ``unmatched``
-    when it changed nothing: a `delete`/`replace` whose anchor is absent, or an
-    `add` that duplicates an existing line. Without this list such edits are
-    invisible — they appear in neither the applied nor the gate-rejected set,
-    so a night can report zero edits while the optimizer actually produced
-    several.
+    whenever it left the document unchanged:
+
+    * ``delete``/``replace`` whose anchor matches no existing line;
+    * ``add`` whose content duplicates an existing line (normalized), or is
+      empty/whitespace;
+    * any unrecognized op.
+
+    Without this list such edits are invisible — they appear in neither the
+    applied nor the gate-rejected set, so a night can report zero edits while
+    the optimizer actually produced several.
     """
     lines = current_learned_lines(doc)
     norm_set = {_norm(line) for line in lines}

--- a/skillopt_sleep/memory.py
+++ b/skillopt_sleep/memory.py
@@ -76,15 +76,36 @@ def apply_edits(doc: str, edits: List[EditRecord]) -> Tuple[str, List[EditRecord
     Returns (new_doc, applied_edits). Dedups: an `add` whose content already
     exists (normalized) is skipped. `delete`/`replace` match on normalized
     anchor substring.
+
+    See :func:`apply_edits_detailed` when the caller also needs the edits that
+    matched nothing.
+    """
+    new_doc, applied, _unmatched = apply_edits_detailed(doc, edits)
+    return new_doc, applied
+
+
+def apply_edits_detailed(
+    doc: str, edits: List[EditRecord]
+) -> Tuple[str, List[EditRecord], List[EditRecord]]:
+    """Apply edits and also report the ones that matched nothing.
+
+    Returns ``(new_doc, applied, unmatched)``. An edit lands in ``unmatched``
+    when it changed nothing: a `delete`/`replace` whose anchor is absent, or an
+    `add` that duplicates an existing line. Without this list such edits are
+    invisible — they appear in neither the applied nor the gate-rejected set,
+    so a night can report zero edits while the optimizer actually produced
+    several.
     """
     lines = current_learned_lines(doc)
     norm_set = {_norm(line) for line in lines}
     applied: List[EditRecord] = []
+    unmatched: List[EditRecord] = []
 
     for e in edits:
         op = (e.op or "add").lower()
         if op == "add":
             if _norm(e.content) in norm_set or not e.content.strip():
+                unmatched.append(e)
                 continue
             lines.append(e.content.strip())
             norm_set.add(_norm(e.content))
@@ -96,6 +117,8 @@ def apply_edits(doc: str, edits: List[EditRecord]) -> Tuple[str, List[EditRecord
                 lines = keep
                 norm_set = {_norm(line) for line in lines}
                 applied.append(e)
+            else:
+                unmatched.append(e)
         elif op == "replace":
             anchor = _norm(e.anchor)
             new_lines = []
@@ -110,8 +133,12 @@ def apply_edits(doc: str, edits: List[EditRecord]) -> Tuple[str, List[EditRecord
                 lines = new_lines
                 norm_set = {_norm(line) for line in lines}
                 applied.append(e)
+            else:
+                unmatched.append(e)
+        else:
+            unmatched.append(e)
 
-    return set_learned(doc, lines), applied
+    return set_learned(doc, lines), applied, unmatched
 
 
 def ensure_skill_scaffold(doc: str, *, name: str, description: str) -> str:

--- a/skillopt_sleep/tasks_file.py
+++ b/skillopt_sleep/tasks_file.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from typing import Any, Dict, List, Tuple
 
+from skillopt_sleep.judges import validate_checks
 from skillopt_sleep.mine import assign_splits, normalize_legacy_split
 from skillopt_sleep.types import TaskRecord
 
@@ -78,4 +80,21 @@ def load_tasks_file(
         if not isinstance(item, dict):
             raise ValueError("each task entry must be a JSON object")
         tasks.append(TaskRecord.from_dict(item))
+
+    # Fail loudly on malformed rule judges. A check that cannot work as written
+    # scores 0.0 on every rollout, which reads exactly like a model that never
+    # complies — the run looks legitimate while one dimension is dead.
+    errors: List[str] = []
+    for task in tasks:
+        if task.reference_kind != "rule" or not task.judge:
+            continue
+        task_errors, task_warnings = validate_checks(task.judge)
+        errors.extend(f"task {task.id}: {e}" for e in task_errors)
+        for w in task_warnings:
+            print(f"[sleep] warning: task {task.id}: {w}", file=sys.stderr)
+    if errors:
+        raise ValueError(
+            "tasks file contains unusable rule checks:\n  " + "\n  ".join(errors)
+        )
+
     return _normalize_tasks(tasks, holdout_fraction=holdout_fraction, seed=seed), meta

--- a/skillopt_sleep/types.py
+++ b/skillopt_sleep/types.py
@@ -138,6 +138,11 @@ class SleepReport:
     no_edits_reason: str = ""
     edits: List[EditRecord] = field(default_factory=list)
     rejected_edits: List[EditRecord] = field(default_factory=list)
+    # Proposed edits that changed nothing (anchor absent, duplicate/empty add,
+    # unknown op). They were never scored by the gate, so they belong in neither
+    # list above — without them a night can report no edits while the optimizer
+    # actually produced several.
+    unmatched_edits: List[EditRecord] = field(default_factory=list)
     tokens_used: int = 0
     notes: List[str] = field(default_factory=list)
 

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -1,0 +1,117 @@
+"""Tests for skillopt_sleep.judges — the rule judge that decides every night.
+
+Focus: a malformed check must never be indistinguishable from an unmet one.
+A regex that does not compile returns False on every rollout, so the affected
+dimension scores 0.0 forever while the run still looks healthy.
+"""
+import unittest
+
+from skillopt_sleep.judges import KNOWN_OPS, score_rule_judge, validate_checks
+
+
+class TestCheckOperators(unittest.TestCase):
+    def _score(self, op, arg, response, tools=None):
+        return score_rule_judge({"kind": "rule", "checks": [{"op": op, "arg": arg}]},
+                                response, tools or [])
+
+    def test_contains_is_case_insensitive(self) -> None:
+        self.assertEqual(self._score("contains", "Key Risks", "the KEY RISKS section")[0], 1.0)
+
+    def test_regex_matches(self) -> None:
+        self.assertEqual(self._score("regex", r"\d+\.\d+", "see 7.4 for details")[0], 1.0)
+
+    def test_min_and_max_chars(self) -> None:
+        self.assertEqual(self._score("min_chars", 5, "abcdef")[0], 1.0)
+        self.assertEqual(self._score("min_chars", 50, "abcdef")[0], 0.0)
+        self.assertEqual(self._score("max_chars", 5, "abcdef")[0], 0.0)
+
+    def test_section_present_accepts_heading_and_bold_and_label(self) -> None:
+        for text in ("## Key Risks", "**Key Risks:**", "Key Risks: something"):
+            self.assertEqual(self._score("section_present", "Key Risks", text)[0], 1.0, text)
+
+    def test_tool_called_via_marker(self) -> None:
+        self.assertEqual(self._score("tool_called", "search", "TOOL_CALL: search")[0], 1.0)
+        self.assertEqual(self._score("tool_called", "search", "nope", ["search"])[0], 1.0)
+
+    def test_unknown_op_does_not_block(self) -> None:
+        self.assertEqual(self._score("no_such_op", "x", "anything")[0], 1.0)
+
+
+class TestSoftAndHardScoring(unittest.TestCase):
+    def test_soft_is_fraction_and_hard_is_all_or_nothing(self) -> None:
+        judge = {"kind": "rule", "checks": [
+            {"op": "contains", "arg": "alpha"},
+            {"op": "contains", "arg": "beta"},
+            {"op": "contains", "arg": "gamma"},
+        ]}
+        hard, soft, why = score_rule_judge(judge, "alpha and beta only")
+        self.assertEqual(hard, 0.0)
+        self.assertAlmostEqual(soft, 2 / 3)
+        self.assertIn("gamma", why)
+
+    def test_empty_checks_score_zero(self) -> None:
+        self.assertEqual(score_rule_judge({"kind": "rule", "checks": []}, "x")[:2], (0.0, 0.0))
+
+
+class TestMalformedRegexIsDistinguishable(unittest.TestCase):
+    """A pattern Python cannot parse must not read like a plain miss."""
+
+    BAD = r"(?i)foo|(?i)bar"  # inline flag not at the start -> re.error
+
+    def test_bad_pattern_still_fails_closed(self) -> None:
+        # the response does contain both alternatives; the pattern is the problem
+        hard, soft, _why = score_rule_judge(
+            {"kind": "rule", "checks": [{"op": "regex", "arg": self.BAD}]}, "foo bar")
+        self.assertEqual(hard, 0.0)
+        self.assertEqual(soft, 0.0)
+
+    def test_rationale_names_the_pattern_as_invalid(self) -> None:
+        _hard, _soft, why = score_rule_judge(
+            {"kind": "rule", "checks": [{"op": "regex", "arg": self.BAD}]}, "foo bar")
+        self.assertIn("invalid regex", why)
+
+    def test_a_genuine_miss_is_not_labelled_invalid(self) -> None:
+        _hard, _soft, why = score_rule_judge(
+            {"kind": "rule", "checks": [{"op": "regex", "arg": r"zzz"}]}, "foo bar")
+        self.assertNotIn("invalid regex", why)
+
+
+class TestValidateChecks(unittest.TestCase):
+    def test_sound_checks_produce_nothing(self) -> None:
+        errors, warnings = validate_checks({"checks": [
+            {"op": "regex", "arg": r"^\s*SKILL:"},
+            {"op": "min_chars", "arg": 10},
+            {"op": "section_present", "arg": "Risks"},
+        ]})
+        self.assertEqual(errors, [])
+        self.assertEqual(warnings, [])
+
+    def test_uncompilable_regex_is_an_error(self) -> None:
+        errors, _warnings = validate_checks({"checks": [{"op": "regex", "arg": r"(?i)a|(?i)b"}]})
+        self.assertEqual(len(errors), 1)
+        self.assertIn("does not compile", errors[0])
+
+    def test_non_integer_char_bound_is_an_error(self) -> None:
+        errors, _warnings = validate_checks({"checks": [{"op": "max_chars", "arg": "many"}]})
+        self.assertEqual(len(errors), 1)
+        self.assertIn("integer", errors[0])
+
+    def test_unknown_op_is_only_a_warning(self) -> None:
+        errors, warnings = validate_checks({"checks": [{"op": "vibes", "arg": 1}]})
+        self.assertEqual(errors, [])
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("always passes", warnings[0])
+
+    def test_non_object_check_is_an_error(self) -> None:
+        errors, _warnings = validate_checks({"checks": ["not-an-object"]})
+        self.assertEqual(len(errors), 1)
+
+    def test_every_known_op_is_accepted(self) -> None:
+        for op in KNOWN_OPS:
+            arg = 1 if op.endswith("_chars") else "x"
+            errors, warnings = validate_checks({"checks": [{"op": op, "arg": arg}]})
+            self.assertEqual((errors, warnings), ([], []), op)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -106,6 +106,22 @@ class TestValidateChecks(unittest.TestCase):
         errors, _warnings = validate_checks({"checks": ["not-an-object"]})
         self.assertEqual(len(errors), 1)
 
+    def test_malformed_judge_is_reported_not_raised(self) -> None:
+        # a tasks file may carry any JSON here; validation must stay structured
+        for bad in (["not", "a", "dict"], "a string", 42):
+            errors, _warnings = validate_checks(bad)
+            self.assertEqual(len(errors), 1, bad)
+            self.assertIn("must be an object", errors[0])
+
+    def test_non_list_checks_is_reported_not_raised(self) -> None:
+        errors, _warnings = validate_checks({"checks": "regex"})
+        self.assertEqual(len(errors), 1)
+        self.assertIn("must be an array", errors[0])
+
+    def test_empty_or_missing_judge_is_sound(self) -> None:
+        for empty in ({}, None, {"checks": []}):
+            self.assertEqual(validate_checks(empty), ([], []), empty)
+
     def test_every_known_op_is_accepted(self) -> None:
         for op in KNOWN_OPS:
             arg = 1 if op.endswith("_chars") else "x"

--- a/tests/test_unmatched_edits.py
+++ b/tests/test_unmatched_edits.py
@@ -60,6 +60,13 @@ class TestUnmatchedEdits(unittest.TestCase):
         self.assertEqual(applied, [e])
         self.assertIn("another rule", new_doc)
 
+    def test_unknown_op_is_unmatched(self) -> None:
+        doc = _doc("existing rule")
+        e = EditRecord(target="skill", op="rewrite-everything", content="x")
+        new_doc, applied, unmatched = apply_edits_detailed(doc, [e])
+        self.assertEqual((applied, unmatched), ([], [e]))
+        self.assertEqual(new_doc, doc)
+
     def test_hand_written_body_is_never_touched(self) -> None:
         doc = _doc("existing rule")
         e = EditRecord(target="skill", op="replace", content="x", anchor="hand-written body")

--- a/tests/test_unmatched_edits.py
+++ b/tests/test_unmatched_edits.py
@@ -1,0 +1,73 @@
+"""Edits that change nothing must stay visible.
+
+An edit whose anchor is absent is applied to nothing, but it is also not
+gate-rejected — so before `apply_edits_detailed` it appeared in neither list and
+the night reported fewer edits than the optimizer actually produced.
+"""
+import unittest
+
+from skillopt_sleep.memory import apply_edits, apply_edits_detailed, set_learned
+from skillopt_sleep.types import EditRecord
+
+
+def _doc(*lines):
+    return set_learned("# Skill\n\nhand-written body\n", list(lines))
+
+
+class TestUnmatchedEdits(unittest.TestCase):
+    def test_replace_with_absent_anchor_is_unmatched(self) -> None:
+        doc = _doc("existing rule")
+        e = EditRecord(target="skill", op="replace", content="new", anchor="NOT THERE")
+        new_doc, applied, unmatched = apply_edits_detailed(doc, [e])
+        self.assertEqual(applied, [])
+        self.assertEqual(unmatched, [e])
+        self.assertEqual(new_doc, doc)
+
+    def test_delete_with_absent_anchor_is_unmatched(self) -> None:
+        doc = _doc("existing rule")
+        e = EditRecord(target="skill", op="delete", content="", anchor="NOT THERE")
+        _new, applied, unmatched = apply_edits_detailed(doc, [e])
+        self.assertEqual((applied, unmatched), ([], [e]))
+
+    def test_duplicate_add_is_unmatched_not_applied(self) -> None:
+        doc = _doc("existing rule")
+        e = EditRecord(target="skill", op="add", content="Existing   Rule")
+        _new, applied, unmatched = apply_edits_detailed(doc, [e])
+        self.assertEqual(applied, [])
+        self.assertEqual(unmatched, [e])
+
+    def test_empty_add_is_unmatched(self) -> None:
+        doc = _doc("existing rule")
+        e = EditRecord(target="skill", op="add", content="   ")
+        _new, applied, unmatched = apply_edits_detailed(doc, [e])
+        self.assertEqual((applied, unmatched), ([], [e]))
+
+    def test_mixed_batch_splits_correctly(self) -> None:
+        doc = _doc("keep me")
+        good = EditRecord(target="skill", op="add", content="brand new rule")
+        bad = EditRecord(target="skill", op="replace", content="x", anchor="ghost")
+        new_doc, applied, unmatched = apply_edits_detailed(doc, [good, bad])
+        self.assertEqual(applied, [good])
+        self.assertEqual(unmatched, [bad])
+        self.assertIn("brand new rule", new_doc)
+
+    def test_apply_edits_keeps_its_two_tuple_contract(self) -> None:
+        doc = _doc("keep me")
+        e = EditRecord(target="skill", op="add", content="another rule")
+        result = apply_edits(doc, [e])
+        self.assertEqual(len(result), 2)
+        new_doc, applied = result
+        self.assertEqual(applied, [e])
+        self.assertIn("another rule", new_doc)
+
+    def test_hand_written_body_is_never_touched(self) -> None:
+        doc = _doc("existing rule")
+        e = EditRecord(target="skill", op="replace", content="x", anchor="hand-written body")
+        new_doc, applied, unmatched = apply_edits_detailed(doc, [e])
+        self.assertIn("hand-written body", new_doc)
+        self.assertEqual(applied, [])
+        self.assertEqual(unmatched, [e])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_unmatched_edits_reporting.py
+++ b/tests/test_unmatched_edits_reporting.py
@@ -1,0 +1,57 @@
+"""Unmatched edits must reach the user-visible report, not just the evidence log.
+
+Collecting them in ConsolidationResult is not enough: the nightly artifact a
+user actually reads is report.md, so an edit that changed nothing has to be
+visible there too.
+"""
+import unittest
+
+from skillopt_sleep.config import load_config
+from skillopt_sleep.cycle import _render_report_md
+from skillopt_sleep.types import EditRecord, SleepReport
+
+
+def _report(**kw) -> SleepReport:
+    base = dict(night=1, project="/tmp/proj", n_sessions=0, n_tasks=3, n_replayed=3,
+                baseline_score=0.5, candidate_score=0.5, accepted=False, gate_action="reject")
+    base.update(kw)
+    return SleepReport(**base)
+
+
+class TestUnmatchedEditsInReport(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cfg = load_config()
+
+    def test_unmatched_section_is_rendered(self) -> None:
+        rep = _report(unmatched_edits=[
+            EditRecord(target="skill", op="replace", content="new wording",
+                       anchor="a line that is not there")])
+        md = _render_report_md(rep, self.cfg)
+        self.assertIn("changed nothing", md)
+        self.assertIn("new wording", md)
+        self.assertIn("a line that is not there", md)
+
+    def test_section_absent_when_nothing_is_unmatched(self) -> None:
+        md = _render_report_md(_report(), self.cfg)
+        self.assertNotIn("changed nothing", md)
+
+    def test_unmatched_does_not_masquerade_as_accepted(self) -> None:
+        rep = _report(
+            edits=[EditRecord(target="skill", op="add", content="a real rule")],
+            unmatched_edits=[EditRecord(target="skill", op="delete", anchor="ghost")])
+        md = _render_report_md(rep, self.cfg)
+        accepted_at = md.index("## Accepted edits")
+        unmatched_at = md.index("## Proposed but changed nothing")
+        self.assertLess(accepted_at, unmatched_at)
+        # the real rule is listed once, under Accepted
+        self.assertEqual(md.count("a real rule"), 1)
+
+    def test_report_dict_round_trips_unmatched(self) -> None:
+        rep = _report(unmatched_edits=[EditRecord(target="memory", op="add", content="x")])
+        d = rep.to_dict()
+        self.assertEqual(len(d["unmatched_edits"]), 1)
+        self.assertEqual(d["unmatched_edits"][0]["target"], "memory")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Context

While using SkillOpt-Sleep to optimize two of my own Claude Code skills (an essay skill and a 24-target router), I ran six nights against real task sets. Three separate times a run *looked* healthy while something was quietly broken — and in each case the failure was indistinguishable from a legitimate negative result. That ambiguity is what this PR removes.

All three are reproducible in a few lines; each fix ships with tests.

## 1. A regex that does not compile fails forever, silently

`judges._check` swallows `re.error` and returns `False`:

```python
>>> score_rule_judge({"checks": [{"op": "regex", "arg": r"(?i)foo|(?i)bar"}]}, "foo bar baz")
(0.0, 0.0, 'failed: regex=(?i)foo|(?i)bar')
```

The response contains both alternatives. Python rejects the second inline flag, so the check can never pass — but the rationale is identical to a genuine miss. In practice this reads as "the model never complies with this rule", and the affected dimension scores `0.0` every night.

I hit this twice in one session, and both times I first blamed the model.

**Fix:** `_check` returns `(passed, problem)`; `score_rule_judge` labels it (`[invalid regex (...)]`); new `validate_checks()` returns `(errors, warnings)`; `load_tasks_file` raises on errors so a malformed set fails at load instead of scoring all night. Unknown ops stay warnings, matching the documented `# unknown op: do not block`.

## 2. An edit whose anchor matches nothing disappears

```python
>>> apply_edits(doc, [EditRecord(target="skill", op="replace", anchor="NO SUCH ANCHOR", content="new")])
(unchanged_doc, [])      # not applied, and not in rejected_edits either
```

The optimizer did work, the report shows nothing. `ConsolidationResult` has `applied_edits` and `rejected_edits`, and such an edit is in neither.

**Fix:** `apply_edits_detailed()` also returns `unmatched`; consolidation collects it into `ConsolidationResult.unmatched_edits` and emits a `reflect/edits_unmatched` evidence event. `apply_edits()` keeps its existing two-tuple contract, so no caller breaks.

## 3. `gate_action` can contradict `accepted`

`consolidate.py` computes them independently — the action from `evaluate_gate`, `accepted` as `bool(all_applied) and final_score > base_gate_score`. When every proposed edit is dropped during the per-target trials, `all_applied` is empty and nothing changed, yet the score comparison can still yield an accept-flavoured action:

```
gate.action='accept_new_best'   accepted=False
```

**Fix:** reconcile the reported action with `accepted`. The gate's own decision logic is untouched.

## Tests

Adds `tests/test_judges.py` — `skillopt_sleep/judges.py` had no dedicated test module, despite deciding the outcome of every night — and `tests/test_unmatched_edits.py`.

```
python -m pytest -q
398 passed, 6 skipped
```

Verified end-to-end: a tasks file with an uncompilable pattern now raises at load with the exact check index and the compiler message, while my three real task sets (72 / 19 / 12 tasks) still load unchanged.

## Notes

Behaviour change worth flagging: a tasks file containing an uncompilable regex now raises instead of loading. That set could never have scored meaningfully, so I judged failing loudly to be right — happy to downgrade it to a warning if you would rather not break existing files.

Related to the Goodhart discussion in #154: these are the gate-side counterparts, where a broken measurement is silently taken at face value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)