### PR TITLE
fix(sleep): pass Codex CLI multi-line prompts via stdin (#197)

### DIFF
--- a/skillopt_sleep/backend.py
+++ b/skillopt_sleep/backend.py
@@ -958,7 +958,8 @@ class CodexCliBackend(CliBackend):
             cmd[3:3] = ["-C", self.project_dir]
         if self.model:
             cmd += ["-m", self.model]
-        cmd += ["--", prompt]
+        # Prompt via stdin (`codex exec -`): the Windows .CMD shim truncates argv at the first CR/LF.
+        cmd += ["-"]
         proc = None
         try:
             try:
@@ -967,8 +968,11 @@ class CodexCliBackend(CliBackend):
                     capture_output=True,
                     creationflags=_NO_WINDOW,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=self.timeout,
                     cwd=self.project_dir or None,
+                    input=prompt,
                 )
             except subprocess.TimeoutExpired:
                 self.last_call_error = f"codex exec timed out after {self.timeout}s"
@@ -1101,11 +1105,22 @@ class CodexCliBackend(CliBackend):
             ]
             if self.model:
                 cmd += ["-m", self.model]
-            cmd += ["--", prompt]
+            # Prompt via stdin (`codex exec -`): the Windows .CMD shim truncates argv at the first CR/LF.
+            cmd += ["-"]
             self.last_call_error = ""
             proc = None
             try:
-                proc = subprocess.run(cmd, capture_output=True, creationflags=_NO_WINDOW, text=True, timeout=self.timeout, cwd=work)
+                proc = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    creationflags=_NO_WINDOW,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=self.timeout,
+                    cwd=work,
+                    input=prompt,
+                )
             except subprocess.TimeoutExpired:
                 self.last_call_error = f"codex exec (tools) timed out after {self.timeout}s"
             except Exception as exc:  # noqa: BLE001

--- a/tests/test_codex_cli_prompt_stdin.py
+++ b/tests/test_codex_cli_prompt_stdin.py
@@ -1,0 +1,114 @@
+"""Codex CLI must send multi-line prompts over stdin (issue #197).
+
+On Windows the npm ``codex.CMD`` shim runs via cmd.exe, which ends the command
+line at the first CR/LF — a multi-line prompt passed as argv is truncated to
+line 1 and every rollout silently scores 0. Both CodexCliBackend call sites
+must use ``codex exec -`` with ``input=prompt`` (and utf-8 decoding).
+"""
+from __future__ import annotations
+
+import tempfile
+import unittest
+from unittest import mock
+
+from skillopt_sleep.types import TaskRecord
+
+
+def _ok_proc_writing(cmd):
+    """Fake successful subprocess.run that materializes the -o output file."""
+    if "-o" in cmd:
+        out_path = cmd[cmd.index("-o") + 1]
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write("ok")
+
+    class Proc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    return Proc()
+
+
+def _assert_prompt_over_stdin(cmd, kwargs, prompt: str) -> None:
+    """Shared contract for both CodexCliBackend sites (issue #197)."""
+    assert kwargs.get("input") == prompt, (
+        f"expected input= full multi-line prompt, got {kwargs.get('input')!r}"
+    )
+    # Positional prompt must be "-" (stdin), never the prompt body as argv.
+    assert prompt not in cmd, "prompt must not be passed as an argv element"
+    assert "--" not in cmd, "legacy '--', prompt argv form must be gone"
+    assert cmd[-1] == "-", "codex exec expects trailing '-' to read prompt from stdin"
+    assert kwargs.get("encoding") == "utf-8"
+    assert kwargs.get("errors") == "replace"
+    assert kwargs.get("text") is True
+
+
+class TestCodexPromptOverStdin(unittest.TestCase):
+    def test_call_once_sends_multiline_prompt_via_stdin(self):
+        from skillopt_sleep.backend import CodexCliBackend
+
+        prompt = "line one\nline two\nline three with unicode café"
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((list(cmd), dict(kwargs)))
+            return _ok_proc_writing(cmd)
+
+        be = CodexCliBackend(codex_path="codex")
+        with mock.patch("skillopt_sleep.backend.subprocess.run", side_effect=fake_run):
+            out = be._call_once(prompt)
+
+        self.assertEqual(out, "ok")
+        self.assertEqual(len(calls), 1)
+        cmd, kwargs = calls[0]
+        _assert_prompt_over_stdin(cmd, kwargs, prompt)
+
+    def test_attempt_with_tools_sends_multiline_prompt_via_stdin(self):
+        from skillopt_sleep.backend import CodexCliBackend
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append((list(cmd), dict(kwargs)))
+            return _ok_proc_writing(cmd)
+
+        be = CodexCliBackend(codex_path="codex")
+        task = TaskRecord(
+            id="t",
+            project="/p",
+            intent="answer the question\nwith a second line",
+            context_excerpt="context line A\ncontext line B",
+            reference_kind="rule",
+            judge={"checks": [{"op": "tool_called", "arg": "search"}]},
+        )
+        with mock.patch("skillopt_sleep.backend.subprocess.run", side_effect=fake_run), \
+             mock.patch("shutil.rmtree"):
+            # Keep workdir so fake_run can write -o; still clean up after.
+            work_holder = []
+            orig_mkdtemp = tempfile.mkdtemp
+
+            def keep_mkdtemp(*a, **k):
+                d = orig_mkdtemp(*a, **k)
+                work_holder.append(d)
+                return d
+
+            with mock.patch("tempfile.mkdtemp", side_effect=keep_mkdtemp):
+                resp, _called = be.attempt_with_tools(task, "skill\nblock", "mem\nblock", ["search"])
+
+        try:
+            self.assertEqual(resp, "ok")
+            self.assertEqual(len(calls), 1)
+            cmd, kwargs = calls[0]
+            prompt = kwargs.get("input")
+            self.assertIsInstance(prompt, str)
+            self.assertIn("\n", prompt)  # multi-line by construction
+            self.assertIn("answer the question", prompt)
+            _assert_prompt_over_stdin(cmd, kwargs, prompt)
+        finally:
+            import shutil
+            for d in work_holder:
+                shutil.rmtree(d, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

On Windows, `CodexCliBackend` was passing the full multi-line prompt as a positional argv element (`cmd += ["--", prompt]`). The npm `codex.CMD` shim runs via `cmd.exe`, which ends the command line at the first CR/LF — so codex only ever saw line 1 of every sleep-engine prompt, replied with a generic “what task?”, and every rollout silently scored 0.

This mirrors the existing `ClaudeCliBackend` pattern: send the prompt on stdin (`codex exec -` + `input=prompt`) and decode subprocess output with `encoding="utf-8", errors="replace"` so locale codepages (e.g. GBK on zh-CN Windows) cannot raise `UnicodeDecodeError`.

Both call sites are fixed:

- `CodexCliBackend._call_once`
- `CodexCliBackend.attempt_with_tools`

## Credits

Thanks to @linshujuan for the excellent root-cause analysis in #197 — including the minimal 36-character repro against the npm shim and the four-case isolation table (real multi-line prompt over argv vs stdin, and the single-line control). The Windows-native truncation behavior was verified by the reporter; this change was developed and regression-tested on macOS via mocked `subprocess.run` (cmd.exe truncation cannot be reproduced live here).

Fixes #197

## Test plan

Commands run in this work-order (honest results):

1. **Revert-proof (tests fail on unmodified code):**
   ```bash
   python3 -m pytest tests/test_codex_cli_prompt_stdin.py -v --tb=short
   ```
   Result before fix: **2 failed** — `input` was `None` (prompt still on argv).

2. **After fix:**
   ```bash
   python3 -m pytest tests/test_codex_cli_prompt_stdin.py tests/test_codex_optimizer_backend.py -v --tb=short
   ```
   Result: **15 passed**

3. **Existing CodexCliBackend coverage:**
   ```bash
   python3 -m pytest tests/test_sleep_engine.py::TestCodexBackend -v --tb=short
   ```
   Result: **6 passed**

4. **Broader sleep + focused modules:**
   ```bash
   python3 -m pytest tests/test_codex_cli_prompt_stdin.py tests/test_codex_optimizer_backend.py tests/test_sleep_engine.py -q
   ```
   Result: **111 passed, 1 skipped**

5. **Full `tests/` directory:**
   ```bash
   python3 -m pytest tests/ -q --tb=line
   ```
   Result: **collection interrupted** — 10 pre-existing `ModuleNotFoundError: No module named 'openai'` errors on research-package tests that import `skillopt.model.azure_openai` without stubs. Not introduced by this change (sleep-path modules do not require `openai`). Environment lacked the project `.[dev]` install / openai extra.

6. **Lint (touched files):**
   ```bash
   uvx ruff check skillopt_sleep/backend.py tests/test_codex_cli_prompt_stdin.py
   ```
   Result: new test file clean after dropping an unused import. `backend.py` still reports pre-existing ruff findings (E702/E401/I001/F841) outside the edit scope — left untouched per scope discipline.

## Notes

- Minimal one-file production change + one new regression test.
- No Windows-native re-verification in this environment (macOS; codex CLI not required for the unit tests).