### PR TITLE
docs(blog): cite the main SkillOpt paper only

### DIFF
--- a/blog/gating-reflection-safe-updates/index.html
+++ b/blog/gating-reflection-safe-updates/index.html
@@ -1697,27 +1697,13 @@
         <h2>Citation</h2>
 
         <div class="citation-title">
-          <h3>Cite this blog post</h3>
-          <button class="copy-button" type="button" data-copy-target="citation-bibtex" aria-live="polite">Copy Blog BibTeX</button>
-        </div>
-        <p>
-          If you find this report useful, please cite it as:
-        </p>
-        <pre><code id="citation-bibtex">@misc{zhou2026skillopttechnicalreport,
-  title        = {Expanded SkillOpt Ablations, Skill-Aware Reflection, and SkillOpt-Sleep},
-  author       = {Zhou, Ziwei and Gong, Ziyang and Yang, Yifan},
-  year         = {2026},
-  url          = {https://microsoft.github.io/SkillOpt/blog/gating-reflection-safe-updates/},
-  note         = {SkillOpt Technical Blog post}
-}</code></pre>
-
-        <div class="citation-title">
-          <h3>SkillOpt paper</h3>
+          <h3>Cite SkillOpt</h3>
           <button class="copy-button" type="button" data-copy-target="citation-skillopt-bibtex" aria-live="polite">Copy SkillOpt BibTeX</button>
         </div>
         <p>
-          For the underlying SkillOpt method, please also cite the
-          <a href="https://arxiv.org/abs/2605.23904">SkillOpt paper</a>:
+          If you find this report useful, please cite the main SkillOpt paper using the
+          citation maintained in the
+          <a href="https://github.com/microsoft/SkillOpt#citation">SkillOpt repository</a>:
         </p>
         <pre><code id="citation-skillopt-bibtex">@article{yang2026skillopt,
   title={Skillopt: Executive strategy for self-evolving agent skills},


### PR DESCRIPTION
Removes the technical blog post's separate self-citation and leaves a single citation path for the main SkillOpt paper.

The remaining BibTeX exactly matches the repository README, and the citation text links to the main repository's Citation section.

Validation:
- git diff --check
- full-tree scan confirms no retired blog citation key or copy control remains
- independent Claude Opus 5.0 review: SHIP