### PR TITLE
fix(config): honor YAML backend selection

### DIFF
--- a/docs/guide/new-backend.md
+++ b/docs/guide/new-backend.md
@@ -84,8 +84,11 @@ python scripts/train.py --config configs/searchqa/default.yaml \
   model.target=llama-3.3-70b-versatile
 ```
 
-Do not rely on the legacy high-level `model.backend` label to replace the two
-role-specific fields in a structured config.
+`model.backend` is a high-level shorthand for SkillOpt's built-in role
+pairings. It replaces role fields that are still at the shipped
+`openai_chat` default, while non-default role fields are preserved. For a
+custom optimizer/target split, set both role-specific fields and do not combine
+them with a conflicting high-level label.
 
 The generic backend uses the official `openai` SDK and the Chat Completions
 API. It records token usage through the shared tracker, supports provider tool
@@ -170,9 +173,11 @@ A new backend normally requires all of the following:
 6. Update `router.py` only when legacy single-backend compatibility is part of
    the intended feature.
 
-Backend selection in `scripts/train.py` must use
-`model.optimizer_backend` and `model.target_backend`. A high-level
-`model.backend` alias alone is not a substitute for this explicit split.
+Backend selection in `scripts/train.py` must support
+`model.optimizer_backend` and `model.target_backend`. If the backend also has a
+high-level `model.backend` alias, resolve its built-in role pairing before
+applying backend-specific model defaults, without replacing non-default role
+fields.
 
 ## Step 3: test the integration
 

--- a/scripts/eval_only.py
+++ b/scripts/eval_only.py
@@ -339,6 +339,11 @@ def main() -> None:
             if key == "model.backend":
                 explicit_backend = str(option).split("=", 1)[1].strip()
                 break
+    if explicit_backend is None:
+        # ``model.backend`` from a structured YAML file is flattened to
+        # ``model_backend``.  Treat it like the equivalent CLI selection so
+        # its role mapping (and backend-specific model defaults) is applied.
+        explicit_backend = cfg.get("model_backend") or cfg.get("backend")
 
     backend = normalize_backend_name(cfg.get("model_backend") or cfg.get("target_backend") or "azure_openai")
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -499,6 +499,11 @@ def load_config(args: argparse.Namespace) -> dict:
             if key == "model.backend":
                 explicit_backend = str(option).split("=", 1)[1].strip()
                 break
+    if explicit_backend is None:
+        # ``model.backend`` from a structured YAML file is flattened to
+        # ``model_backend``.  Treat it like the equivalent CLI selection so
+        # its role mapping (and backend-specific model defaults) is applied.
+        explicit_backend = flat.get("model_backend") or flat.get("backend")
 
     backend = normalize_backend_name(flat.get("model_backend") or flat.get("target_backend") or "azure_openai")
 

--- a/tests/test_copilot_exec_backend.py
+++ b/tests/test_copilot_exec_backend.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+import scripts.eval_only as eval_script
 import scripts.train as train_script
 import skillopt.model as model
 from skillopt.config import flatten_config
@@ -247,6 +248,142 @@ def test_train_copilot_exec_omits_inherited_openai_target_model(monkeypatch) -> 
 
     assert cfg["target_backend"] == "copilot_exec"
     assert cfg["target_model"] == ""
+
+
+def _write_copilot_yaml_config(tmp_path: Path) -> Path:
+    root = Path(__file__).resolve().parents[1]
+    config_path = tmp_path / "copilot_exec.yaml"
+    config_path.write_text(
+        f"""\
+_base_: {json.dumps(str(root / "configs" / "searchqa" / "default.yaml"))}
+
+model:
+  backend: copilot_exec
+
+env:
+  out_root: {json.dumps(str(tmp_path / "out"))}
+""",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_train_resolves_copilot_exec_from_structured_yaml(monkeypatch, tmp_path) -> None:
+    config_path = _write_copilot_yaml_config(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["skillopt-train", "--config", str(config_path)],
+    )
+
+    cfg = train_script.load_config(train_script.parse_args())
+
+    assert cfg["optimizer_backend"] == "openai_chat"
+    assert cfg["target_backend"] == "copilot_exec"
+    assert cfg["target_model"] == ""
+
+
+def test_train_keeps_default_structured_azure_backend(monkeypatch) -> None:
+    root = Path(__file__).resolve().parents[1]
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "skillopt-train",
+            "--config",
+            str(root / "configs" / "searchqa" / "default.yaml"),
+        ],
+    )
+
+    cfg = train_script.load_config(train_script.parse_args())
+
+    assert cfg["model_backend"] == "azure_openai"
+    assert cfg["optimizer_backend"] == "openai_chat"
+    assert cfg["target_backend"] == "openai_chat"
+    assert cfg["optimizer_model"] == "gpt-5.5"
+    assert cfg["target_model"] == "gpt-5.5"
+
+
+def test_train_resolves_copilot_exec_from_legacy_flat_yaml(monkeypatch, tmp_path) -> None:
+    config_path = tmp_path / "copilot_exec_flat.yaml"
+    config_path.write_text(
+        f"""\
+backend: copilot_exec
+optimizer_backend: openai_chat
+target_backend: openai_chat
+optimizer_model: gpt-5.5
+target_model: gpt-5.5
+env: searchqa
+out_root: {json.dumps(str(tmp_path / "out"))}
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["skillopt-train", "--config", str(config_path)],
+    )
+
+    cfg = train_script.load_config(train_script.parse_args())
+
+    assert cfg["model_backend"] == "copilot_exec"
+    assert cfg["optimizer_backend"] == "openai_chat"
+    assert cfg["target_backend"] == "copilot_exec"
+    assert cfg["target_model"] == ""
+
+
+def test_eval_resolves_copilot_exec_from_structured_yaml(monkeypatch, tmp_path) -> None:
+    config_path = _write_copilot_yaml_config(tmp_path)
+    skill_path = tmp_path / "skill.md"
+    skill_path.write_text("# Test skill\n", encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "skillopt-eval",
+            "--config",
+            str(config_path),
+            "--skill",
+            str(skill_path),
+        ],
+    )
+
+    observed = {}
+    monkeypatch.setattr(eval_script, "configure_azure_openai", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        eval_script,
+        "set_optimizer_backend",
+        lambda value: observed.__setitem__("optimizer_backend", value),
+    )
+    monkeypatch.setattr(
+        eval_script,
+        "set_target_backend",
+        lambda value: observed.__setitem__("target_backend", value),
+    )
+    monkeypatch.setattr(
+        eval_script,
+        "set_optimizer_deployment",
+        lambda value: observed.__setitem__("optimizer_model", value),
+    )
+
+    class StopAfterModelConfiguration(Exception):
+        pass
+
+    def capture_target_model(value):
+        observed["target_model"] = value
+        raise StopAfterModelConfiguration
+
+    monkeypatch.setattr(eval_script, "set_target_deployment", capture_target_model)
+
+    with pytest.raises(StopAfterModelConfiguration):
+        eval_script.main()
+
+    assert observed == {
+        "optimizer_backend": "openai_chat",
+        "target_backend": "copilot_exec",
+        "optimizer_model": "gpt-5.5",
+        "target_model": "",
+    }
 
 
 def test_train_copilot_exec_preserves_explicit_target_model(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- treat model.backend from structured YAML (and backend from legacy flat YAML) like the equivalent CLI backend selection
- apply role mapping and backend-specific model defaults in both train and eval entry points
- prevent copilot_exec YAML configs from inheriting and passing the Azure gpt-5.5 deployment name to Copilot CLI
- clarify the high-level backend shorthand and role-field precedence in the backend guide

## Validation

- 894 passed, 6 skipped, 130 subtests passed
- focused Copilot/config tests: 88 passed
- Ruff checks passed for the changed code (excluding pre-existing lint findings in the two script files)
- mkdocs build --strict passed
- git diff --check passed