### PR TITLE
feat(sleep): group mined tasks by skill hint with catch-all fallback

### DIFF
--- a/skillopt_sleep/mine.py
+++ b/skillopt_sleep/mine.py
@@ -18,7 +18,7 @@ import hashlib
 import os
 import re
 from collections import Counter
-from typing import Callable, List, Optional, Set, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple
 
 from skillopt_sleep.backend import CursorBackendError
 from skillopt_sleep.types import SessionDigest, TaskRecord
@@ -236,6 +236,30 @@ def dedup_tasks(tasks: List[TaskRecord]) -> List[TaskRecord]:
         hints = hints_by_id.get(task_id, set())
         task.skill_hint = next(iter(hints)) if len(hints) == 1 else ""
     return list(by_id.values())
+
+
+def group_tasks_by_skill_hint(
+    tasks: List[TaskRecord],
+    managed_skill_name: str,
+) -> Dict[str, List[TaskRecord]]:
+    """Group mined tasks by their skill hint, in first-seen order.
+
+    A task ID reaches a hinted group only when every observation of it agrees on
+    the same non-empty hint. Missing hints, conflicting hints, and a mixture of
+    hinted and unhinted observations all fall back to ``managed_skill_name`` —
+    the existing catch-all skill — so ambiguous evidence never invents a group.
+    Each task ID is emitted exactly once, with ``dedup_tasks`` merge semantics.
+    """
+    observed: dict = {}
+    for t in tasks:
+        observed.setdefault(t.id, set()).add((t.skill_hint or "").strip())
+
+    groups: Dict[str, List[TaskRecord]] = {}
+    for task in dedup_tasks(tasks):
+        hints = observed[task.id]
+        hint = next(iter(hints)) if len(hints) == 1 else ""
+        groups.setdefault(hint or managed_skill_name, []).append(task)
+    return groups
 
 
 def assign_splits(

--- a/tests/test_sleep_engine.py
+++ b/tests/test_sleep_engine.py
@@ -19,7 +19,13 @@ from skillopt_sleep.cycle import run_sleep_cycle
 from skillopt_sleep.experiments.personas import programmer_persona, researcher_persona
 from skillopt_sleep.harvest import _detect_feedback, _is_meta_prompt, digest_transcript
 from skillopt_sleep.memory import apply_edits, current_learned_lines, extract_learned, set_learned
-from skillopt_sleep.mine import assign_splits, filter_tasks_for_target, heuristic_mine, mine
+from skillopt_sleep.mine import (
+    assign_splits,
+    filter_tasks_for_target,
+    group_tasks_by_skill_hint,
+    heuristic_mine,
+    mine,
+)
 from skillopt_sleep.staging import adopt
 from skillopt_sleep.types import EditRecord, SessionDigest, SleepReport, TaskRecord
 
@@ -2250,6 +2256,82 @@ class TestDiagnosticsRedaction(unittest.TestCase):
         joined = "\n".join(cm.output)
         self.assertNotIn(secret, joined, "raw token leaked into the log line")
         self.assertIn("REDACTED", joined)
+
+
+class TestGroupTasksBySkillHint(unittest.TestCase):
+    MANAGED = "managed-skill"
+
+    def _task(self, tid, hint="", session="s1", outcome="unknown"):
+        return TaskRecord(
+            id=tid, project="/repo/example", intent="intent " + tid,
+            skill_hint=hint, source_sessions=[session], outcome=outcome,
+        )
+
+    def _ids(self, groups):
+        return {name: [t.id for t in tasks] for name, tasks in groups.items()}
+
+    def test_group_tasks_by_skill_hint_empty_input(self):
+        self.assertEqual(group_tasks_by_skill_hint([], self.MANAGED), {})
+
+    def test_group_tasks_by_skill_hint_legacy_tasks_go_to_managed_skill(self):
+        groups = group_tasks_by_skill_hint(
+            [self._task("t1"), self._task("t2")], self.MANAGED
+        )
+        self.assertEqual(self._ids(groups), {self.MANAGED: ["t1", "t2"]})
+
+    def test_group_tasks_by_skill_hint_blank_hint_goes_to_managed_skill(self):
+        groups = group_tasks_by_skill_hint([self._task("t1", "   ")], self.MANAGED)
+        self.assertEqual(self._ids(groups), {self.MANAGED: ["t1"]})
+
+    def test_group_tasks_by_skill_hint_preserves_first_seen_order(self):
+        groups = group_tasks_by_skill_hint(
+            [
+                self._task("t1", "alpha"),
+                self._task("t2", "beta"),
+                self._task("t3", "alpha"),
+                self._task("t4"),
+            ],
+            self.MANAGED,
+        )
+        self.assertEqual(list(groups), ["alpha", "beta", self.MANAGED])
+        self.assertEqual(
+            self._ids(groups),
+            {"alpha": ["t1", "t3"], "beta": ["t2"], self.MANAGED: ["t4"]},
+        )
+
+    def test_group_tasks_by_skill_hint_merges_duplicate_ids_once(self):
+        groups = group_tasks_by_skill_hint(
+            [
+                self._task("t1", "alpha", session="s1"),
+                self._task("t2", "beta"),
+                self._task("t1", "alpha", session="s2", outcome="success"),
+            ],
+            self.MANAGED,
+        )
+        self.assertEqual(self._ids(groups), {"alpha": ["t1"], "beta": ["t2"]})
+        merged = groups["alpha"][0]
+        self.assertEqual(merged.source_sessions, ["s1", "s2"])
+        self.assertEqual(merged.outcome, "success")
+
+    def test_group_tasks_by_skill_hint_conflicting_hints_go_to_managed_skill(self):
+        groups = group_tasks_by_skill_hint(
+            [self._task("t1", "alpha"), self._task("t1", "beta", session="s2")],
+            self.MANAGED,
+        )
+        self.assertEqual(self._ids(groups), {self.MANAGED: ["t1"]})
+
+    def test_group_tasks_by_skill_hint_partial_hint_evidence_goes_to_managed_skill(self):
+        groups = group_tasks_by_skill_hint(
+            [self._task("t1", "alpha"), self._task("t1", session="s2")],
+            self.MANAGED,
+        )
+        self.assertEqual(self._ids(groups), {self.MANAGED: ["t1"]})
+
+    def test_group_tasks_by_skill_hint_hint_equal_to_managed_skill_is_one_group(self):
+        groups = group_tasks_by_skill_hint(
+            [self._task("t1", self.MANAGED), self._task("t2")], self.MANAGED
+        )
+        self.assertEqual(self._ids(groups), {self.MANAGED: ["t1", "t2"]})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Third review-sized slice of #120: the grouping primitive, so mined tasks can be
routed per skill while everything without clear evidence stays in the existing
managed-skill catch-all.

Adds `mine.group_tasks_by_skill_hint(tasks, managed_skill_name)`, a
deterministic, side-effect-free helper returning ordinary insertion-ordered
dicts/lists:

- groups preserve first-seen order, and so does task order inside a group;
- each task ID is emitted exactly once, reusing `dedup_tasks` merge semantics
  (source sessions unioned, best outcome kept);
- a task reaches a hinted group only when *every* observation of that ID agrees
  on the same non-empty hint;
- absent/blank hints, two different hints for one ID, and a mixture of hinted and
  unhinted observations for one ID all route to `managed_skill_name`;
- a hint equal to `managed_skill_name` lands in that one group, never a duplicate.

The grouping rule is deliberately the same order-independent "full set of
non-empty hints" rule you asked for in the #183 review, so grouping and
`dedup_tasks` cannot disagree about what an ambiguous ID means.

Nothing else changes: `mine()`, `filter_tasks_for_target()`, cycle, gates,
staging, and adoption are untouched, and the caller supplies the configured
managed-skill name rather than the helper resolving paths or reading skill files.

Rebased onto current `main` (`e7014cd`); the earlier stacked parents (#182, #183)
have landed, so this is now a single commit against `main`.

## Tests

Base is unmodified `main` at `e7014cd`, same machine, same interpreter
(CPython 3.12.13, macOS):

| Run | Result |
| --- | --- |
| `pytest tests/test_sleep_engine.py` (this branch) | 94 passed, 1 skipped |
| `pytest tests` (this branch) | 611 passed, 6 skipped, 130 subtests, 2 failed |
| `pytest tests` (base `main` @ `e7014cd`) | 603 passed, 6 skipped, 130 subtests, 2 failed |
| `ruff check .` | identical finding set to base - 0 new |

The 2 failures are `tests/test_superpowers_scenarios.py::TestOverlayIntegration`
(`test_skill_copied_to_correct_path`, `test_source_checkout_unchanged`). They are
the macOS `/var` → `/private/var` symlink artifact and reproduce unchanged on
untouched `main`, so they are not regressions from this branch.

Covered by the new tests: empty input, legacy hint-less tasks, blank hint,
interleaved `alpha`/`beta`/`alpha` ordering, duplicate ID merge, conflicting
hints, partial hint evidence, and a hint equal to the managed skill name.

Refs #120
