### PR TITLE
fix(gradient): guard merge_batch_size < 2 to prevent infinite hierarchical merge

### DIFF
--- a/skillopt/engine/trainer.py
+++ b/skillopt/engine/trainer.py
@@ -866,6 +866,8 @@ class ReflACTTrainer:
             raise ValueError(f"batch_size must be positive, got {batch_size}")
         if accumulation <= 0:
             raise ValueError(f"accumulation must be positive, got {accumulation}")
+        if merge_bs < 2:
+            raise ValueError(f"merge_batch_size must be >= 2, got {merge_bs}")
 
         train_size = _resolve_train_size(cfg, dataloader)
         steps_per_epoch = math.ceil(train_size / (batch_size * accumulation))

--- a/skillopt/gradient/aggregate.py
+++ b/skillopt/gradient/aggregate.py
@@ -81,6 +81,9 @@ def _hierarchical_merge(
     """Hierarchically merge N patches using the given system prompt.
 
     Same-level batches are executed in PARALLEL via ThreadPoolExecutor.
+    batch_size values < 2 are clamped to 2 so each merge level shrinks
+    (values < 2 cannot make progress). Trainer-level config validation
+    separately enforces merge_batch_size >= 2; this clamp is defense-in-depth.
     """
     if not patches:
         return {"reasoning": "no patches", payload_key(update_mode): []}

--- a/skillopt/gradient/aggregate.py
+++ b/skillopt/gradient/aggregate.py
@@ -87,6 +87,7 @@ def _hierarchical_merge(
     if len(patches) == 1:
         return patches[0]
 
+    batch_size = max(2, batch_size)
     current = list(patches)
     level = 0
     while len(current) > 1:

--- a/tests/test_hierarchical_merge.py
+++ b/tests/test_hierarchical_merge.py
@@ -1,0 +1,95 @@
+"""Tests for skillopt.gradient.aggregate._hierarchical_merge.
+
+Issue #194: merge_batch_size=1 used to infinite-loop because every batch
+had length 1 and was passed through unchanged, so `current` never shrank.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from skillopt.gradient.aggregate import _hierarchical_merge
+
+
+def _stub_merge_batch(skill_content, patches, system_prompt, update_mode,
+                      meta_skill_context="", level=1):
+    """Deterministic merge: concatenate edits and tag with merge level."""
+    all_edits = []
+    for p in patches:
+        for e in p.get("edits", []):
+            all_edits.append({**e, "merge_level": level})
+    return {
+        "reasoning": f"merged {len(patches)} patches at level {level}",
+        "edits": all_edits,
+    }
+
+
+class TestHierarchicalMergeBatchSizeGuard:
+    """_hierarchical_merge must terminate for batch_size < 2 (issue #194)."""
+
+    def test_batch_size_one_terminates_and_merges(self) -> None:
+        patches = [
+            {"reasoning": "a", "edits": [{"id": "1", "content": "one"}]},
+            {"reasoning": "b", "edits": [{"id": "2", "content": "two"}]},
+            {"reasoning": "c", "edits": [{"id": "3", "content": "three"}]},
+        ]
+        with patch(
+            "skillopt.gradient.aggregate._merge_batch",
+            side_effect=_stub_merge_batch,
+        ):
+            result = _hierarchical_merge(
+                skill_content="skill body",
+                patches=patches,
+                system_prompt="merge prompt",
+                update_mode="patch",
+                batch_size=1,
+                verbose=False,
+                label="test",
+                workers=1,
+            )
+
+        assert isinstance(result, dict)
+        assert "edits" in result
+        ids = {e["id"] for e in result["edits"]}
+        assert ids == {"1", "2", "3"}
+
+    def test_batch_size_zero_terminates(self) -> None:
+        patches = [
+            {"reasoning": "a", "edits": [{"id": "1"}]},
+            {"reasoning": "b", "edits": [{"id": "2"}]},
+        ]
+        with patch(
+            "skillopt.gradient.aggregate._merge_batch",
+            side_effect=_stub_merge_batch,
+        ):
+            result = _hierarchical_merge(
+                skill_content="skill",
+                patches=patches,
+                system_prompt="sys",
+                update_mode="patch",
+                batch_size=0,
+                verbose=False,
+                workers=1,
+            )
+        assert {e["id"] for e in result["edits"]} == {"1", "2"}
+
+    def test_normal_batch_size_still_merges(self) -> None:
+        patches = [
+            {"reasoning": "a", "edits": [{"id": "1"}]},
+            {"reasoning": "b", "edits": [{"id": "2"}]},
+            {"reasoning": "c", "edits": [{"id": "3"}]},
+            {"reasoning": "d", "edits": [{"id": "4"}]},
+        ]
+        with patch(
+            "skillopt.gradient.aggregate._merge_batch",
+            side_effect=_stub_merge_batch,
+        ):
+            result = _hierarchical_merge(
+                skill_content="skill",
+                patches=patches,
+                system_prompt="sys",
+                update_mode="patch",
+                batch_size=2,
+                verbose=False,
+                workers=2,
+            )
+        assert {e["id"] for e in result["edits"]} == {"1", "2", "3", "4"}


### PR DESCRIPTION
## Summary

Fixes #194. When `merge_batch_size` is 1, `_hierarchical_merge` splits patches into batches of length 1, each of which is passed through unchanged (`if len(batch) == 1: next_level[idx] = batch[0]`). The `while len(current) > 1` loop never shrinks and hangs forever.

Credit to @sonnietran190586 for the precise root-cause analysis in the issue report.

## Changes

1. **`skillopt/engine/trainer.py`** — validate `merge_batch_size` next to the existing `batch_size` / `accumulation` guards:

   ```python
   if merge_bs < 2:
       raise ValueError(f"merge_batch_size must be >= 2, got {merge_bs}")
   ```

2. **`skillopt/gradient/aggregate.py`** — defensive floor at the start of `_hierarchical_merge` so direct callers also cannot hang:

   ```python
   batch_size = max(2, batch_size)
   ```

3. **`tests/test_hierarchical_merge.py`** — unit tests that `batch_size=1` and `batch_size=0` terminate with a correct merged result (stubbed `_merge_batch`), plus a normal `batch_size=2` path.

## Config note (issue requested a YAML fix)

The issue also asked to update `configs/searchqa/claude_code_smoke.yaml` (shipped with `merge_batch_size: 1`). **That file no longer exists on current `main`.** A repo-wide check of `merge_batch_size` in config files shows only:

- `configs/_base_/default.yaml` → `merge_batch_size: 8`
- `configs/{alfworld,spreadsheetbench,officeqa,docvqa,searchqa}/default.yaml` → `merge_batch_size: 8`

So the config part of the original report is moot on current main; only the code guards apply.

## Test plan

```bash
pytest tests/test_hierarchical_merge.py -v
```

Results (local, Python 3.12 + project `.[dev]`):

```
tests/test_hierarchical_merge.py::TestHierarchicalMergeBatchSizeGuard::test_batch_size_one_terminates_and_merges PASSED
tests/test_hierarchical_merge.py::TestHierarchicalMergeBatchSizeGuard::test_batch_size_zero_terminates PASSED
tests/test_hierarchical_merge.py::TestHierarchicalMergeBatchSizeGuard::test_normal_batch_size_still_merges PASSED
============================== 3 passed in 0.77s ===============================