### PR TITLE
feat(sleep): add OpenCode CLI backend for plain replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to SkillOpt are documented here. This project adheres to
 ## [Unreleased]
 
 ### Added
+- **OpenCode CLI backend** (`--backend opencode`) for SkillOpt-Sleep model calls,
+  including plain task replay, using an installed OpenCode CLI with the user's
+  existing login and file-based global configuration. Calls parse OpenCode's
+  JSONL output and disable project configuration, tool use, external plugins,
+  and configured MCP servers. Transcript harvesting and tool-aware replay
+  remain follow-up work.
 - **GitHub Copilot CLI backend**, in two forms: `copilot_chat` (usable as both
   optimizer and target) and `copilot_exec` (target-only execution harness).
   Because the Copilot CLI carries its own sign-in, `--backend copilot` selects
@@ -86,6 +92,8 @@ All notable changes to SkillOpt are documented here. This project adheres to
   @Alphaxalchemy's #129).
 
 ### Tests
+- Add focused OpenCode backend coverage and opt-in real-CLI smoke tests for a
+  plain call and a seeded cycle-level run.
 - Strengthen SkillOpt-Sleep verifier-discipline assertions, including recorded
   scores and gate actions (thanks @Tanmay9223, #96).
 - Add focused coverage for the validation-gate decision core and edit-budget

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4,9 +4,9 @@
 > include the generic research `openai_compatible` backend, Sleep handoff,
 > Sleep support for non-Azure OpenAI-compatible endpoints, the Sleep
 > `--preferences` flag, the research `cursor_exec` target harness, or Cursor
-> source/backend/plugin support, Pi source/backend support, or VS Code Copilot
-> transcript harvesting; use a source install from `main` for those features
-> until the next release.
+> source/backend/plugin support, Pi source/backend support, the OpenCode Sleep
+> backend, or VS Code Copilot transcript harvesting; use a source install from
+> `main` for those features until the next release.
 
 ## Training
 
@@ -130,13 +130,14 @@ Actions are `run`, `dry-run`, `status`, `adopt`, `harvest`, `schedule`, and
 | `--project PATH` | Project used for transcript scope, targets, state, and staging (default: current directory) |
 | `--scope invoked\|all` | Harvest this project or all projects |
 | `--source claude\|codex\|copilot\|cursor\|pi\|auto` | Transcript source; `auto` keeps Codex-then-Claude precedence and does not select Copilot, Cursor, or Pi |
-| `--backend mock\|claude\|codex\|copilot\|cursor\|pi\|handoff\|azure_openai` | Replay/optimizer backend |
+| `--backend mock\|claude\|codex\|copilot\|cursor\|pi\|opencode\|handoff\|azure_openai` | Replay/optimizer backend |
 | `--model NAME` | Backend-specific model override |
 | `--cursor-home PATH` | Override `~/.cursor` for Cursor transcript harvesting |
 | `--pi-home PATH` | Parent directory containing Pi's `agent/sessions` tree (default: `~/.pi`) |
 | `--vscode-workspace-storage PATH` | Override VS Code's `User/workspaceStorage` root for Copilot transcript harvesting |
 | `--cursor-path PATH` | Path to the installed Cursor Agent CLI |
 | `--pi-path PATH` | Path to the installed Pi coding-agent CLI |
+| `--opencode-path PATH` | Path to the installed OpenCode CLI |
 | `--preferences TEXT` | House rules supplied to reflection |
 | `--lookback-hours N` | Initial transcript lookback; `0` scans all history |
 | `--max-sessions N` / `--max-tasks N` | Bound the harvested workload |
@@ -212,6 +213,54 @@ The managed `schedule` command preserves the backend but not `--source`,
 `transcript_source`, `pi_home`, `pi_path`, and `model` in
 `~/.skillopt-sleep/config.json`; use an absolute `pi_path` and verify
 authentication for the scheduled account.
+
+### OpenCode backend
+
+Install and configure OpenCode using its
+[official documentation](https://opencode.ai/docs/), then confirm the CLI is
+available with `opencode --version`.
+
+`--backend opencode` runs SkillOpt's model calls for mining, plain task replay,
+judging, and reflection through an installed OpenCode CLI. It uses the user's
+existing OpenCode login, provider environment variables, and file-based global
+configuration; SkillOpt does not manage OpenCode accounts or provider
+credentials. Transcript sources remain independent, and there is not yet a
+`--source opencode` harvester.
+
+If OpenCode is on `PATH`, no path option is needed. Otherwise use
+`--opencode-path`, the `opencode_path` config key, or
+`SKILLOPT_SLEEP_OPENCODE_PATH`. Use `--model`, the `model` config key, or
+`SKILLOPT_SLEEP_OPENCODE_MODEL` to override OpenCode's configured model:
+
+```bash
+skillopt-sleep run --project "$(pwd)" \
+  --source codex --backend opencode \
+  --opencode-path /absolute/path/to/opencode \
+  --model provider/model --max-sessions 5 --max-tasks 3 --progress
+```
+
+Plain calls run from a temporary directory with project configuration, tool
+use, and external plugins disabled. Before contacting the model, SkillOpt
+discovers the resolved MCP configuration, disables every
+configured MCP server for the call, and verifies that none remains enabled. If
+that check fails, the model call is not made. Tool-aware replay is not yet
+supported.
+
+The child process keeps normal OpenCode file-based global configuration and
+data directories. SkillOpt sets `OPENCODE_CONFIG_CONTENT` for the child process
+to define the temporary agent and disable configured MCP servers. This replaces
+the user's existing value in that child process, so settings supplied only
+through that value are unavailable. Because `--pure` skips external plugins,
+authentication or provider setup that depends on one of those plugins is also
+unavailable. Calls may appear in the user's normal OpenCode session history;
+these controls are invocation settings, not complete account or process
+isolation.
+
+The managed scheduler stores the backend but not `--opencode-path`, `--model`,
+or the transcript source. Before scheduling OpenCode, put `opencode_path`,
+`model`, and `transcript_source` in `~/.skillopt-sleep/config.json` as needed.
+Prefer an absolute executable path and verify OpenCode access for the account
+that runs the scheduled job.
 
 ### Cursor source and backend
 

--- a/docs/sleep/README.md
+++ b/docs/sleep/README.md
@@ -90,8 +90,8 @@ skillopt-sleep schedule     # install a nightly cron entry for this project
 > **Version note.** This page tracks `main`. PyPI 0.2.0 provides the base
 > commands above. Cursor source/backend/plugin support, VS Code Copilot
 > transcript harvesting, Pi source/backend support, Sleep handoff, non-Azure
-> OpenAI-compatible endpoints, and `--preferences` landed later and require a
-> source install from `main` until the next release.
+> OpenAI-compatible endpoints, the OpenCode Sleep backend, and `--preferences`
+> landed later and require a source install from `main` until the next release.
 
 The per-agent integrations below still come from the repo; the CLI above is the
 standalone, pip-only way to run a cycle. Claude Code, Codex, Cursor, Copilot, and
@@ -169,6 +169,40 @@ The managed scheduler records the backend but does not preserve `--source`,
 `transcript_source`, `pi_home`, `pi_path`, and `model` in
 `~/.skillopt-sleep/config.json`. Use an absolute `pi_path` and verify the
 scheduled account's Pi authentication.
+
+### OpenCode
+
+Install and configure OpenCode using its
+[official documentation](https://opencode.ai/docs/), then confirm the CLI is
+available with `opencode --version`.
+
+`--backend opencode` sends SkillOpt's model calls for mining, plain task replay,
+judging, and reflection through an installed OpenCode CLI, using the user's
+existing login, provider environment variables, and file-based global
+configuration. Select a binary and model only when the OpenCode defaults are
+not suitable:
+
+```bash
+skillopt-sleep run --project "$(pwd)" \
+  --source codex --backend opencode \
+  --opencode-path /absolute/path/to/opencode --model provider/model
+```
+
+For plain calls, SkillOpt disables project configuration, tool use, external
+plugins, and configured MCP servers. It stops before the model call if it cannot
+confirm that every resolved MCP server is disabled. The subprocess keeps
+OpenCode's normal data directory, so calls may appear in the user's OpenCode
+session history. SkillOpt sets `OPENCODE_CONFIG_CONTENT` for the child process
+to define the temporary agent and disable configured MCP servers. This replaces
+the user's existing value in that child process, so settings supplied only
+through that value are unavailable; use file-based global configuration or
+provider environment variables instead.
+
+OpenCode transcript harvesting and tool-aware replay are not implemented yet.
+For scheduling, put `opencode_path`, `model`, and the desired
+`transcript_source` in `~/.skillopt-sleep/config.json` as needed, and verify the
+scheduled account can run OpenCode. See the
+[CLI reference](../reference/cli.md#opencode-backend) for full details.
 
 ### Cursor
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -48,8 +48,8 @@ an importable `skillopt_sleep` module. Install with `uv tool install skillopt` o
 > **Version note.** This integration reference tracks `main`. PyPI 0.2.0
 > supports the base Sleep CLI, while Cursor source/backend/plugin support,
 > Pi source/backend support, handoff, Sleep support for non-Azure
-> OpenAI-compatible endpoints, and `--preferences` require a source checkout
-> from `main` until the next release.
+> OpenAI-compatible endpoints, the OpenCode Sleep backend, and `--preferences`
+> require a source checkout from `main` until the next release.
 
 ## One sleep cycle
 
@@ -93,6 +93,12 @@ optimization.
   retained for scope filtering and may appear in miner prompts sent to a real
   backend and its provider. Known secret-shaped strings in retained message text
   are redacted only as defense in depth.
+- The core `opencode` backend uses the installed OpenCode CLI for plain model
+  calls. It keeps the user's login and file-based global configuration
+  while disabling project configuration, tool use, external plugins, and
+  configured MCP servers for those calls. OpenCode transcript harvesting,
+  tool-aware replay, and a native OpenCode plugin or command are not included
+  yet.
 - Outbound prompts are not currently guaranteed to be free of secrets. Do not
   use a third-party provider on sensitive transcripts without reviewing the data
   source and the provider's retention policy.
@@ -128,13 +134,14 @@ Common implemented flags include:
 
 | Flag | Default | Purpose |
 |---|---|---|
-| `--backend mock\|claude\|codex\|cursor\|copilot\|pi\|handoff\|azure_openai` | `mock` | select who performs model calls |
+| `--backend mock\|claude\|codex\|cursor\|copilot\|pi\|opencode\|handoff\|azure_openai` | `mock` | select who performs model calls |
 | `--model NAME` | backend default | select a backend-specific model |
 | `--source claude\|codex\|copilot\|cursor\|pi\|auto` | `claude` | select the transcript source; `auto` retains Codex-then-Claude precedence and does not select Copilot, Cursor, or Pi |
 | `--cursor-home PATH` | `~/.cursor` | override the Cursor transcript home |
 | `--cursor-path PATH` | auto-detect `cursor-agent` | select the Cursor Agent CLI executable |
 | `--pi-home PATH` | `~/.pi` | select the parent directory containing `agent/sessions` |
 | `--pi-path PATH` | auto-detect `pi` | select the Pi coding-agent CLI executable |
+| `--opencode-path PATH` | `SKILLOPT_SLEEP_OPENCODE_PATH`, then `opencode` on `PATH`/`PATHEXT` | select the OpenCode CLI executable |
 | `--project PATH` | current directory | select the project and invoked harvest scope |
 | `--scope invoked\|all` | `invoked` | limit transcript harvesting |
 | `--target-skill-path PATH` | managed skill | select a specific `SKILL.md` to stage/adopt |

--- a/plugins/openclaw/run_sleep.py
+++ b/plugins/openclaw/run_sleep.py
@@ -43,6 +43,7 @@ def get_backend(
     codex_path="",
     pi_path="",
     cursor_path="",
+    opencode_path="",
     azure_endpoint="",
     project_dir="",
 ):
@@ -55,6 +56,7 @@ def get_backend(
         codex_path=codex_path,
         pi_path=pi_path,
         cursor_path=cursor_path,
+        opencode_path=opencode_path,
         azure_endpoint=azure_endpoint,
         project_dir=project_dir,
     )

--- a/skillopt_sleep/__main__.py
+++ b/skillopt_sleep/__main__.py
@@ -13,7 +13,7 @@ Common flags:
     --max-tasks N       cap mined tasks per run
     --target-skill-path PATH explicit live SKILL.md to stage/adopt
     --tasks-file PATH   reviewed TaskRecord JSON file to replay instead of harvesting
-    --backend mock|claude|codex|copilot|cursor|pi|handoff|azure_openai
+    --backend mock|claude|codex|copilot|cursor|pi|opencode|handoff|azure_openai
     --source claude|codex|copilot|copilot_cli|cursor|pi|auto
     --vscode-workspace-storage PATH
     --copilot-cli-session-store PATH
@@ -74,11 +74,12 @@ def _add_common(p: argparse.ArgumentParser) -> None:
     p.add_argument("--scope", default="", choices=["", "all", "invoked"])
     p.add_argument("--backend", default="",
                    choices=["", "mock", "claude", "codex", "copilot", "cursor", "pi",
-                            "handoff", "azure_openai"])
+                            "opencode", "handoff", "azure_openai"])
     p.add_argument("--model", default="")
     p.add_argument("--codex-path", default="", help="path to the real @openai/codex binary")
     p.add_argument("--cursor-path", default="", help="path to the Cursor Agent CLI")
     p.add_argument("--pi-path", default="", help="path to the Pi coding-agent CLI")
+    p.add_argument("--opencode-path", default="", help="path to the OpenCode CLI")
     p.add_argument("--claude-home", default="", help="override ~/.claude (also isolates state)")
     p.add_argument("--codex-home", default="", help="override ~/.codex for archived session harvest")
     p.add_argument("--cursor-home", default="", help="override ~/.cursor for Cursor session harvest")
@@ -126,6 +127,8 @@ def _cfg_from_args(args, task_meta: Dict[str, Any] | None = None) -> Any:
         overrides["pi_path"] = os.path.abspath(os.path.expanduser(args.pi_path))
     if getattr(args, "cursor_path", ""):
         overrides["cursor_path"] = os.path.abspath(os.path.expanduser(args.cursor_path))
+    if getattr(args, "opencode_path", ""):
+        overrides["opencode_path"] = os.path.abspath(os.path.expanduser(args.opencode_path))
     if getattr(args, "claude_home", ""):
         overrides["claude_home"] = os.path.abspath(args.claude_home)
     if getattr(args, "codex_home", ""):

--- a/skillopt_sleep/backend.py
+++ b/skillopt_sleep/backend.py
@@ -974,6 +974,56 @@ class OpenCodeCliBackend(CliBackend):
             self._cache.pop(key, None)
         return out
 
+    def _read_mcp_disabled_statuses(
+        self,
+        env: Dict[str, str],
+        work: str,
+        stage: str,
+    ) -> Optional[Dict[str, bool]]:
+        """Return whether each configured MCP server is explicitly disabled."""
+        try:
+            proc = subprocess.run(
+                [self.opencode_path, "debug", "config", "--pure"],
+                capture_output=True,
+                creationflags=_NO_WINDOW,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=self.timeout,
+                cwd=work,
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            self.last_call_error = f"OpenCode CLI {stage} timed out after {self.timeout}s"
+            return None
+        except Exception:
+            self.last_call_error = f"OpenCode CLI {stage} could not be completed"
+            return None
+
+        if proc.returncode != 0:
+            self.last_call_error = f"OpenCode CLI {stage} exited {proc.returncode}"
+            return None
+        try:
+            resolved = json.loads(proc.stdout or "")
+        except (json.JSONDecodeError, RecursionError, TypeError):
+            self.last_call_error = f"OpenCode CLI {stage} returned invalid configuration"
+            return None
+        if not isinstance(resolved, dict):
+            self.last_call_error = f"OpenCode CLI {stage} returned invalid configuration"
+            return None
+
+        mcp = resolved.get("mcp", {})
+        if not isinstance(mcp, dict):
+            self.last_call_error = f"OpenCode CLI {stage} returned invalid MCP configuration"
+            return None
+        disabled_by_name: Dict[str, bool] = {}
+        for name, entry in mcp.items():
+            if not isinstance(name, str) or not isinstance(entry, dict):
+                self.last_call_error = f"OpenCode CLI {stage} returned invalid MCP configuration"
+                return None
+            disabled_by_name[name] = entry.get("enabled") is False
+        return disabled_by_name
+
     def _call(self, prompt: str, *, max_tokens: int = 1024) -> str:
         import secrets
 
@@ -990,6 +1040,8 @@ class OpenCodeCliBackend(CliBackend):
             "json",
             "--agent",
             agent_name,
+            "--title",
+            "skillopt-sleep",
             "--dir",
             work,
         ]
@@ -1018,18 +1070,43 @@ class OpenCodeCliBackend(CliBackend):
         env["PWD"] = work
         env.pop("OLDPWD", None)
         # Define the per-call agent without changing the user's config files.
-        env["OPENCODE_CONFIG_CONTENT"] = json.dumps(
-            {
-                "agent": {
-                    agent_name: {
-                        "mode": "primary",
-                        "permission": {"*": "deny"},
-                    }
+        plain_config = {
+            "agent": {
+                agent_name: {
+                    "mode": "primary",
+                    "permission": {"*": "deny"},
                 }
-            },
+            }
+        }
+        env["OPENCODE_CONFIG_CONTENT"] = json.dumps(
+            plain_config,
             separators=(",", ":"),
         )
         try:
+            # Tool permissions alone do not disable configured MCP servers. Read
+            # the merged config, disable every server it contains, and verify the
+            # result before calling the model.
+            discovered_mcp_statuses = self._read_mcp_disabled_statuses(
+                env, work, "MCP discovery"
+            )
+            if discovered_mcp_statuses is None:
+                return ""
+            plain_config["mcp"] = {
+                name: {"enabled": False} for name in sorted(discovered_mcp_statuses)
+            }
+            env["OPENCODE_CONFIG_CONTENT"] = json.dumps(
+                plain_config,
+                separators=(",", ":"),
+            )
+            verified_mcp_statuses = self._read_mcp_disabled_statuses(
+                env, work, "MCP verification"
+            )
+            if verified_mcp_statuses is None:
+                return ""
+            if any(not disabled for disabled in verified_mcp_statuses.values()):
+                self.last_call_error = "OpenCode CLI could not disable every configured MCP server"
+                return ""
+
             try:
                 proc = subprocess.run(
                     cmd,

--- a/skillopt_sleep/backend.py
+++ b/skillopt_sleep/backend.py
@@ -864,6 +864,231 @@ class ClaudeCliBackend(CliBackend):
             except Exception:
                 pass
 
+
+def resolve_opencode_path(explicit: str = "") -> str:
+    """Find the OpenCode CLI, including Windows npm ``.CMD`` launchers."""
+    import shutil
+
+    candidate = os.path.expanduser(
+        explicit or os.environ.get("SKILLOPT_SLEEP_OPENCODE_PATH", "") or "opencode"
+    )
+    resolved = shutil.which(candidate)
+    if resolved:
+        # Make the result absolute before the child changes directory.
+        return os.path.abspath(resolved)
+    if os.path.dirname(candidate):
+        # Do the same for a path-like value even if the file does not exist yet.
+        return os.path.abspath(candidate)
+    # Otherwise let the operating system find the command on PATH when it runs.
+    return candidate
+
+
+def _parse_opencode_jsonl_text(raw: str) -> Tuple[str, str]:
+    """Extract text and an error code from one OpenCode JSONL response."""
+    text_parts: List[str] = []
+    session_id = ""
+    saw_step_start = False
+    last_known_event_type = ""
+    known_event_types = {"error", "reasoning", "step_finish", "step_start", "text", "tool_use"}
+    expected_part_types = {
+        "reasoning": "reasoning",
+        "step_finish": "step-finish",
+        "step_start": "step-start",
+        "text": "text",
+        "tool_use": "tool",
+    }
+
+    for raw_line in raw.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except (json.JSONDecodeError, RecursionError):
+            return "", "malformed_jsonl"
+        if not isinstance(event, dict):
+            return "", "invalid_event"
+
+        event_type = event.get("type")
+        event_session_id = event.get("sessionID")
+        if not isinstance(event_type, str) or not event_type:
+            return "", "invalid_event"
+        if not isinstance(event_session_id, str) or not event_session_id:
+            return "", "invalid_event"
+        if not session_id:
+            session_id = event_session_id
+        elif event_session_id != session_id:
+            return "", "mixed_session"
+
+        if event_type not in known_event_types:
+            continue
+        last_known_event_type = event_type
+        if event_type == "error":
+            return "", "error_event"
+
+        part = event.get("part")
+        if not isinstance(part, dict) or part.get("type") != expected_part_types[event_type]:
+            return "", "invalid_event"
+        if event_type == "tool_use":
+            return "", "unexpected_tool_event"
+        if event_type == "step_start":
+            saw_step_start = True
+        elif event_type == "text":
+            text = part.get("text")
+            if not isinstance(text, str):
+                return "", "invalid_event"
+            text_parts.append(text)
+
+    if not saw_step_start or last_known_event_type != "step_finish":
+        return "", "incomplete_stream"
+    text = "\n".join(text_parts).strip()
+    if not text:
+        return "", "empty_response"
+    return text, ""
+
+
+class OpenCodeCliBackend(CliBackend):
+    """Run SkillOpt model calls through the user's OpenCode CLI."""
+
+    name = "opencode"
+
+    def __init__(
+        self,
+        model: str = "",
+        opencode_path: str = "",
+        timeout: int = 180,
+    ) -> None:
+        super().__init__(
+            model=model or os.environ.get("SKILLOPT_SLEEP_OPENCODE_MODEL", ""),
+            timeout=timeout,
+        )
+        self.opencode_path = resolve_opencode_path(opencode_path)
+
+    def _cached_call(self, key: str, prompt: str, *, max_tokens: int = 1024) -> str:
+        """Do not cache failed OpenCode calls."""
+        if key in self._cache:
+            # A cached answer makes any earlier error irrelevant to this call.
+            self.last_call_error = ""
+        out = super()._cached_call(key, prompt, max_tokens=max_tokens)
+        if not out:
+            self._cache.pop(key, None)
+        return out
+
+    def _call(self, prompt: str, *, max_tokens: int = 1024) -> str:
+        import secrets
+
+        del max_tokens
+        self.last_call_error = ""
+        # Use a per-call agent so settings from the user's default agent do not apply.
+        agent_name = f"skillopt-sleep-{secrets.token_hex(16)}"
+        work = tempfile.mkdtemp(prefix="skillopt_sleep_opencode_")
+        cmd = [
+            self.opencode_path,
+            "run",
+            "--pure",
+            "--format",
+            "json",
+            "--agent",
+            agent_name,
+            "--dir",
+            work,
+        ]
+        if self.model:
+            cmd += ["--model", self.model]
+
+        # Keep the user's login and file-based global settings.
+        env = os.environ.copy()
+        # The child changes directory below, so resolve relative config paths now.
+        for key in ("OPENCODE_CONFIG", "OPENCODE_CONFIG_DIR"):
+            value = env.get(key)
+            if value:
+                env[key] = os.path.abspath(os.path.expanduser(value))
+        env.update(
+            {
+                "NO_COLOR": "1",
+                "OPENCODE_DISABLE_AUTOUPDATE": "1",
+                "OPENCODE_DISABLE_EXTERNAL_SKILLS": "1",
+                "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
+                "OPENCODE_DISABLE_SHARE": "1",
+                "OPENCODE_DISABLE_TERMINAL_TITLE": "1",
+                "OPENCODE_PERMISSION": '{"*":"deny"}',
+                "OPENCODE_PURE": "1",
+            }
+        )
+        env["PWD"] = work
+        env.pop("OLDPWD", None)
+        # Define the per-call agent without changing the user's config files.
+        env["OPENCODE_CONFIG_CONTENT"] = json.dumps(
+            {
+                "agent": {
+                    agent_name: {
+                        "mode": "primary",
+                        "permission": {"*": "deny"},
+                    }
+                }
+            },
+            separators=(",", ":"),
+        )
+        try:
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    creationflags=_NO_WINDOW,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=self.timeout,
+                    cwd=work,
+                    env=env,
+                    input=prompt,
+                )
+            except subprocess.TimeoutExpired:
+                self.last_call_error = f"OpenCode CLI timed out after {self.timeout}s"
+                return ""
+            except Exception:
+                self.last_call_error = "OpenCode CLI could not be executed"
+                return ""
+        finally:
+            try:
+                import shutil
+
+                shutil.rmtree(work, ignore_errors=True)
+            except Exception:
+                pass
+
+        if proc.returncode != 0:
+            self.last_call_error = f"OpenCode CLI exited {proc.returncode}"
+            return ""
+        text, error_code = _parse_opencode_jsonl_text(proc.stdout or "")
+        if error_code:
+            error_messages = {
+                "malformed_jsonl": "OpenCode CLI returned malformed JSONL",
+                "invalid_event": "OpenCode CLI returned an invalid JSONL event",
+                "mixed_session": "OpenCode CLI returned mixed sessions",
+                "error_event": "OpenCode CLI emitted an error event",
+                "unexpected_tool_event": "OpenCode CLI attempted unsupported tool use",
+                "incomplete_stream": "OpenCode CLI returned an incomplete stream",
+                "empty_response": "OpenCode CLI returned an empty response",
+            }
+            self.last_call_error = error_messages.get(
+                error_code, "OpenCode CLI returned an unknown JSONL error"
+            )
+            return ""
+        return text
+
+    def attempt_with_tools(
+        self,
+        task: TaskRecord,
+        skill: str,
+        memory: str,
+        tools: List[str],
+    ) -> Tuple[str, List[str]]:
+        del task, skill, memory, tools
+        self.last_call_error = "OpenCode CLI tool replay is not supported"
+        return "", []
+
+
 def resolve_codex_path(explicit: str = "") -> str:
     """Find the REAL `@openai/codex` binary, skipping the hermes wrapper.
 
@@ -1977,6 +2202,7 @@ def get_backend(
     codex_path: str = "",
     pi_path: str = "",
     cursor_path: str = "",
+    opencode_path: str = "",
     azure_endpoint: str = "",
     project_dir: str = "",
 ) -> Backend:
@@ -1996,6 +2222,8 @@ def get_backend(
         return CopilotCliBackend(model=model)
     if n in {"cursor", "cursor_agent", "cursor_cli"}:
         return CursorCliBackend(model=model, cursor_path=cursor_path)
+    if n in {"opencode", "opencode_cli", "opencode-cli"}:
+        return OpenCodeCliBackend(model=model, opencode_path=opencode_path)
     if n in {"handoff", "session", "file"}:
         # Lazy import: handoff_backend imports CliBackend from this module.
         from skillopt_sleep.handoff_backend import HandoffBackend
@@ -2017,6 +2245,7 @@ def build_backend(
     codex_path: str = "",
     pi_path: str = "",
     cursor_path: str = "",
+    opencode_path: str = "",
     azure_endpoint: str = "",
     preferences: str = "",
     project_dir: str = "",
@@ -2036,6 +2265,7 @@ def build_backend(
             codex_path=codex_path,
             pi_path=pi_path,
             cursor_path=cursor_path,
+            opencode_path=opencode_path,
             azure_endpoint=azure_endpoint,
             project_dir=project_dir,
         )
@@ -2043,11 +2273,11 @@ def build_backend(
         return be
     tgt = get_backend(target_backend or backend, model=target_model or model,
                       codex_path=codex_path, pi_path=pi_path, cursor_path=cursor_path,
-                      azure_endpoint=azure_endpoint,
+                      opencode_path=opencode_path, azure_endpoint=azure_endpoint,
                       project_dir=project_dir)
     opt = get_backend(optimizer_backend or backend, model=optimizer_model or model,
                       codex_path=codex_path, pi_path=pi_path, cursor_path=cursor_path,
-                      azure_endpoint=azure_endpoint,
+                      opencode_path=opencode_path, azure_endpoint=azure_endpoint,
                       project_dir=project_dir)
     opt.preferences = preferences  # reflect runs on the optimizer
     dual = DualBackend(target=tgt, optimizer=opt)

--- a/skillopt_sleep/config.py
+++ b/skillopt_sleep/config.py
@@ -45,7 +45,7 @@ DEFAULTS: Dict[str, Any] = {
     "val_fraction": 0.34,         # real tasks reserved to gate updates
     "test_fraction": 0.0,         # real tasks reserved as the final held-out measure
     # ── optimizer ──────────────────────────────────────────────────────────
-    "backend": "mock",            # "mock" | "claude" | "codex" | "copilot" | "cursor" | "pi"
+    "backend": "mock",            # "mock" | "claude" | "codex" | "copilot" | "cursor" | "pi" | "opencode"
     "model": "",                  # backend-specific; "" => backend default
     # Dual-backend split (both empty => single backend above plays all roles).
     # target = the model whose skill is deployed (runs `attempt` rollouts);
@@ -59,6 +59,7 @@ DEFAULTS: Dict[str, Any] = {
     "codex_path": "",             # "" => auto-detect the real @openai/codex binary
     "pi_path": "",                # "" => use `pi` on PATH
     "cursor_path": "",            # "" => auto-detect the Cursor Agent CLI
+    "opencode_path": "",          # "" => SKILLOPT_SLEEP_OPENCODE_PATH, then `opencode` on PATH/PATHEXT
     "edit_budget": 4,             # textual learning rate (max edits/night)
     "preferences": "",            # free-text house rules injected into reflect as a prior
     "gate_metric": "mixed",       # hard | soft | mixed (mixed best for tiny holdouts)

--- a/skillopt_sleep/cycle.py
+++ b/skillopt_sleep/cycle.py
@@ -55,6 +55,7 @@ def _make_model_key(cfg: SleepConfig) -> str:
             codex_path=cfg.get("codex_path", ""),
             pi_path=cfg.get("pi_path", ""),
             cursor_path=cfg.get("cursor_path", ""),
+            opencode_path=cfg.get("opencode_path", ""),
             azure_endpoint=cfg.get("azure_endpoint", ""),
             project_dir=cfg.get("invoked_project", "") or os.getcwd(),
         )
@@ -308,6 +309,7 @@ def run_sleep_cycle(
         codex_path=cfg.get("codex_path", ""),
         pi_path=cfg.get("pi_path", ""),
         cursor_path=cfg.get("cursor_path", ""),
+        opencode_path=cfg.get("opencode_path", ""),
         azure_endpoint=cfg.get("azure_endpoint", ""),
         preferences=cfg.get("preferences", ""),
         project_dir=project,

--- a/tests/test_backend_opencode.py
+++ b/tests/test_backend_opencode.py
@@ -22,7 +22,7 @@ from skillopt_sleep.backend import (
     get_backend,
     resolve_opencode_path,
 )
-from skillopt_sleep.config import load_config
+from skillopt_sleep.config import DEFAULTS, SleepConfig, load_config
 
 
 class _FakeProc:
@@ -46,6 +46,26 @@ def _success_stream(*texts: str) -> str:
         _event("step_finish", part={"type": "step-finish"}),
     ]
     return "\n".join(lines)
+
+
+def _resolved_mcp(*names: str, disabled: bool = False) -> str:
+    mcp = {
+        name: {
+            "type": "local",
+            "command": ["mcp-server"],
+            **({"enabled": False} if disabled else {}),
+        }
+        for name in names
+    }
+    return json.dumps({"mcp": mcp})
+
+
+def _successful_plain_results(*mcp_names: str, answer: str = "answer") -> list[_FakeProc]:
+    return [
+        _FakeProc(_resolved_mcp(*mcp_names)),
+        _FakeProc(_resolved_mcp(*mcp_names, disabled=True)),
+        _FakeProc(_success_stream(answer)),
+    ]
 
 
 def test_resolve_opencode_path_precedence(monkeypatch):
@@ -166,26 +186,66 @@ def test_call_uses_stdin_temp_workspace_and_user_environment(monkeypatch, tmp_pa
     config_dir = str(tmp_path / ".opencode")
     monkeypatch.setenv("OPENCODE_CONFIG", config_path)
     monkeypatch.setenv("OPENCODE_CONFIG_DIR", config_dir)
-    monkeypatch.setenv("OPENCODE_DISABLE_PROJECT_CONFIG", "0")
+    for key in (
+        "NO_COLOR",
+        "OPENCODE_DISABLE_AUTOUPDATE",
+        "OPENCODE_DISABLE_EXTERNAL_SKILLS",
+        "OPENCODE_DISABLE_PROJECT_CONFIG",
+        "OPENCODE_DISABLE_SHARE",
+        "OPENCODE_DISABLE_TERMINAL_TITLE",
+        "OPENCODE_PURE",
+    ):
+        monkeypatch.setenv(key, "0")
+    monkeypatch.setenv("OPENCODE_PERMISSION", '{"*":"allow"}')
     monkeypatch.delenv("OPENCODE_DISABLE_DEFAULT_PLUGINS", raising=False)
-    captured = {}
+    captured = []
+    results = iter(_successful_plain_results("alpha", "beta"))
 
     def fake_run(cmd, **kwargs):
-        captured["cmd"] = cmd
-        captured.update(kwargs)
+        snapshot = dict(kwargs)
+        snapshot["env"] = kwargs["env"].copy()
+        captured.append((cmd, snapshot))
         assert os.path.isdir(kwargs["cwd"])
         assert os.listdir(kwargs["cwd"]) == []
-        return _FakeProc(_success_stream("answer"))
+        return next(results)
 
     executable = str(tmp_path / "opencode")
     be = OpenCodeCliBackend(
         model="provider/model",
         opencode_path=executable,
+        timeout=37,
     )
     with mock.patch("skillopt_sleep.backend.subprocess.run", side_effect=fake_run):
         assert be._call("do the thing") == "answer"
 
-    cmd = captured["cmd"]
+    assert len(captured) == 3
+    discovery_cmd, discovery_call = captured[0]
+    verification_cmd, verification_call = captured[1]
+    cmd, run_call = captured[2]
+    expected_child_env = {
+        "NO_COLOR": "1",
+        "OPENCODE_DISABLE_AUTOUPDATE": "1",
+        "OPENCODE_DISABLE_EXTERNAL_SKILLS": "1",
+        "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
+        "OPENCODE_DISABLE_SHARE": "1",
+        "OPENCODE_DISABLE_TERMINAL_TITLE": "1",
+        "OPENCODE_PERMISSION": '{"*":"deny"}',
+        "OPENCODE_PURE": "1",
+    }
+    for _, call in captured:
+        assert call["capture_output"] is True
+        assert call["creationflags"] == _NO_WINDOW
+        assert call["text"] is True
+        assert call["encoding"] == "utf-8"
+        assert call["errors"] == "replace"
+        assert call["timeout"] == be.timeout
+        assert call["cwd"] == run_call["cwd"]
+        assert call["env"]["PWD"] == call["cwd"]
+        assert "OLDPWD" not in call["env"]
+        for key, value in expected_child_env.items():
+            assert call["env"][key] == value
+    assert discovery_cmd == [executable, "debug", "config", "--pure"]
+    assert verification_cmd == discovery_cmd
     assert cmd[:5] == [
         executable,
         "run",
@@ -196,23 +256,21 @@ def test_call_uses_stdin_temp_workspace_and_user_environment(monkeypatch, tmp_pa
     agent_name = cmd[cmd.index("--agent") + 1]
     assert agent_name.startswith("skillopt-sleep-")
     assert agent_name != "unsafe-user-agent"
-    assert cmd[cmd.index("--dir") + 1] == captured["cwd"]
+    assert cmd[cmd.index("--title") + 1] == "skillopt-sleep"
+    assert cmd[cmd.index("--dir") + 1] == run_call["cwd"]
     assert cmd[cmd.index("--model") + 1] == "provider/model"
-    assert captured["input"] == "do the thing"
+    assert run_call["input"] == "do the thing"
+    assert "input" not in discovery_call
+    assert "input" not in verification_call
     assert "do the thing" not in cmd
-    assert captured["creationflags"] == _NO_WINDOW
-    assert captured["encoding"] == "utf-8"
-    assert captured["env"]["OPENAI_API_KEY"] == "ambient-provider-key"
-    assert captured["env"]["HOME"] == "/home/example"
-    assert captured["env"]["PWD"] == captured["cwd"]
-    assert captured["env"]["PWD"] != "/original/project"
-    assert "OLDPWD" not in captured["env"]
-    assert captured["env"]["OPENCODE_DISABLE_PROJECT_CONFIG"] == "1"
-    assert captured["env"]["OPENCODE_PERMISSION"] == '{"*":"deny"}'
-    assert captured["env"]["OPENCODE_PURE"] == "1"
-    assert captured["env"]["OPENCODE_CONFIG"] == config_path
-    assert captured["env"]["OPENCODE_CONFIG_DIR"] == config_dir
-    injected = json.loads(captured["env"]["OPENCODE_CONFIG_CONTENT"])
+    assert run_call["env"]["OPENAI_API_KEY"] == "ambient-provider-key"
+    assert run_call["env"]["HOME"] == "/home/example"
+    assert run_call["env"]["PWD"] != "/original/project"
+    assert run_call["env"]["OPENCODE_CONFIG"] == config_path
+    assert run_call["env"]["OPENCODE_CONFIG_DIR"] == config_dir
+    discovered = json.loads(discovery_call["env"]["OPENCODE_CONFIG_CONTENT"])
+    assert "mcp" not in discovered
+    injected = json.loads(run_call["env"]["OPENCODE_CONFIG_CONTENT"])
     assert injected == {
         "agent": {
             agent_name: {
@@ -220,11 +278,16 @@ def test_call_uses_stdin_temp_workspace_and_user_environment(monkeypatch, tmp_pa
                 "permission": {"*": "deny"},
             }
         },
+        "mcp": {
+            "alpha": {"enabled": False},
+            "beta": {"enabled": False},
+        },
     }
-    assert captured["env"]["OPENCODE_CONFIG_CONTENT"] != inline_config
-    assert "unsafe-user-agent" not in captured["env"]["OPENCODE_CONFIG_CONTENT"]
-    assert "OPENCODE_DISABLE_DEFAULT_PLUGINS" not in captured["env"]
-    assert not os.path.exists(captured["cwd"])
+    assert verification_call["env"]["OPENCODE_CONFIG_CONTENT"] == run_call["env"]["OPENCODE_CONFIG_CONTENT"]
+    assert run_call["env"]["OPENCODE_CONFIG_CONTENT"] != inline_config
+    assert "unsafe-user-agent" not in run_call["env"]["OPENCODE_CONFIG_CONTENT"]
+    assert "OPENCODE_DISABLE_DEFAULT_PLUGINS" not in run_call["env"]
+    assert not os.path.exists(run_call["cwd"])
     assert be.last_call_error == ""
 
 
@@ -234,18 +297,20 @@ def test_relative_opencode_config_paths_become_absolute(monkeypatch, tmp_path):
     config_dir = os.path.join("profiles", "opencode")
     monkeypatch.setenv("OPENCODE_CONFIG", config_path)
     monkeypatch.setenv("OPENCODE_CONFIG_DIR", config_dir)
-    captured = {}
+    captured = []
+    results = iter(_successful_plain_results())
 
     def fake_run(cmd, **kwargs):
-        captured.update(kwargs)
-        return _FakeProc(_success_stream("answer"))
+        captured.append(kwargs["env"].copy())
+        return next(results)
 
     be = OpenCodeCliBackend(opencode_path=str(tmp_path / "opencode"))
     with mock.patch("skillopt_sleep.backend.subprocess.run", side_effect=fake_run):
         assert be._call("hello") == "answer"
 
-    assert captured["env"]["OPENCODE_CONFIG"] == os.path.abspath(config_path)
-    assert captured["env"]["OPENCODE_CONFIG_DIR"] == os.path.abspath(config_dir)
+    assert len(captured) == 3
+    assert all(env["OPENCODE_CONFIG"] == os.path.abspath(config_path) for env in captured)
+    assert all(env["OPENCODE_CONFIG_DIR"] == os.path.abspath(config_dir) for env in captured)
 
 
 def test_empty_model_leaves_model_selection_to_opencode(monkeypatch):
@@ -253,10 +318,10 @@ def test_empty_model_leaves_model_selection_to_opencode(monkeypatch):
     be = OpenCodeCliBackend(opencode_path="opencode")
     with mock.patch(
         "skillopt_sleep.backend.subprocess.run",
-        return_value=_FakeProc(_success_stream("answer")),
+        side_effect=_successful_plain_results(),
     ) as run:
         assert be._call("hello") == "answer"
-    assert "--model" not in run.call_args.args[0]
+    assert "--model" not in run.call_args_list[-1].args[0]
 
 
 def test_each_call_uses_a_new_agent_name():
@@ -265,13 +330,13 @@ def test_each_call_uses_a_new_agent_name():
         mock.patch("secrets.token_hex", side_effect=["a" * 32, "b" * 32]),
         mock.patch(
             "skillopt_sleep.backend.subprocess.run",
-            return_value=_FakeProc(_success_stream("answer")),
+            side_effect=_successful_plain_results() + _successful_plain_results(),
         ) as run,
     ):
         assert be._call("first") == "answer"
         assert be._call("second") == "answer"
 
-    commands = [call.args[0] for call in run.call_args_list]
+    commands = [call.args[0] for call in run.call_args_list if call.args[0][1] == "run"]
     assert commands[0][commands[0].index("--agent") + 1] == ("skillopt-sleep-" + "a" * 32)
     assert commands[1][commands[1].index("--agent") + 1] == ("skillopt-sleep-" + "b" * 32)
 
@@ -287,11 +352,173 @@ def test_each_call_uses_a_new_agent_name():
 )
 def test_call_records_process_and_protocol_failures(side_effect, return_value, error_fragment):
     be = OpenCodeCliBackend(opencode_path="opencode", timeout=1)
-    patch_kwargs = {"side_effect": side_effect} if side_effect is not None else {"return_value": return_value}
-    with mock.patch("skillopt_sleep.backend.subprocess.run", **patch_kwargs):
+    run_result = side_effect if side_effect is not None else return_value
+    effects = _successful_plain_results()[:2] + [run_result]
+    with mock.patch("skillopt_sleep.backend.subprocess.run", side_effect=effects):
         assert be._call("hello") == ""
     assert error_fragment in be.last_call_error
     assert "secret path" not in be.last_call_error
+
+
+def test_mcp_reenabled_by_final_config_stops_before_model_call():
+    discovered = _FakeProc(_resolved_mcp("global-server"))
+    reenabled = _FakeProc(
+        json.dumps(
+            {
+                "mcp": {
+                    "global-server": {
+                        "type": "local",
+                        "command": ["mcp-server"],
+                        "enabled": True,
+                    }
+                }
+            }
+        )
+    )
+    be = OpenCodeCliBackend(opencode_path="opencode")
+
+    with mock.patch(
+        "skillopt_sleep.backend.subprocess.run",
+        side_effect=[discovered, reenabled],
+    ) as run:
+        assert be._call("hello") == ""
+
+    assert run.call_count == 2
+    assert all(call.args[0][1:3] == ["debug", "config"] for call in run.call_args_list)
+    assert "disable every configured MCP server" in be.last_call_error
+
+
+def test_new_enabled_mcp_in_final_config_stops_before_model_call():
+    discovered = _FakeProc(_resolved_mcp("known-server"))
+    verification = _FakeProc(
+        json.dumps(
+            {
+                "mcp": {
+                    "known-server": {"enabled": False},
+                    "new-server": {
+                        "type": "local",
+                        "command": ["mcp-server"],
+                        "enabled": True,
+                    },
+                }
+            }
+        )
+    )
+    be = OpenCodeCliBackend(opencode_path="opencode")
+
+    with mock.patch(
+        "skillopt_sleep.backend.subprocess.run",
+        side_effect=[discovered, verification],
+    ) as run:
+        assert be._call("hello") == ""
+
+    assert run.call_count == 2
+    assert all(call.args[0][1:3] == ["debug", "config"] for call in run.call_args_list)
+    assert "disable every configured MCP server" in be.last_call_error
+
+
+@pytest.mark.parametrize(
+    ("bad_result", "error_fragment"),
+    [
+        (subprocess.TimeoutExpired("opencode", 1), "timed out"),
+        (OSError("private config path"), "could not be completed"),
+        (_FakeProc("", returncode=3), "exited 3"),
+        (_FakeProc("not json"), "invalid configuration"),
+        (_FakeProc(json.dumps(["not", "an", "object"])), "invalid configuration"),
+        (_FakeProc(json.dumps({"mcp": []})), "invalid MCP configuration"),
+        (
+            _FakeProc(json.dumps({"mcp": {"server": "not an object"}})),
+            "invalid MCP configuration",
+        ),
+    ],
+)
+def test_mcp_discovery_failure_stops_before_model_call(bad_result, error_fragment):
+    be = OpenCodeCliBackend(opencode_path="opencode", timeout=1)
+
+    with mock.patch(
+        "skillopt_sleep.backend.subprocess.run",
+        side_effect=[bad_result],
+    ) as run:
+        assert be._call("hello") == ""
+
+    assert run.call_count == 1
+    assert run.call_args.args[0][1:3] == ["debug", "config"]
+    assert error_fragment in be.last_call_error
+    assert "private config path" not in be.last_call_error
+
+
+@pytest.mark.parametrize(
+    "bad_verification",
+    [
+        subprocess.TimeoutExpired("opencode", 1),
+        _FakeProc("", returncode=4),
+        _FakeProc("not json"),
+        _FakeProc(json.dumps({"mcp": {"server": []}})),
+    ],
+)
+def test_mcp_verification_failure_stops_before_model_call(bad_verification):
+    be = OpenCodeCliBackend(opencode_path="opencode")
+
+    with mock.patch(
+        "skillopt_sleep.backend.subprocess.run",
+        side_effect=[_FakeProc(_resolved_mcp("server")), bad_verification],
+    ) as run:
+        assert be._call("hello") == ""
+
+    assert run.call_count == 2
+    assert all(call.args[0][1:3] == ["debug", "config"] for call in run.call_args_list)
+    assert "MCP verification" in be.last_call_error
+
+
+def test_resolved_config_secrets_are_not_exposed(caplog):
+    secret = "resolved-provider-secret-74f92"
+    discovered = _FakeProc(
+        json.dumps(
+            {
+                "provider": {"custom": {"options": {"apiKey": secret}}},
+                "mcp": {
+                    "private-server": {
+                        "type": "remote",
+                        "url": "https://mcp.invalid",
+                        "headers": {"Authorization": secret},
+                    }
+                },
+            }
+        )
+    )
+    verification = _FakeProc(secret, stderr=secret, returncode=5)
+    be = OpenCodeCliBackend(opencode_path="opencode")
+
+    with mock.patch(
+        "skillopt_sleep.backend.subprocess.run",
+        side_effect=[discovered, verification],
+    ) as run:
+        assert be._call("hello") == ""
+
+    assert run.call_count == 2
+    assert secret not in be.last_call_error
+    assert secret not in caplog.text
+    assert secret not in run.call_args.kwargs["env"]["OPENCODE_CONFIG_CONTENT"]
+
+
+def test_mcp_checks_run_once_per_cache_miss():
+    be = OpenCodeCliBackend(opencode_path="opencode")
+    results = _successful_plain_results("server") + _successful_plain_results("server")
+
+    with mock.patch("skillopt_sleep.backend.subprocess.run", side_effect=results) as run:
+        assert be._cached_call("attempt:first", "first prompt") == "answer"
+        assert be._cached_call("attempt:first", "first prompt") == "answer"
+        assert be._cached_call("attempt:second", "second prompt") == "answer"
+
+    commands = [call.args[0][1:3] for call in run.call_args_list]
+    assert commands == [
+        ["debug", "config"],
+        ["debug", "config"],
+        ["run", "--pure"],
+        ["debug", "config"],
+        ["debug", "config"],
+        ["run", "--pure"],
+    ]
 
 
 def test_failed_call_is_not_cached():
@@ -356,4 +583,28 @@ def test_cycle_diagnostic_build_forwards_opencode_path():
     cfg = load_config(backend="opencode", opencode_path="custom-opencode")
     with mock.patch("skillopt_sleep.cycle.build_backend", return_value=MockBackend()) as builder:
         cycle._make_model_key(cfg)
+    assert builder.call_args.kwargs["opencode_path"] == "custom-opencode"
+
+
+def test_runtime_cycle_build_forwards_opencode_path(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    cfg = SleepConfig(
+        data={
+            **DEFAULTS,
+            "backend": "opencode",
+            "opencode_path": "custom-opencode",
+            "projects": "invoked",
+            "invoked_project": str(project),
+            "state_dir": str(tmp_path / "state"),
+            "claude_home": str(tmp_path / "claude-home"),
+            "evidence_log": False,
+        }
+    )
+
+    with mock.patch("skillopt_sleep.cycle.build_backend", return_value=MockBackend()) as builder:
+        outcome = cycle.run_sleep_cycle(cfg, seed_tasks=[], dry_run=True)
+
+    assert outcome.report.n_tasks == 0
+    assert builder.call_count == 1
     assert builder.call_args.kwargs["opencode_path"] == "custom-opencode"

--- a/tests/test_backend_opencode.py
+++ b/tests/test_backend_opencode.py
@@ -1,0 +1,359 @@
+"""Tests for the OpenCode CLI backend."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from unittest import mock
+
+import pytest
+
+from skillopt_sleep import cycle
+from skillopt_sleep.__main__ import _add_common, _cfg_from_args
+from skillopt_sleep.backend import (
+    _NO_WINDOW,
+    DualBackend,
+    MockBackend,
+    OpenCodeCliBackend,
+    _parse_opencode_jsonl_text,
+    build_backend,
+    get_backend,
+    resolve_opencode_path,
+)
+from skillopt_sleep.config import load_config
+
+
+class _FakeProc:
+    def __init__(self, stdout: str, stderr: str = "", returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def _event(event_type: str, *, session: str = "session-1", part=None) -> str:
+    event = {"type": event_type, "sessionID": session}
+    if part is not None:
+        event["part"] = part
+    return json.dumps(event)
+
+
+def _success_stream(*texts: str) -> str:
+    lines = [
+        _event("step_start", part={"type": "step-start"}),
+        *(_event("text", part={"type": "text", "text": text}) for text in texts),
+        _event("step_finish", part={"type": "step-finish"}),
+    ]
+    return "\n".join(lines)
+
+
+def test_resolve_opencode_path_precedence(monkeypatch):
+    monkeypatch.setenv("SKILLOPT_SLEEP_OPENCODE_PATH", "env-opencode")
+    with mock.patch("shutil.which", side_effect=lambda value: os.path.abspath(f"resolved-{value}")):
+        assert resolve_opencode_path("explicit-opencode") == os.path.abspath("resolved-explicit-opencode")
+        assert resolve_opencode_path() == os.path.abspath("resolved-env-opencode")
+
+
+def test_resolve_opencode_path_falls_back_to_path_or_command(monkeypatch, tmp_path):
+    monkeypatch.delenv("SKILLOPT_SLEEP_OPENCODE_PATH", raising=False)
+    executable = str(tmp_path / "opencode")
+    with mock.patch("shutil.which", return_value=executable):
+        assert resolve_opencode_path() == executable
+    with mock.patch("shutil.which", return_value=None):
+        assert resolve_opencode_path() == "opencode"
+
+
+def test_resolve_opencode_path_anchors_relative_path_search_result(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SKILLOPT_SLEEP_OPENCODE_PATH", raising=False)
+    resolved = os.path.join("tools", "opencode")
+
+    with mock.patch("shutil.which", return_value=resolved):
+        assert resolve_opencode_path("opencode") == os.path.abspath(resolved)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows PATHEXT shim behavior")
+def test_resolve_opencode_path_preserves_windows_cmd_shim(monkeypatch):
+    monkeypatch.delenv("SKILLOPT_SLEEP_OPENCODE_PATH", raising=False)
+    executable = r"C:\npm\opencode.CMD"
+
+    with mock.patch("shutil.which", return_value=executable):
+        assert resolve_opencode_path() == executable
+
+
+@pytest.mark.parametrize("which_result", [None, os.path.join("bin", "opencode")])
+@pytest.mark.parametrize("source", ["explicit", "environment"])
+def test_resolve_opencode_path_anchors_relative_paths(monkeypatch, tmp_path, which_result, source):
+    monkeypatch.chdir(tmp_path)
+    relative = os.path.join("bin", "opencode")
+    explicit = relative if source == "explicit" else ""
+    if source == "environment":
+        monkeypatch.setenv("SKILLOPT_SLEEP_OPENCODE_PATH", relative)
+
+    with mock.patch("shutil.which", return_value=which_result):
+        assert resolve_opencode_path(explicit) == os.path.abspath(relative)
+
+
+def test_constructor_uses_explicit_or_environment_model(monkeypatch):
+    monkeypatch.setenv("SKILLOPT_SLEEP_OPENCODE_MODEL", "env/model")
+    with mock.patch("shutil.which", return_value=None):
+        assert OpenCodeCliBackend(model="explicit/model").model == "explicit/model"
+        assert OpenCodeCliBackend().model == "env/model"
+
+
+def test_parse_opencode_jsonl_collects_text_and_ignores_extensions():
+    raw = "\n".join(
+        [
+            _event("step_start", part={"type": "step-start"}),
+            _event("future_event"),
+            _event("reasoning", part={"type": "reasoning", "text": "hidden"}),
+            _event("text", part={"type": "text", "text": "first"}),
+            "",
+            _event("text", part={"type": "text", "text": "second"}),
+            _event("step_finish", part={"type": "step-finish"}),
+        ]
+    )
+    assert _parse_opencode_jsonl_text(raw) == ("first\nsecond", "")
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_code"),
+    [
+        ("not json", "malformed_jsonl"),
+        (json.dumps(["not", "an", "object"]), "invalid_event"),
+        (json.dumps({"type": "text"}), "invalid_event"),
+        (
+            "\n".join(
+                [
+                    _event("step_start", session="a", part={"type": "step-start"}),
+                    _event("step_finish", session="b", part={"type": "step-finish"}),
+                ]
+            ),
+            "mixed_session",
+        ),
+        (_event("error"), "error_event"),
+        (
+            "\n".join(
+                [
+                    _event("step_start", part={"type": "step-start"}),
+                    _event("tool_use", part={"type": "tool", "tool": "shell"}),
+                ]
+            ),
+            "unexpected_tool_event",
+        ),
+        (_event("step_start", part={"type": "step-start"}), "incomplete_stream"),
+        (_success_stream("  "), "empty_response"),
+    ],
+)
+def test_parse_opencode_jsonl_rejects_invalid_streams(raw, expected_code):
+    assert _parse_opencode_jsonl_text(raw) == ("", expected_code)
+
+
+def test_call_uses_stdin_temp_workspace_and_user_environment(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "ambient-provider-key")
+    monkeypatch.setenv("HOME", "/home/example")
+    monkeypatch.setenv("PWD", "/original/project")
+    monkeypatch.setenv("OLDPWD", "/previous/project")
+    inline_config = json.dumps(
+        {
+            "default_agent": "unsafe-user-agent",
+            "agent": {"unsafe-user-agent": {"permission": {"bash": "allow", "edit": "allow"}}},
+        }
+    )
+    monkeypatch.setenv("OPENCODE_CONFIG_CONTENT", inline_config)
+    config_path = str(tmp_path / "custom-opencode.json")
+    config_dir = str(tmp_path / ".opencode")
+    monkeypatch.setenv("OPENCODE_CONFIG", config_path)
+    monkeypatch.setenv("OPENCODE_CONFIG_DIR", config_dir)
+    monkeypatch.setenv("OPENCODE_DISABLE_PROJECT_CONFIG", "0")
+    monkeypatch.delenv("OPENCODE_DISABLE_DEFAULT_PLUGINS", raising=False)
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured.update(kwargs)
+        assert os.path.isdir(kwargs["cwd"])
+        assert os.listdir(kwargs["cwd"]) == []
+        return _FakeProc(_success_stream("answer"))
+
+    executable = str(tmp_path / "opencode")
+    be = OpenCodeCliBackend(
+        model="provider/model",
+        opencode_path=executable,
+    )
+    with mock.patch("skillopt_sleep.backend.subprocess.run", side_effect=fake_run):
+        assert be._call("do the thing") == "answer"
+
+    cmd = captured["cmd"]
+    assert cmd[:5] == [
+        executable,
+        "run",
+        "--pure",
+        "--format",
+        "json",
+    ]
+    agent_name = cmd[cmd.index("--agent") + 1]
+    assert agent_name.startswith("skillopt-sleep-")
+    assert agent_name != "unsafe-user-agent"
+    assert cmd[cmd.index("--dir") + 1] == captured["cwd"]
+    assert cmd[cmd.index("--model") + 1] == "provider/model"
+    assert captured["input"] == "do the thing"
+    assert "do the thing" not in cmd
+    assert captured["creationflags"] == _NO_WINDOW
+    assert captured["encoding"] == "utf-8"
+    assert captured["env"]["OPENAI_API_KEY"] == "ambient-provider-key"
+    assert captured["env"]["HOME"] == "/home/example"
+    assert captured["env"]["PWD"] == captured["cwd"]
+    assert captured["env"]["PWD"] != "/original/project"
+    assert "OLDPWD" not in captured["env"]
+    assert captured["env"]["OPENCODE_DISABLE_PROJECT_CONFIG"] == "1"
+    assert captured["env"]["OPENCODE_PERMISSION"] == '{"*":"deny"}'
+    assert captured["env"]["OPENCODE_PURE"] == "1"
+    assert captured["env"]["OPENCODE_CONFIG"] == config_path
+    assert captured["env"]["OPENCODE_CONFIG_DIR"] == config_dir
+    injected = json.loads(captured["env"]["OPENCODE_CONFIG_CONTENT"])
+    assert injected == {
+        "agent": {
+            agent_name: {
+                "mode": "primary",
+                "permission": {"*": "deny"},
+            }
+        },
+    }
+    assert captured["env"]["OPENCODE_CONFIG_CONTENT"] != inline_config
+    assert "unsafe-user-agent" not in captured["env"]["OPENCODE_CONFIG_CONTENT"]
+    assert "OPENCODE_DISABLE_DEFAULT_PLUGINS" not in captured["env"]
+    assert not os.path.exists(captured["cwd"])
+    assert be.last_call_error == ""
+
+
+def test_relative_opencode_config_paths_become_absolute(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    config_path = os.path.join("profiles", "opencode.json")
+    config_dir = os.path.join("profiles", "opencode")
+    monkeypatch.setenv("OPENCODE_CONFIG", config_path)
+    monkeypatch.setenv("OPENCODE_CONFIG_DIR", config_dir)
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        return _FakeProc(_success_stream("answer"))
+
+    be = OpenCodeCliBackend(opencode_path=str(tmp_path / "opencode"))
+    with mock.patch("skillopt_sleep.backend.subprocess.run", side_effect=fake_run):
+        assert be._call("hello") == "answer"
+
+    assert captured["env"]["OPENCODE_CONFIG"] == os.path.abspath(config_path)
+    assert captured["env"]["OPENCODE_CONFIG_DIR"] == os.path.abspath(config_dir)
+
+
+def test_empty_model_leaves_model_selection_to_opencode(monkeypatch):
+    monkeypatch.delenv("SKILLOPT_SLEEP_OPENCODE_MODEL", raising=False)
+    be = OpenCodeCliBackend(opencode_path="opencode")
+    with mock.patch(
+        "skillopt_sleep.backend.subprocess.run",
+        return_value=_FakeProc(_success_stream("answer")),
+    ) as run:
+        assert be._call("hello") == "answer"
+    assert "--model" not in run.call_args.args[0]
+
+
+def test_each_call_uses_a_new_agent_name():
+    be = OpenCodeCliBackend(opencode_path="opencode")
+    with (
+        mock.patch("secrets.token_hex", side_effect=["a" * 32, "b" * 32]),
+        mock.patch(
+            "skillopt_sleep.backend.subprocess.run",
+            return_value=_FakeProc(_success_stream("answer")),
+        ) as run,
+    ):
+        assert be._call("first") == "answer"
+        assert be._call("second") == "answer"
+
+    commands = [call.args[0] for call in run.call_args_list]
+    assert commands[0][commands[0].index("--agent") + 1] == ("skillopt-sleep-" + "a" * 32)
+    assert commands[1][commands[1].index("--agent") + 1] == ("skillopt-sleep-" + "b" * 32)
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "return_value", "error_fragment"),
+    [
+        (subprocess.TimeoutExpired("opencode", 1), None, "timed out"),
+        (OSError("secret path"), None, "could not be executed"),
+        (None, _FakeProc("misleading", returncode=2), "exited 2"),
+        (None, _FakeProc("not json"), "malformed JSONL"),
+    ],
+)
+def test_call_records_process_and_protocol_failures(side_effect, return_value, error_fragment):
+    be = OpenCodeCliBackend(opencode_path="opencode", timeout=1)
+    patch_kwargs = {"side_effect": side_effect} if side_effect is not None else {"return_value": return_value}
+    with mock.patch("skillopt_sleep.backend.subprocess.run", **patch_kwargs):
+        assert be._call("hello") == ""
+    assert error_fragment in be.last_call_error
+    assert "secret path" not in be.last_call_error
+
+
+def test_failed_call_is_not_cached():
+    be = OpenCodeCliBackend(opencode_path="opencode")
+    with mock.patch.object(be, "_call", side_effect=["", "recovered"]) as call:
+        assert be._cached_call("attempt:key", "prompt") == ""
+        assert be._cached_call("attempt:key", "prompt") == "recovered"
+    assert call.call_count == 2
+
+
+def test_cached_success_clears_stale_call_error():
+    be = OpenCodeCliBackend(opencode_path="opencode")
+    with mock.patch.object(be, "_call", return_value="answer") as call:
+        assert be._cached_call("attempt:key", "prompt") == "answer"
+        be.last_call_error = "unrelated later failure"
+        assert be._cached_call("attempt:key", "prompt") == "answer"
+    assert call.call_count == 1
+    assert be.last_call_error == ""
+
+
+def test_attempt_with_tools_fails_without_starting_child():
+    be = OpenCodeCliBackend(opencode_path="opencode")
+    with mock.patch("skillopt_sleep.backend.subprocess.run") as run:
+        assert be.attempt_with_tools(mock.Mock(), "skill", "memory", ["search"]) == ("", [])
+    run.assert_not_called()
+    assert "not supported" in be.last_call_error
+
+
+def test_get_and_build_backend_route_opencode_path():
+    with mock.patch("shutil.which", return_value=None):
+        for alias in ("opencode", "opencode_cli", "opencode-cli", "OPENCODE"):
+            assert isinstance(get_backend(alias), OpenCodeCliBackend)
+
+        single = build_backend(backend="opencode", opencode_path="custom-opencode")
+        assert isinstance(single, OpenCodeCliBackend)
+        assert single.opencode_path == "custom-opencode"
+
+        dual = build_backend(
+            backend="mock",
+            optimizer_backend="opencode",
+            target_backend="opencode",
+            opencode_path="custom-opencode",
+        )
+        assert isinstance(dual, DualBackend)
+        assert dual.optimizer.opencode_path == "custom-opencode"
+        assert dual.target.opencode_path == "custom-opencode"
+
+
+def test_cli_makes_relative_opencode_path_absolute(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    parser = argparse.ArgumentParser()
+    _add_common(parser)
+    relative = os.path.join("bin", "opencode")
+    args = parser.parse_args(["--backend", "opencode", "--opencode-path", relative])
+    monkeypatch.setattr("skillopt_sleep.config._user_config_path", lambda: None)
+    cfg = _cfg_from_args(args)
+    assert cfg.get("backend") == "opencode"
+    assert cfg.get("opencode_path") == os.path.abspath(relative)
+
+
+def test_cycle_diagnostic_build_forwards_opencode_path():
+    cfg = load_config(backend="opencode", opencode_path="custom-opencode")
+    with mock.patch("skillopt_sleep.cycle.build_backend", return_value=MockBackend()) as builder:
+        cycle._make_model_key(cfg)
+    assert builder.call_args.kwargs["opencode_path"] == "custom-opencode"

--- a/tests/test_backend_opencode_live.py
+++ b/tests/test_backend_opencode_live.py
@@ -1,0 +1,275 @@
+"""Opt-in live tests for the OpenCode CLI backend.
+
+These tests make real model calls through the user's OpenCode installation,
+account, and configuration.  They run unchanged on Windows and POSIX, but are
+skipped unless ``SKILLOPT_TEST_REAL_OPENCODE=1`` is set.  An opted-in run also
+requires an explicit model in ``SKILLOPT_SLEEP_OPENCODE_MODEL`` so the
+provider/model selection is explicit.  They may incur provider charges and
+create entries in the user's OpenCode session history.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from skillopt_sleep.backend import _NO_WINDOW, OpenCodeCliBackend, resolve_opencode_path
+from skillopt_sleep.config import DEFAULTS, SleepConfig
+from skillopt_sleep.cycle import run_sleep_cycle
+from skillopt_sleep.evidence import read_events
+from skillopt_sleep.types import TaskRecord
+
+_LIVE_ENABLED = os.environ.get("SKILLOPT_TEST_REAL_OPENCODE", "").strip() == "1"
+_PLAIN_MARKER = "SKILLOPT_OPENCODE_PLAIN_OK_7F3C"
+_CYCLE_MARKER = "SKILLOPT_OPENCODE_CYCLE_OK_9A6D"
+
+pytestmark = pytest.mark.skipif(
+    not _LIVE_ENABLED,
+    reason="set SKILLOPT_TEST_REAL_OPENCODE=1 to make real OpenCode model calls",
+)
+
+
+def _live_settings() -> tuple[str, str]:
+    """Return the model and executable required by the opted-in tests."""
+    model = os.environ.get("SKILLOPT_SLEEP_OPENCODE_MODEL", "").strip()
+    if not model:
+        pytest.fail(
+            "SKILLOPT_SLEEP_OPENCODE_MODEL is required for opted-in OpenCode live tests",
+            pytrace=False,
+        )
+
+    opencode_path = resolve_opencode_path()
+    if shutil.which(opencode_path) is None:
+        pytest.fail(
+            "OpenCode CLI was not found for an opted-in live test",
+            pytrace=False,
+        )
+    return model, opencode_path
+
+
+def _require_marker(response: str, marker: str, backend: OpenCodeCliBackend) -> None:
+    """Fail without copying provider output into pytest's assertion report."""
+    if backend.last_call_error:
+        pytest.fail("the real OpenCode call failed", pytrace=False)
+    if not response:
+        pytest.fail("the real OpenCode call returned no text", pytrace=False)
+    if marker not in response:
+        pytest.fail("the real OpenCode response did not contain the requested marker", pytrace=False)
+
+
+def _add_mcp_canary(monkeypatch, tmp_path: Path) -> tuple[Path, str]:
+    """Add a local MCP that leaves a marker if OpenCode starts it."""
+    mcp_name = f"skillopt-live-canary-{secrets.token_hex(8)}"
+    marker = tmp_path / "mcp-started.txt"
+    script = tmp_path / "mcp-canary.py"
+    script.write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('started', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    config = {
+        "$schema": "https://opencode.ai/config.json",
+        "mcp": {
+            mcp_name: {
+                "type": "local",
+                "command": [sys.executable, str(script)],
+            }
+        },
+    }
+
+    if not os.environ.get("OPENCODE_CONFIG"):
+        config_path = tmp_path / "mcp-canary-opencode.json"
+        config_path.write_text(json.dumps(config), encoding="utf-8")
+        monkeypatch.setenv("OPENCODE_CONFIG", str(config_path))
+        return marker, mcp_name
+
+    if not os.environ.get("OPENCODE_CONFIG_DIR"):
+        config_dir = tmp_path / "mcp-canary-config"
+        config_dir.mkdir()
+        (config_dir / "opencode.json").write_text(json.dumps(config), encoding="utf-8")
+        monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(config_dir))
+        return marker, mcp_name
+
+    pytest.fail(
+        "the live MCP canary needs either OPENCODE_CONFIG or OPENCODE_CONFIG_DIR to be unused",
+        pytrace=False,
+    )
+
+
+def _require_mcp_canary_configured(opencode_path: str, mcp_name: str, tmp_path: Path) -> None:
+    """Check the synthetic MCP is visible without starting MCP services."""
+    env = os.environ.copy()
+    env["OPENCODE_DISABLE_PROJECT_CONFIG"] = "1"
+    env["OPENCODE_PURE"] = "1"
+    env["PWD"] = str(tmp_path)
+    env.pop("OLDPWD", None)
+    try:
+        proc = subprocess.run(
+            [opencode_path, "debug", "config", "--pure"],
+            capture_output=True,
+            creationflags=_NO_WINDOW,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=180,
+            cwd=tmp_path,
+            env=env,
+        )
+        resolved = json.loads(proc.stdout or "") if proc.returncode == 0 else None
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError, RecursionError):
+        resolved = None
+    mcp = resolved.get("mcp") if isinstance(resolved, dict) else None
+    entry = mcp.get(mcp_name) if isinstance(mcp, dict) else None
+    if not isinstance(entry, dict) or entry.get("enabled") is False:
+        pytest.fail("the real OpenCode config did not include the MCP canary", pytrace=False)
+
+
+def test_real_opencode_plain_replay(monkeypatch, tmp_path):
+    """Exercise one public backend attempt against the real OpenCode CLI."""
+    model, opencode_path = _live_settings()
+    monkeypatch.setenv("SKILLOPT_SLEEP_PROMPTS_PATH", str(tmp_path / "no-prompt-overrides.json"))
+    mcp_marker, mcp_name = _add_mcp_canary(monkeypatch, tmp_path)
+    _require_mcp_canary_configured(opencode_path, mcp_name, tmp_path)
+
+    backend = OpenCodeCliBackend(model=model, opencode_path=opencode_path)
+    task = TaskRecord(
+        id="opencode-live-plain",
+        project=str(tmp_path),
+        intent=f"Reply with exactly this text and nothing else: {_PLAIN_MARKER}",
+        reference_kind="exact",
+        reference=_PLAIN_MARKER,
+    )
+
+    response = backend.attempt(task, skill="", memory="")
+
+    if mcp_marker.exists():
+        pytest.fail("the real OpenCode call started a configured MCP server", pytrace=False)
+    _require_marker(response, _PLAIN_MARKER, backend)
+
+
+def test_real_opencode_cycle_smoke(monkeypatch, tmp_path):
+    """Run one seeded sleep cycle through a real, factory-built OpenCode backend."""
+    model, opencode_path = _live_settings()
+    project = tmp_path / "project"
+    state_dir = tmp_path / "state"
+    claude_home = tmp_path / "claude-home"
+    project.mkdir()
+    monkeypatch.setenv("SKILLOPT_SLEEP_PROMPTS_PATH", str(tmp_path / "no-prompt-overrides.json"))
+    monkeypatch.setenv("SKILLOPT_SLEEP_WORKERS", "1")
+
+    cfg = SleepConfig(
+        data={
+            **DEFAULTS,
+            "backend": "opencode",
+            "model": model,
+            "opencode_path": opencode_path,
+            "projects": "invoked",
+            "invoked_project": str(project),
+            "state_dir": str(state_dir),
+            "claude_home": str(claude_home),
+            "gate_mode": "on",
+            "evolve_skill": False,
+            "evolve_memory": False,
+            "llm_mine": False,
+            "dream_rollouts": 1,
+            "dream_factor": 0,
+            "recall_k": 0,
+            "multi_skill_report": False,
+            "auto_adopt": False,
+            "evidence_log": True,
+            "redact_secrets": True,
+            "progress": False,
+        }
+    )
+    task = TaskRecord(
+        id="opencode-live-cycle",
+        project=str(project),
+        intent=f"Reply with exactly this text and nothing else: {_CYCLE_MARKER}",
+        reference_kind="exact",
+        reference=_CYCLE_MARKER,
+        split="val",
+    )
+
+    outcome = run_sleep_cycle(cfg, seed_tasks=[task])
+
+    staging_dir = Path(outcome.staging_dir)
+    try:
+        staging_dir.resolve().relative_to(project.resolve())
+    except (OSError, ValueError):
+        pytest.fail("the live cycle did not stage inside its temporary project", pytrace=False)
+    artifact_paths = {name: staging_dir / name for name in ("report.json", "diagnostics.json", "evidence.jsonl")}
+    if not all(path.is_file() for path in artifact_paths.values()):
+        pytest.fail("the live cycle did not write its expected staging artifacts", pytrace=False)
+
+    try:
+        with artifact_paths["diagnostics.json"].open(encoding="utf-8") as handle:
+            diagnostics = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        pytest.fail("the live cycle wrote unreadable diagnostics", pytrace=False)
+    if not isinstance(diagnostics, dict):
+        pytest.fail("the live cycle wrote invalid diagnostics", pytrace=False)
+    holdout_detail = diagnostics.get("holdout_detail")
+    holdout_entry = (
+        holdout_detail[0]
+        if isinstance(holdout_detail, list) and len(holdout_detail) == 1 and isinstance(holdout_detail[0], dict)
+        else {}
+    )
+    response_len = holdout_entry.get("response_len", 0)
+    if (
+        diagnostics.get("backend") != "opencode"
+        or diagnostics.get("call_error")
+        or not holdout_entry
+        or holdout_entry.get("hard") != 1.0
+        or not isinstance(response_len, (int, float))
+        or response_len <= 0
+    ):
+        pytest.fail("the live cycle diagnostics did not record a successful replay", pytrace=False)
+
+    events = read_events(str(artifact_paths["evidence.jsonl"]))
+    uncached_model_calls = [
+        event
+        for event in events
+        if event.get("stage") == "replay" and event.get("event") == "model_call" and not event.get("cache_hit")
+    ]
+    model_calls = [
+        event
+        for event in events
+        if event.get("stage") == "replay"
+        and event.get("event") == "model_call"
+        and event.get("kind") == "attempt"
+        and not event.get("cache_hit")
+    ]
+    replay_results = [
+        event
+        for event in events
+        if event.get("stage") == "replay" and event.get("event") == "result" and event.get("task_id") == task.id
+    ]
+    cycle_ends = [event for event in events if event.get("stage") == "cycle" and event.get("event") == "end"]
+
+    # Keep any provider text in the temporary evidence file and out of pytest output.
+    if len(uncached_model_calls) != 1 or len(model_calls) != 1:
+        pytest.fail(
+            "the live cycle did not make exactly one uncached OpenCode model call",
+            pytrace=False,
+        )
+    if _CYCLE_MARKER not in str(model_calls[0].get("response", "")):
+        pytest.fail("the live cycle did not complete one successful OpenCode attempt", pytrace=False)
+    replay_phases = {event.get("phase") for event in replay_results}
+    if (
+        len(replay_results) != 3
+        or replay_phases != {"baseline_val", "train", "final_val"}
+        or any(event.get("hard") != 1.0 for event in replay_results)
+    ):
+        pytest.fail("the live cycle did not score its seeded replay successfully", pytrace=False)
+    if len(cycle_ends) != 1 or cycle_ends[0].get("outcome") != "completed":
+        pytest.fail("the live cycle did not reach completion", pytrace=False)
+    if outcome.report.n_tasks != 1 or outcome.report.n_replayed != 1:
+        pytest.fail("the live cycle report did not record its seeded replay", pytrace=False)
+    if not outcome.staging_dir or outcome.adopted or outcome.adopted_paths:
+        pytest.fail("the live cycle did not preserve review-before-adopt behavior", pytrace=False)

--- a/tests/test_plugin_sync.py
+++ b/tests/test_plugin_sync.py
@@ -112,11 +112,13 @@ class TestPluginParity(unittest.TestCase):
         self.assertIn('claude_path="claude"', text)
         self.assertIn('pi_path=""', text)
         self.assertIn('cursor_path=""', text)
+        self.assertIn('opencode_path=""', text)
         self.assertIn('azure_endpoint=""', text)
         self.assertIn('project_dir=""', text)
         self.assertIn("claude_path=claude_path", text)
         self.assertIn("pi_path=pi_path", text)
         self.assertIn("cursor_path=cursor_path", text)
+        self.assertIn("opencode_path=opencode_path", text)
         self.assertIn("azure_endpoint=azure_endpoint", text)
         self.assertIn("project_dir=project_dir", text)
         self.assertNotIn("**kwargs", text)
@@ -130,6 +132,7 @@ from skillopt_sleep.backend import build_backend
 backend = build_backend(
     backend="mock",
     pi_path="unused-pi",
+    opencode_path="unused-opencode",
     azure_endpoint="https://unused.invalid",
 )
 assert backend.name == "mock", backend.name


### PR DESCRIPTION
Part of #56

## Implemented

- Added OpenCode as a SkillOpt Sleep backend (`--backend opencode`) and wired it through the CLI, config, backend factory, and sleep cycle.
- Added plain replay through the installed OpenCode CLI, using the user's existing OpenCode login, provider environment variables, and file-based global configuration.
- Plain replay runs from a temporary working directory with project configuration, tool use, external plugins, and configured MCP servers disabled.
- Added JSONL response parsing. Calls stop before model execution if SkillOpt cannot verify that all configured MCP servers are disabled, and failed calls are not cached.
- Added focused tests, opt-in real-CLI smoke tests, documentation, and a changelog entry.

## Validation

- Focused automated tests: `61 passed, 2 skipped`. The two opt-in live tests are skipped by default.
- Live tests used OpenCode `1.18.15` with its built-in `opencode` provider and the free `opencode/deepseek-v4-flash-free` model. No SkillOpt-specific provider credentials were configured.
- The real plain-replay and cycle-level smoke tests passed on Windows.
- The same tests passed on Ubuntu 26.04 under WSL2 with Python 3.12.13.
- Wheel and sdist builds passed, and the installed wheel passed a CLI smoke test.
- Documentation built successfully with `python -m mkdocs build --strict`.
- Full Windows test run: `932 passed, 17 skipped, 37 failed`. The 37 failures were outside the OpenCode tests and were concentrated in existing Windows-specific Devin, Superpowers, Pi, and Cursor tests.

## Scope and follow-ups

This PR covers the core OpenCode CLI backend and plain replay.

Separate follow-up work will cover:

- OpenCode transcript harvesting and `--source opencode`
- Structured tool replay with explicit opt-in
- A native OpenCode Sleep plugin or command
- Optional OpenCode support in the Copilot and Devin Sleep MCP integrations
- A documented OpenCode version range and improved error reporting