### PR TITLE
docs: add Novita AI to openai_compatible backend examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ export AZURE_OPENAI_AUTH_MODE=api_key
 # export OPENAI_COMPATIBLE_BASE_URL=https://api.deepseek.com/v1
 # export OPENAI_COMPATIBLE_API_KEY=sk-...
 # export OPENAI_COMPATIBLE_MODEL=deepseek-chat
+# Novita AI (OpenAI-compatible) works the same way:
+# export OPENAI_COMPATIBLE_BASE_URL=https://api.novita.ai/openai/v1
+# export OPENAI_COMPATIBLE_API_KEY=...
+# export OPENAI_COMPATIBLE_MODEL=zai-org/glm-5.2
 # Per-role overrides use OPTIMIZER_OPENAI_COMPATIBLE_* and
 # TARGET_OPENAI_COMPATIBLE_* (BASE_URL, API_KEY, MODEL, TEMPERATURE,
 # MAX_TOKENS, TIMEOUT_SECONDS).

--- a/docs/guide/new-backend.md
+++ b/docs/guide/new-backend.md
@@ -22,6 +22,7 @@ A single `base_url` + `api_key` pair lets you point SkillOpt at, for example:
 | DeepSeek | `https://api.deepseek.com/v1` | `deepseek-chat` |
 | Groq | `https://api.groq.com/openai/v1` | `llama-3.3-70b-versatile` |
 | Together AI | `https://api.together.xyz/v1` | `meta-llama/Llama-3.3-70B-Instruct-Turbo` |
+| Novita AI | `https://api.novita.ai/openai/v1` | `zai-org/glm-5.2` |
 | Ollama (local) | `http://localhost:11434/v1` | `qwen2.5:7b` |
 | vLLM / SGLang / TGI | `http://localhost:8000/v1` | your served model |
 | LiteLLM proxy | `http://localhost:4000` | any proxied model |


### PR DESCRIPTION

## Summary

Adds Novita AI as an example provider for the existing `openai_compatible` backend, alongside DeepSeek, Groq, and Together AI. Novita AI exposes an OpenAI-compatible endpoint, so no new backend module or registration is needed.

## Changes

- `docs/guide/new-backend.md`: add a Novita AI row to the provider examples table
- `.env.example`: add a commented Novita AI example block under the `OPENAI_COMPATIBLE_*` section

## Verification

- `python -m pytest tests/test_openai_compatible_backend.py -q`: 4 passed
- `python -m pytest tests/ -q`: 898 passed, 6 skipped (pre-existing `openpyxl`-related skip unrelated to this change)
- `python -m mkdocs build --strict`: passed
- Manually exercised `skillopt.model.chat_optimizer()` against `https://api.novita.ai/openai/v1` with `zai-org/glm-5.2`, confirming a non-empty response and usage accounting
