### PR TITLE
fix(scripts): force UTF-8 on stdout/stderr so runs survive a cp1252 console

### DIFF
--- a/scripts/eval_only.py
+++ b/scripts/eval_only.py
@@ -24,21 +24,11 @@ _PROJECT_ROOT = os.path.dirname(_SCRIPT_DIR)
 if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, _PROJECT_ROOT)
 
-# Progress output contains box-drawing and arrow characters. On a Windows
-# console defaulting to cp1252 those raise UnicodeEncodeError mid-run. A cp1252
-# file redirection crashes identically, so this deliberately is not gated on
-# isatty(); it is a best-effort no-op for streams that are already UTF-8 or
-# expose an incompatible reconfigure().
-for _stream in (sys.stdout, sys.stderr):
-    _reconfigure = getattr(_stream, "reconfigure", None)
-    if _reconfigure is None:
-        continue
-    if (getattr(_stream, "encoding", "") or "").lower().replace("-", "") == "utf8":
-        continue
-    try:
-        _reconfigure(encoding="utf-8", errors="replace")
-    except (ValueError, OSError, TypeError):
-        pass
+# Progress output uses box-drawing and arrow characters that crash a cp1252
+# console/redirection mid-run; force UTF-8 before any of it is written.
+from skillopt.utils.console import force_utf8_stdout_stderr
+
+force_utf8_stdout_stderr()
 
 from skillopt.model import (
     configure_azure_openai,

--- a/scripts/eval_only.py
+++ b/scripts/eval_only.py
@@ -24,6 +24,12 @@ _PROJECT_ROOT = os.path.dirname(_SCRIPT_DIR)
 if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, _PROJECT_ROOT)
 
+# Progress output contains box-drawing and arrow characters. On a Windows
+# console defaulting to cp1252 those raise UnicodeEncodeError mid-run.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
 from skillopt.model import (
     configure_azure_openai,
     configure_claude_code_exec,

--- a/scripts/eval_only.py
+++ b/scripts/eval_only.py
@@ -25,10 +25,20 @@ if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, _PROJECT_ROOT)
 
 # Progress output contains box-drawing and arrow characters. On a Windows
-# console defaulting to cp1252 those raise UnicodeEncodeError mid-run.
+# console defaulting to cp1252 those raise UnicodeEncodeError mid-run. A cp1252
+# file redirection crashes identically, so this deliberately is not gated on
+# isatty(); it is a best-effort no-op for streams that are already UTF-8 or
+# expose an incompatible reconfigure().
 for _stream in (sys.stdout, sys.stderr):
-    if hasattr(_stream, "reconfigure"):
-        _stream.reconfigure(encoding="utf-8", errors="replace")
+    _reconfigure = getattr(_stream, "reconfigure", None)
+    if _reconfigure is None:
+        continue
+    if (getattr(_stream, "encoding", "") or "").lower().replace("-", "") == "utf8":
+        continue
+    try:
+        _reconfigure(encoding="utf-8", errors="replace")
+    except (ValueError, OSError, TypeError):
+        pass
 
 from skillopt.model import (
     configure_azure_openai,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -26,6 +26,13 @@ _PROJECT_ROOT = os.path.dirname(_SCRIPT_DIR)
 if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, _PROJECT_ROOT)
 
+# Progress output contains box-drawing and arrow characters. On a Windows
+# console defaulting to cp1252 those raise UnicodeEncodeError mid-run, which
+# kills a training loop after real work has already been done.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
 from skillopt.model.common import default_model_for_backend, normalize_backend_name
 
 _OPENAI_DEFAULT_MODEL_SENTINELS = {"gpt-5.4", "gpt-5.5"}

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -26,22 +26,11 @@ _PROJECT_ROOT = os.path.dirname(_SCRIPT_DIR)
 if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, _PROJECT_ROOT)
 
-# Progress output contains box-drawing and arrow characters. On a Windows
-# console defaulting to cp1252 those raise UnicodeEncodeError mid-run, which
-# kills a training loop after real work has already been done. A cp1252 file
-# redirection crashes identically, so this deliberately is not gated on
-# isatty(); it is a best-effort no-op for streams that are already UTF-8 or
-# expose an incompatible reconfigure().
-for _stream in (sys.stdout, sys.stderr):
-    _reconfigure = getattr(_stream, "reconfigure", None)
-    if _reconfigure is None:
-        continue
-    if (getattr(_stream, "encoding", "") or "").lower().replace("-", "") == "utf8":
-        continue
-    try:
-        _reconfigure(encoding="utf-8", errors="replace")
-    except (ValueError, OSError, TypeError):
-        pass
+# Progress output uses box-drawing and arrow characters that crash a cp1252
+# console/redirection mid-run; force UTF-8 before any of it is written.
+from skillopt.utils.console import force_utf8_stdout_stderr
+
+force_utf8_stdout_stderr()
 
 from skillopt.model.common import default_model_for_backend, normalize_backend_name
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -28,10 +28,20 @@ if _PROJECT_ROOT not in sys.path:
 
 # Progress output contains box-drawing and arrow characters. On a Windows
 # console defaulting to cp1252 those raise UnicodeEncodeError mid-run, which
-# kills a training loop after real work has already been done.
+# kills a training loop after real work has already been done. A cp1252 file
+# redirection crashes identically, so this deliberately is not gated on
+# isatty(); it is a best-effort no-op for streams that are already UTF-8 or
+# expose an incompatible reconfigure().
 for _stream in (sys.stdout, sys.stderr):
-    if hasattr(_stream, "reconfigure"):
-        _stream.reconfigure(encoding="utf-8", errors="replace")
+    _reconfigure = getattr(_stream, "reconfigure", None)
+    if _reconfigure is None:
+        continue
+    if (getattr(_stream, "encoding", "") or "").lower().replace("-", "") == "utf8":
+        continue
+    try:
+        _reconfigure(encoding="utf-8", errors="replace")
+    except (ValueError, OSError, TypeError):
+        pass
 
 from skillopt.model.common import default_model_for_backend, normalize_backend_name
 

--- a/skillopt/utils/console.py
+++ b/skillopt/utils/console.py
@@ -1,0 +1,28 @@
+"""Console encoding helpers shared by the entry-point scripts."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+
+def force_utf8_stdout_stderr() -> None:
+    """Best-effort switch of ``stdout``/``stderr`` to UTF-8.
+
+    Progress output contains box-drawing and arrow characters. On a Windows
+    console defaulting to cp1252 those raise ``UnicodeEncodeError`` mid-run,
+    which kills a loop after real work has already been done; a cp1252 file
+    redirection crashes identically, so this is deliberately not gated on
+    ``isatty()``. It is a no-op for streams that are already UTF-8 or that
+    expose an incompatible ``reconfigure()``.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure: Any = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        if (getattr(stream, "encoding", "") or "").lower().replace("-", "") == "utf8":
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError, TypeError):
+            pass

--- a/skillopt/utils/console.py
+++ b/skillopt/utils/console.py
@@ -20,7 +20,7 @@ def force_utf8_stdout_stderr() -> None:
         reconfigure: Any = getattr(stream, "reconfigure", None)
         if reconfigure is None:
             continue
-        if (getattr(stream, "encoding", "") or "").lower().replace("-", "") == "utf8":
+        if (getattr(stream, "encoding", "") or "").lower().replace("-", "").replace("_", "") == "utf8":
             continue
         try:
             reconfigure(encoding="utf-8", errors="replace")

--- a/tests/test_console_encoding.py
+++ b/tests/test_console_encoding.py
@@ -1,0 +1,46 @@
+"""Entry-point scripts must not die on a non-UTF-8 console."""
+
+from __future__ import annotations
+
+import io
+import os
+import runpy
+import sys
+
+import pytest
+
+_SCRIPTS = ["train", "eval_only"]
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+@pytest.mark.parametrize("script", _SCRIPTS)
+def test_script_reconfigures_streams_to_utf8(script: str, monkeypatch) -> None:
+    """Progress output uses arrows and box-drawing characters.
+
+    A cp1252 console raises UnicodeEncodeError partway through a run, after
+    real work has been done, so the scripts force UTF-8 at import time.
+    """
+    recorded: list[dict] = []
+
+    class _Stream(io.StringIO):
+        def reconfigure(self, **kwargs):
+            recorded.append(kwargs)
+
+    monkeypatch.setattr(sys, "stdout", _Stream())
+    monkeypatch.setattr(sys, "stderr", _Stream())
+    monkeypatch.setattr(sys, "argv", [script])
+
+    # run_name is not "__main__", so main() never runs; stream setup happens
+    # at import time, which is the point.
+    runpy.run_path(os.path.join(_ROOT, "scripts", f"{script}.py"), run_name="not_main")
+
+    assert {"encoding": "utf-8", "errors": "replace"} in recorded
+
+
+@pytest.mark.parametrize("script", _SCRIPTS)
+def test_cp1252_console_survives_arrow_output(script: str) -> None:
+    """The characters that used to crash a run must now be writable."""
+    buf = io.TextIOWrapper(io.BytesIO(), encoding="cp1252", errors="strict")
+    buf.reconfigure(encoding="utf-8", errors="replace")
+    buf.write("[2/6 REFLECT] failure=0→0 groups — SkillOpt")
+    buf.flush()

--- a/tests/test_console_encoding.py
+++ b/tests/test_console_encoding.py
@@ -45,3 +45,27 @@ def test_cp1252_console_survives_arrow_output() -> None:
     buf.reconfigure(encoding="utf-8", errors="replace")
     buf.write("[2/6 REFLECT] failure=0→0 groups — SkillOpt")
     buf.flush()
+
+
+@pytest.mark.parametrize(
+    ("encoding", "expect_reconfigure"),
+    [("cp1252", True), ("utf-8", False), ("utf_8", False), ("UTF8", False)],
+)
+def test_helper_skips_streams_already_utf8(encoding, expect_reconfigure, monkeypatch) -> None:
+    from skillopt.utils.console import force_utf8_stdout_stderr
+
+    recorded: list[dict] = []
+
+    class _Stream:
+        def __init__(self, enc):
+            self.encoding = enc
+
+        def reconfigure(self, **kwargs):
+            recorded.append(kwargs)
+
+    monkeypatch.setattr(sys, "stdout", _Stream(encoding))
+    monkeypatch.setattr(sys, "stderr", _Stream(encoding))
+    force_utf8_stdout_stderr()
+
+    assert bool(recorded) is expect_reconfigure
+

--- a/tests/test_console_encoding.py
+++ b/tests/test_console_encoding.py
@@ -23,6 +23,8 @@ def test_script_reconfigures_streams_to_utf8(script: str, monkeypatch) -> None:
     recorded: list[dict] = []
 
     class _Stream(io.StringIO):
+        encoding = "cp1252"
+
         def reconfigure(self, **kwargs):
             recorded.append(kwargs)
 
@@ -37,8 +39,7 @@ def test_script_reconfigures_streams_to_utf8(script: str, monkeypatch) -> None:
     assert {"encoding": "utf-8", "errors": "replace"} in recorded
 
 
-@pytest.mark.parametrize("script", _SCRIPTS)
-def test_cp1252_console_survives_arrow_output(script: str) -> None:
+def test_cp1252_console_survives_arrow_output() -> None:
     """The characters that used to crash a run must now be writable."""
     buf = io.TextIOWrapper(io.BytesIO(), encoding="cp1252", errors="strict")
     buf.reconfigure(encoding="utf-8", errors="replace")


### PR DESCRIPTION
Progress output contains arrow and box-drawing characters (e.g. the '[2/6 REFLECT] failure=0->0 groups' line and the banner rules). On a Windows console that defaults to cp1252, writing them raises UnicodeEncodeError and kills the process partway through a run -- after rollouts and reflect calls have already been paid for.

Both entry points now reconfigure stdout/stderr to UTF-8 with errors='replace' at import time, guarded by hasattr so redirected or exotic streams are left alone.