### PR TITLE
docs(guide): document OrcaRouter as an openai_compatible provider example

### DIFF
--- a/docs/guide/new-backend.md
+++ b/docs/guide/new-backend.md
@@ -26,6 +26,12 @@ A single `base_url` + `api_key` pair lets you point SkillOpt at, for example:
 | vLLM / SGLang / TGI | `http://localhost:8000/v1` | your served model |
 | LiteLLM proxy | `http://localhost:4000` | any proxied model |
 | OpenRouter / Fireworks / xAI / … | provider base URL | provider model id |
+| OrcaRouter | `https://api.orcarouter.ai/v1` | `openai/gpt-5.5` |
+
+[OrcaRouter](https://www.orcarouter.ai) exposes OpenAI, Anthropic, Google,
+DeepSeek and other models behind one OpenAI-compatible endpoint. Its model IDs
+are namespaced by upstream provider (e.g. `openai/gpt-5.5`,
+`anthropic/claude-sonnet-4.6`), so pass a namespaced ID as the model.
 
 ### Python API
 


### PR DESCRIPTION
## Summary

Documents [OrcaRouter](https://www.orcarouter.ai) as a drop-in provider for the built-in `openai_compatible` backend in the model backend guide. OrcaRouter is an OpenAI-compatible model routing gateway that exposes OpenAI, Anthropic, Google, DeepSeek and other models behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

No code changes are needed: the generic backend already speaks the OpenAI Chat Completions protocol, so the integration is a documentation entry alongside the existing DeepSeek, Groq, Together AI, Ollama and LiteLLM examples.

## What this changes

- `docs/guide/new-backend.md`: adds OrcaRouter to the `openai_compatible` provider table (`base_url` + example model), plus a short note that its model IDs are namespaced by upstream provider (e.g. `openai/gpt-5.5`) and must be passed as-is.

## Verification

### Docs build

- `python -m mkdocs build --strict` passes.

### L3 live (official `openai` SDK, same call path as the `openai_compatible` backend)

All against `https://api.orcarouter.ai/v1` with an `sk-orca-` key and a standard tool-calling request:

- `openai/gpt-5.5` → HTTP 200, tool call returned (namespaced ID passes through verbatim)
- `orcarouter/fusion-mini` → HTTP 200, tool call returned
- `orcarouter/auto` → HTTP 200, tool call returned
- Negative control: a bare model name (`gpt-5.5`) is rejected with `503 No available channel`, which is why the docs tell users to use a namespaced ID

I'm an engineer on the OrcaRouter team.
