### PR TITLE
fix(sleep): validate proposal content before staging

### DIFF
--- a/skillopt_sleep/staging.py
+++ b/skillopt_sleep/staging.py
@@ -346,6 +346,11 @@ def skill_proposal_rows(proposals: Iterable[SkillProposal]) -> List[Dict[str, An
         name = _safe_skill_name(proposal.skill_name)
         if not name:
             raise StagingError(f"unsafe skill name for staging: {proposal.skill_name!r}")
+        if not isinstance(proposal.proposed_skill, str):
+            raise StagingError(
+                f"proposed skill content for {name!r} must be text, "
+                f"got {type(proposal.proposed_skill).__name__}"
+            )
         live = _safe_live_path(proposal.live_skill_path)
         if not live:
             raise StagingError(

--- a/tests/test_sleep_staging_fanout.py
+++ b/tests/test_sleep_staging_fanout.py
@@ -151,6 +151,15 @@ class TestWriteSkillProposals(unittest.TestCase):
                 write_skill_proposals(tmp, [_proposal("alpha"), _proposal("../escape")])
             self.assertEqual(os.listdir(tmp), [])
 
+    def test_non_text_proposal_leaves_no_partial_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(StagingError, "must be text"):
+                write_skill_proposals(
+                    tmp,
+                    [_proposal("alpha", "# alpha\n"), _proposal("beta", None)],
+                )
+            self.assertEqual(os.listdir(tmp), [])
+
     def test_writes_leave_no_temporary_files_behind(self):
         with tempfile.TemporaryDirectory() as tmp:
             write_skill_proposals(tmp, [_proposal("alpha")])


### PR DESCRIPTION
Follow-up to #188.

Validate every proposed skill body before creating the output directory or writing any staged file. This prevents a later non-text proposal from raising TypeError after earlier proposals have already been persisted, and preserves the documented no-partial-files contract for invalid input.

Regression coverage exercises a valid first proposal followed by an invalid body and asserts that staging remains empty.

Validation:
- focused fan-out suite: 21 passed
- full test suite: 920 passed, 6 skipped, 130 subtests passed
- Ruff: passed

Refs #188.