### PR TITLE
fix: sync LiveMath split metadata

### DIFF
--- a/.osc-metadata/sync.json
+++ b/.osc-metadata/sync.json
@@ -1,0 +1,5 @@
+{
+  "fork_synced_at": "2026-07-26T09:38:34.869801+00:00",
+  "commits_behind_before_sync": 210,
+  "action_taken": "synced"
+}

--- a/data/README.md
+++ b/data/README.md
@@ -29,7 +29,7 @@ Each `items.json` contains only stable IDs or source-path hints.
 | Manifest directory | Benchmark | Counts | Coverage | Raw data source | `split_dir` |
 |---|---|---:|---|---|---|
 | `searchqa_id_split/` | SearchQA | 400 / 200 / 1400 | Official HF dataset IDs | [lucadiliello/searchqa](https://huggingface.co/datasets/lucadiliello/searchqa) | `data/searchqa_split` |
-| `livemathematicianbench_id_split/` | LiveMathematicianBench | 35 / 18 / 124 | Four official monthly files | [LiveMathematicianBench/LiveMathematicianBench](https://huggingface.co/datasets/LiveMathematicianBench/LiveMathematicianBench) | `data/livemathematicianbench_split` |
+| `livemathematicianbench_id_split/` | LiveMathematicianBench | 35 / 17 / 125 | Four official monthly files | [LiveMathematicianBench/LiveMathematicianBench](https://huggingface.co/datasets/LiveMathematicianBench/LiveMathematicianBench) | `data/livemathematicianbench_split` |
 | `docvqa_id_split/` | DocVQA | 107 / 53 / 374 | 10% subset of validation | [lmms-lab/DocVQA](https://huggingface.co/datasets/lmms-lab/DocVQA) | `data/docvqa/splits` |
 | `officeqa_id_split/` | OfficeQA | 50 / 24 / 172 | OfficeQA Full | [databricks/officeqa](https://huggingface.co/datasets/databricks/officeqa) | `data/officeqa_split` |
 | `spreadsheetbench_id_split/` | SpreadsheetBench | 80 / 40 / 280 | SpreadsheetBench Verified 400 | [KAKA22/SpreadsheetBench](https://huggingface.co/datasets/KAKA22/SpreadsheetBench) | `data/spreadsheetbench_split` |

--- a/data/livemathematicianbench_id_split/split_manifest.json
+++ b/data/livemathematicianbench_id_split/split_manifest.json
@@ -16,8 +16,8 @@
   "split_seed": 42,
   "counts": {
     "train": 35,
-    "val": 18,
-    "test": 124
+    "val": 17,
+    "test": 125
   },
   "item_fields": [
     "id",

--- a/tests/test_data_manifests.py
+++ b/tests/test_data_manifests.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+
+from skillopt.datasets.base import SPLIT_NAMES
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
+
+
+def test_split_manifest_counts_match_item_files() -> None:
+    manifest_paths = sorted(DATA_DIR.glob("*/split_manifest.json"))
+    assert manifest_paths, f"No split manifests found under {DATA_DIR}"
+
+    for manifest_path in manifest_paths:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+        for split_name in SPLIT_NAMES:
+            declared_count = manifest["counts"][split_name]
+            items_path = manifest_path.parent / split_name / "items.json"
+            actual_count = len(json.loads(items_path.read_text(encoding="utf-8")))
+
+            assert declared_count == actual_count, (
+                f"{manifest_path} split {split_name!r}: declared count {declared_count}, actual count {actual_count}"
+            )


### PR DESCRIPTION
The maintainer identified one LiveMathematicianBench item that belonged in the test split and moved `202512:46` on current `main`, so the checked-in item files now contain 35 train, 17 validation, and 125 test records. The accompanying `split_manifest.json` and released-splits table still advertise 35/18/124, leaving the repository's canonical metadata inconsistent with the corrected paper split. Because the hard scorer averages binary per-example results, using the corrected 125-item test file resolves the reported LiveMath denominator mismatch, but consumers following the stale metadata can still materialize or report the wrong split sizes. There are no competing or closed-unmerged cross-referenced PRs.

## Summary

Update the LiveMathematicianBench manifest counts and the corresponding `data/README.md` released-splits row to 35/17/125, preserving the item move already present on `main` and avoiding unsupported claims about the other benchmarks' run aggregation. Add a focused `tests/test_data_manifests.py` consistency test that discovers each checked-in `data/*/split_manifest.json`, follows the canonical train/val/test layout, and compares every declared count with the length of its `items.json` array. This uses the manifest as the published contract and the checked-in item files as the implementation source of truth, covering the data-to-documentation wiring without changing the runtime scorer or benchmark loader.

## Validation

- Happy path: every released split manifest, including LiveMathematicianBench at 35/17/125, declares counts equal to the lengths of its train, val, and test `items.json` arrays.
- Edge cases: manifests with different benchmark-specific item fields and large item arrays are validated solely by canonical split names and array length, without assuming a particular item schema.
- Error paths: a declared count that differs from its checked-in item array fails with the manifest path, split name, declared count, and actual count, reproducing the stale 18/124 LiveMath metadata failure.

Fixes #158
