### PR TITLE
fix(config): retire gradient.max_analyst_rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,9 @@ All notable changes to SkillOpt are documented here. This project adheres to
 - Configuration files are read explicitly as UTF-8 (thanks @nankingjing,
   #124).
 - `gradient.max_analyst_rounds` is retired: it was parsed and logged but never
-  reached reflection. `--max_analyst_rounds` is still accepted and now warns
-  (thanks @xs229, #213).
+  reached reflection. Every way of still supplying it (`--max_analyst_rounds`,
+  `--cfg-options`, or a structured or legacy flat config file) is accepted and
+  warns rather than being dropped in silence (thanks @xs229, #213).
 
 ### Fixed
 - Preserve fractional rollout hard scores instead of coercing them to binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ All notable changes to SkillOpt are documented here. This project adheres to
   unsupported temperature parameters (thanks @chirag127, #128).
 - Configuration files are read explicitly as UTF-8 (thanks @nankingjing,
   #124).
+- `gradient.max_analyst_rounds` is retired: it was parsed and logged but never
+  reached reflection. `--max_analyst_rounds` is still accepted and now warns
+  (thanks @xs229, #213).
 
 ### Fixed
 - Preserve fractional rollout hard scores instead of coercing them to binary
@@ -95,7 +98,7 @@ All notable changes to SkillOpt are documented here. This project adheres to
 Thank you to the contributors behind this unreleased work:
 @AKhozya, @Alphaxalchemy, @Phoenix0531-sudo, @SparshGarg999,
 @Tanmay9223, @chirag127, @codeL1985, @dimitarvdenev,
-@ichoosetoaccept, @jcforever1, @nankingjing, and
+@ichoosetoaccept, @jcforever1, @nankingjing, @xs229, and
 @zixuanguo786-ctrl.
 
 ## [0.2.0] — 2026-07-02

--- a/configs/_base_/default.yaml
+++ b/configs/_base_/default.yaml
@@ -78,7 +78,6 @@ gradient:
   minibatch_size: 8
   merge_batch_size: 8
   analyst_workers: 16
-  max_analyst_rounds: 3
   failure_only: false
 
 optimizer:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -96,7 +96,6 @@ train:
 gradient:
   minibatch_size: 8              # Reflect minibatch size
   analyst_workers: 16            # Parallel reflection workers
-  max_analyst_rounds: 3          # Max rounds of analyst reflection
   failure_only: false            # Only reflect on failures
 ```
 

--- a/docs/guide/local-env-smoke.md
+++ b/docs/guide/local-env-smoke.md
@@ -74,7 +74,6 @@ gradient:
   minibatch_size: 1
   merge_batch_size: 2
   analyst_workers: 1
-  max_analyst_rounds: 1
 
 optimizer:
   learning_rate: 1

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -93,7 +93,6 @@ defaults to `claude` and can be overridden with `CLAUDE_CLI_BIN`.
 | `gradient.minibatch_size` | int | `8` | Reflect minibatch size |
 | `gradient.merge_batch_size` | int | `8` | Patch merge batch size |
 | `gradient.analyst_workers` | int | `16` | Parallel reflection workers |
-| `gradient.max_analyst_rounds` | int | `3` | Maximum analyst rounds |
 | `gradient.failure_only` | bool | `false` | Reflect only on failures |
 
 ## Optimizer (`optimizer`)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -235,7 +235,8 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--lr_control_mode", type=str,
                    choices=["fixed", "autonomous", "none"])
     p.add_argument("--merge_batch_size", type=int)
-    p.add_argument("--max_analyst_rounds", type=int)
+    # Retired, still accepted so existing launch scripts keep running.
+    p.add_argument("--max_analyst_rounds", type=int, help=argparse.SUPPRESS)
     p.add_argument("--sel_env_num", type=int)
     p.add_argument("--test_env_num", type=int)
     p.add_argument("--eval_test", type=_BOOL)
@@ -286,6 +287,20 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--mode", type=str)
 
     return p.parse_args()
+
+
+# ── Retired CLI options ──────────────────────────────────────────────────────
+
+# Still parsed so that existing launch scripts do not fail on an unrecognised
+# argument, but deliberately kept out of the config: an option here has no
+# structured path, and without the explicit skip below the mapping loop in
+# ``load_config`` would file it under ``env.<name>``.
+_RETIRED_CLI_OPTIONS: dict[str, str] = {
+    "max_analyst_rounds": (
+        "the analyst call count follows from the rollout results, "
+        "gradient.minibatch_size and gradient.failure_only"
+    ),
+}
 
 
 # ── Flat key → structured path mapping (for legacy CLI → structured config) ──
@@ -376,7 +391,6 @@ _LEGACY_TO_STRUCTURED: dict[str, str] = {
     "minibatch_size": "gradient.minibatch_size",
     "merge_batch_size": "gradient.merge_batch_size",
     "analyst_workers": "gradient.analyst_workers",
-    "max_analyst_rounds": "gradient.max_analyst_rounds",
     "failure_only": "gradient.failure_only",
     "edit_budget": "optimizer.learning_rate",
     "min_edit_budget": "optimizer.min_learning_rate",
@@ -461,12 +475,22 @@ def load_config(args: argparse.Namespace) -> dict:
                 stacklevel=2,
             )
 
+    for _retired, _rationale in _RETIRED_CLI_OPTIONS.items():
+        if getattr(args, _retired, None) is not None:
+            warnings.warn(
+                f"--{_retired} is deprecated and has no effect: {_rationale}.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
     cfg = _load(args.config, overrides=args.cfg_options)
     structured = is_structured(cfg)
 
     # Apply legacy --key value overrides
     cli = {k: v for k, v in vars(args).items()
-           if v is not None and k not in ("config", "cfg_options")}
+           if v is not None
+           and k not in ("config", "cfg_options")
+           and k not in _RETIRED_CLI_OPTIONS}
     if cli:
         if structured:
             from skillopt.config import apply_overrides

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -295,12 +295,65 @@ def parse_args() -> argparse.Namespace:
 # argument, but deliberately kept out of the config: an option here has no
 # structured path, and without the explicit skip below the mapping loop in
 # ``load_config`` would file it under ``env.<name>``.
-_RETIRED_CLI_OPTIONS: dict[str, str] = {
+# Flat CLI name -> (the structured key it used to have, why it is gone).
+_RETIRED_CLI_OPTIONS: dict[str, tuple[str, str]] = {
     "max_analyst_rounds": (
+        "gradient.max_analyst_rounds",
         "the analyst call count follows from the rollout results, "
-        "gradient.minibatch_size and gradient.failure_only"
+        "gradient.minibatch_size and gradient.failure_only",
     ),
 }
+
+
+def _lookup_dotted(cfg: dict, dotted: str):
+    """Value at a dotted path in *cfg*, or ``None`` if any level is missing."""
+    node: object = cfg
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+def _retired_option_sources(
+    args: argparse.Namespace,
+    cfg: dict,
+    structured: bool,
+    flat_name: str,
+    dotted: str,
+) -> list[str]:
+    """Every input path that still supplies a retired option.
+
+    The CLI flag is not the only way in, and it is the least dangerous one. A
+    retired key left in a YAML file is dropped in silence: ``flatten_config`` no
+    longer maps it and the trainer no longer reads it, so the run proceeds as
+    though the file had never mentioned it. That silence is what the CLI warning
+    exists to prevent, so the config file and ``--cfg-options`` get the same
+    treatment.
+    """
+    sources: list[str] = []
+    if getattr(args, flat_name, None) is not None:
+        sources.append(f"--{flat_name}")
+
+    accepted = {dotted, flat_name}
+    overrides = [
+        key.strip()
+        for key, separator, _value in (
+            str(option).partition("=")
+            for option in getattr(args, "cfg_options", None) or []
+        )
+        if separator and key.strip() in accepted
+    ]
+    sources.extend(f"--cfg-options {key}" for key in overrides)
+
+    # Only when no override named it: ``skillopt.config.load_config`` merges
+    # ``--cfg-options`` into *cfg*, so an override found there would otherwise be
+    # reported twice, and the override is the one that would have won anyway.
+    if not overrides:
+        key = dotted if structured else flat_name
+        if _lookup_dotted(cfg, key) is not None:
+            sources.append("the config file")
+    return sources
 
 
 # ── Flat key → structured path mapping (for legacy CLI → structured config) ──
@@ -475,16 +528,24 @@ def load_config(args: argparse.Namespace) -> dict:
                 stacklevel=2,
             )
 
-    for _retired, _rationale in _RETIRED_CLI_OPTIONS.items():
-        if getattr(args, _retired, None) is not None:
-            warnings.warn(
-                f"--{_retired} is deprecated and has no effect: {_rationale}.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
     cfg = _load(args.config, overrides=args.cfg_options)
     structured = is_structured(cfg)
+
+    for _retired, (_dotted, _rationale) in _RETIRED_CLI_OPTIONS.items():
+        _sources = _retired_option_sources(args, cfg, structured, _retired, _dotted)
+        if _sources:
+            warnings.warn(
+                f"{_dotted} was retired and is ignored: {_rationale}. "
+                f"Still supplied via {', '.join(_sources)}; remove it.",
+                # FutureWarning rather than DeprecationWarning: ``skillopt-train``
+                # is a console script pointing at ``scripts.train:main``, so this
+                # is raised from an imported module and not from ``__main__``.
+                # Python's default filters are ``default::DeprecationWarning:
+                # __main__`` followed by ``ignore::DeprecationWarning``, which
+                # would drop it before any normal CLI user saw it.
+                FutureWarning,
+                stacklevel=2,
+            )
 
     # Apply legacy --key value overrides
     cli = {k: v for k, v in vars(args).items()

--- a/skillopt/config.py
+++ b/skillopt/config.py
@@ -115,7 +115,6 @@ _FLATTEN_MAP: dict[str, str] = {
     "gradient.merge_batch_size": "merge_batch_size",
     "gradient.analyst_workers": "analyst_workers",
     "gradient.failure_only": "failure_only",
-    "gradient.max_analyst_rounds": "max_analyst_rounds",
     "optimizer.learning_rate": "edit_budget",
     "optimizer.min_learning_rate": "min_edit_budget",
     "optimizer.lr_scheduler": "lr_scheduler",

--- a/skillopt/engine/trainer.py
+++ b/skillopt/engine/trainer.py
@@ -850,7 +850,6 @@ class ReflACTTrainer:
         accumulation = cfg["accumulation"]
         seed = cfg["seed"]
         merge_bs = cfg["merge_batch_size"]
-        max_analyst_rounds = int(cfg.get("max_analyst_rounds", 3) or 3)
         update_mode = normalize_update_mode(cfg.get("skill_update_mode", "patch"))
         lr_control_mode = _normalise_lr_control_mode(cfg.get("lr_control_mode", "fixed"))
         if is_full_rewrite_minibatch_mode(update_mode):
@@ -918,8 +917,7 @@ class ReflACTTrainer:
         print(f"  [config] skill_update_mode={update_mode} "
               f"lr_control_mode={lr_control_mode} "
               f"rewrite_reasoning_effort={rewrite_reasoning_effort or 'off'} "
-              f"rewrite_max_completion_tokens={rewrite_max_completion_tokens} "
-              f"max_analyst_rounds={max_analyst_rounds}")
+              f"rewrite_max_completion_tokens={rewrite_max_completion_tokens}")
         print(f"  [config] longitudinal_pair_policy={longitudinal_pair_policy}")
         print(f"  [config] base_seeds={base_seeds}")
 

--- a/tests/test_retired_cli_options.py
+++ b/tests/test_retired_cli_options.py
@@ -5,18 +5,53 @@ import warnings
 from pathlib import Path
 
 import pytest
+import yaml
 
 import scripts.train as train_script
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_REAL_CONFIG = _REPO_ROOT / "configs" / "searchqa" / "default.yaml"
 
-def _argv(*extra: str) -> list[str]:
-    root = Path(__file__).resolve().parents[1]
+
+def _argv(*extra: str, config: Path | None = None) -> list[str]:
     return [
         "skillopt-train",
         "--config",
-        str(root / "configs" / "searchqa" / "default.yaml"),
+        str(config or _REAL_CONFIG),
         *extra,
     ]
+
+
+def _structured_config_setting_the_retired_key(tmp_path: Path) -> Path:
+    """A real structured config that still sets ``gradient.max_analyst_rounds``.
+
+    Inherits the shipped config through ``_base_`` (absolute, which ``_load_yaml``
+    resolves via ``os.path.join``) so this is a complete config and not a
+    hand-built fragment that only exercises the parts we remembered.
+    """
+    path = tmp_path / "still_sets_it.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {"_base_": str(_REAL_CONFIG), "gradient": {"max_analyst_rounds": 3}}
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _legacy_flat_config_setting_the_retired_key(tmp_path: Path) -> Path:
+    """The same thing in the legacy flat format.
+
+    Built by flattening the shipped structured config, so it is exactly the
+    layout `flatten_config` produces rather than an invented subset.
+    """
+    from skillopt.config import flatten_config, load_config
+
+    flat = flatten_config(load_config(str(_REAL_CONFIG)))
+    flat["max_analyst_rounds"] = 3
+    path = tmp_path / "legacy_flat.yaml"
+    path.write_text(yaml.safe_dump(flat), encoding="utf-8")
+    return path
 
 
 # "0" is the case from the original report: the option has to be recognised as
@@ -25,12 +60,91 @@ def _argv(*extra: str) -> list[str]:
 def test_retired_option_warns_and_stays_out_of_the_config(monkeypatch, value) -> None:
     monkeypatch.setattr(sys, "argv", _argv("--max_analyst_rounds", value))
 
-    with pytest.warns(DeprecationWarning, match="max_analyst_rounds"):
+    with pytest.warns(FutureWarning, match="max_analyst_rounds"):
         cfg = train_script.load_config(train_script.parse_args())
 
     # A retired option has no structured path, so without an explicit skip the
     # legacy CLI mapping files it under ``env.`` and it reaches the trainer.
     assert "max_analyst_rounds" not in cfg
+
+
+def test_the_warning_survives_pythons_default_filters(monkeypatch) -> None:
+    """``DeprecationWarning`` would not reach a user here.
+
+    ``skillopt-train`` is a console script pointing at ``scripts.train:main``, so
+    the warning is raised from an imported module rather than from ``__main__``,
+    and Python's default filters end in ``ignore::DeprecationWarning``. Asserting
+    the category alone would not catch that, so this runs the real
+    ``load_config`` under those filters instead of pytest's permissive ones and
+    asserts the user is told.
+    """
+    monkeypatch.setattr(sys, "argv", _argv("--max_analyst_rounds", "5"))
+    args = train_script.parse_args()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.resetwarnings()  # drop pytest's filters
+        warnings.simplefilter("default")  # Python's startup default for most
+        warnings.filterwarnings("default", category=DeprecationWarning,
+                                module="__main__")
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        train_script.load_config(args)
+
+    assert [w for w in caught if "max_analyst_rounds" in str(w.message)], (
+        "the retirement warning did not survive Python's default filters, so a "
+        "normal `skillopt-train` run would drop it silently"
+    )
+
+
+def test_a_config_file_that_still_sets_it_warns(monkeypatch, tmp_path) -> None:
+    """The path the CLI warning missed. ``flatten_config`` no longer maps the key
+    and the trainer no longer reads it, so without this the file is ignored in
+    silence."""
+    config = _structured_config_setting_the_retired_key(tmp_path)
+    monkeypatch.setattr(sys, "argv", _argv(config=config))
+
+    with pytest.warns(FutureWarning, match="the config file"):
+        cfg = train_script.load_config(train_script.parse_args())
+
+    assert "max_analyst_rounds" not in cfg
+
+
+def test_a_legacy_flat_config_that_still_sets_it_warns(monkeypatch, tmp_path) -> None:
+    """Legacy flat YAML gets the same treatment: the key is top-level there, so
+    the structured lookup would miss it."""
+    config = _legacy_flat_config_setting_the_retired_key(tmp_path)
+    monkeypatch.setattr(sys, "argv", _argv(config=config))
+
+    with pytest.warns(FutureWarning, match="the config file"):
+        train_script.load_config(train_script.parse_args())
+
+
+@pytest.mark.parametrize(
+    "override",
+    ["gradient.max_analyst_rounds=3", "max_analyst_rounds=3"],
+)
+def test_cfg_options_that_still_set_it_warn(monkeypatch, tmp_path, override) -> None:
+    """Both spellings, because a user migrating a launch script reaches for the
+    structured key and a user migrating a flag reaches for the flat one."""
+    monkeypatch.setattr(sys, "argv", _argv("--cfg-options", override))
+
+    with pytest.warns(FutureWarning, match="cfg-options"):
+        train_script.load_config(train_script.parse_args())
+
+
+def test_an_override_is_not_reported_twice(monkeypatch) -> None:
+    """``--cfg-options`` is merged into the config before this check runs, so the
+    naive version names both the flag and the file for one mistake."""
+    monkeypatch.setattr(
+        sys, "argv", _argv("--cfg-options", "gradient.max_analyst_rounds=3")
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        train_script.load_config(train_script.parse_args())
+
+    messages = [str(w.message) for w in caught if "max_analyst_rounds" in str(w.message)]
+    assert len(messages) == 1, messages
+    assert "the config file" not in messages[0], messages[0]
 
 
 def test_no_warning_when_the_option_is_absent(monkeypatch) -> None:

--- a/tests/test_retired_cli_options.py
+++ b/tests/test_retired_cli_options.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+import pytest
+
+import scripts.train as train_script
+
+
+def _argv(*extra: str) -> list[str]:
+    root = Path(__file__).resolve().parents[1]
+    return [
+        "skillopt-train",
+        "--config",
+        str(root / "configs" / "searchqa" / "default.yaml"),
+        *extra,
+    ]
+
+
+# "0" is the case from the original report: the option has to be recognised as
+# supplied even when it is falsy.
+@pytest.mark.parametrize("value", ["5", "0"])
+def test_retired_option_warns_and_stays_out_of_the_config(monkeypatch, value) -> None:
+    monkeypatch.setattr(sys, "argv", _argv("--max_analyst_rounds", value))
+
+    with pytest.warns(DeprecationWarning, match="max_analyst_rounds"):
+        cfg = train_script.load_config(train_script.parse_args())
+
+    # A retired option has no structured path, so without an explicit skip the
+    # legacy CLI mapping files it under ``env.`` and it reaches the trainer.
+    assert "max_analyst_rounds" not in cfg
+
+
+def test_no_warning_when_the_option_is_absent(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", _argv())
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        train_script.load_config(train_script.parse_args())
+
+    assert [w for w in caught if "max_analyst_rounds" in str(w.message)] == []


### PR DESCRIPTION
`gradient.max_analyst_rounds` is parsed, exposed on the CLI and printed in the trainer's config banner, but nothing reads it. Changing it has never changed how many analyst calls a step makes.

Every occurrence in the tree before this change:

```
configs/_base_/default.yaml:81:  max_analyst_rounds: 3
docs/guide/configuration.md:99:  max_analyst_rounds: 3          # Max rounds of analyst reflection
docs/guide/local-env-smoke.md:77:  max_analyst_rounds: 1
docs/reference/config.md:96:| `gradient.max_analyst_rounds` | int | `3` | Maximum analyst rounds |
skillopt/config.py:118:    "gradient.max_analyst_rounds": "max_analyst_rounds",
scripts/train.py:238:    p.add_argument("--max_analyst_rounds", type=int)
scripts/train.py:379:    "max_analyst_rounds": "gradient.max_analyst_rounds",
skillopt/engine/trainer.py:853:        max_analyst_rounds = int(cfg.get("max_analyst_rounds", 3) or 3)
skillopt/engine/trainer.py:922:              f"max_analyst_rounds={max_analyst_rounds}")
```

A definition, the plumbing, one read into a local and one print. `run_minibatch_reflect()` takes no rounds parameter, and the `adapter.reflect()` call in the trainer passes an explicit keyword list rather than the config, so the value cannot reach reflection through `**kwargs` either. The analyst call count is the number of minibatch groups, which follows from the rollout results, `gradient.minibatch_size` and `gradient.failure_only`.

Two consequences beyond the option being inert:

- The trainer writes `cfg` to each run's `config.json`, so every run record claims a setting the run did not use.
- `docs/guide/local-env-smoke.md` recommends `max_analyst_rounds: 1` for a deliberately cheap smoke run. With `minibatch_size: 1` and `train_size: 3`, that recipe can still make six analyst calls.

I removed the option rather than implementing it, because implementing it means picking semantics I cannot infer from the code, and the two readings behave differently:

- if a round is one analyst call, capping it means dropping trajectories, and something has to decide which ones
- if a round is one parallel wave of `analyst_workers` calls, then the default of 3 permits 48 calls and never binds at stock settings

Glad to send the wiring instead if you tell me which one you had in mind. In that case the `or 3` fallback the issue mentions matters as well, since it turns a deliberate `0` into `3`.

`--max_analyst_rounds` stays as a deprecated no-op so existing launch scripts do not fail on an unrecognised argument. It is skipped explicitly when CLI arguments are mapped into the config: `_LEGACY_TO_STRUCTURED` no longer has an entry for it, and the fallback branch would otherwise file it under `env.max_analyst_rounds`, which `flatten_config` passes straight through to the trainer. That is what the new test covers, the warning firing (including for `0`) and the value staying out of the config. Existing YAML needs no migration, because `flatten_config` only copies keys it knows and ignores the rest.

There is no test for the removal itself. The proof there is the grep above plus the documentation updates.

Fixes #213

---

Verified with `python -m pytest tests/test_retired_cli_options.py tests/test_copilot_exec_backend.py tests/test_cursor_exec_backend.py tests/test_model_change_warning.py -q` (77 passed) and `python -m mkdocs build --strict`. A full `python -m pytest -q` matches the pre-change baseline on my machine: the same 48 failures in the Sleep and scenario harness suites appear on an unmodified checkout, all of them Windows environment issues around symlinks and permissions.
