### PR TITLE
fix: harden fallback parsing after #216

### DIFF
--- a/skillopt/engine/trainer.py
+++ b/skillopt/engine/trainer.py
@@ -574,7 +574,7 @@ def _extract_failure_patterns(
                     ft = fs.get("failure_type", "")
                     sd = fs.get("description", "")
                     analyst_descs.append(f"{ft}: {sd}" if sd else ft)
-            except (json.JSONDecodeError, OSError, AttributeError, TypeError):
+            except (ValueError, RecursionError, OSError, AttributeError, TypeError):
                 pass
 
     patterns = []

--- a/skillopt/envs/spreadsheetbench/adapter.py
+++ b/skillopt/envs/spreadsheetbench/adapter.py
@@ -113,7 +113,7 @@ class SpreadsheetBenchAdapter(EnvAdapter):
                 for line in f:
                     try:
                         existing.append(json.loads(line))
-                    except (json.JSONDecodeError, TypeError):
+                    except (ValueError, RecursionError, TypeError):
                         pass
             if existing:
                 return existing

--- a/skillopt/envs/spreadsheetbench/rollout.py
+++ b/skillopt/envs/spreadsheetbench/rollout.py
@@ -480,7 +480,7 @@ def run_spreadsheet_batch(
                     r = json.loads(line)
                     done_ids.add(str(r["id"]))
                     existing.append(r)
-                except (json.JSONDecodeError, KeyError, TypeError):
+                except (ValueError, RecursionError, KeyError, TypeError):
                     pass
 
     pending = [it for it in items if str(it["id"]) not in done_ids]
@@ -875,7 +875,7 @@ def run_spreadsheet_batch_codegen(
                     r = json.loads(line)
                     done_ids.add(str(r["id"]))
                     existing.append(r)
-                except (json.JSONDecodeError, KeyError, TypeError):
+                except (ValueError, RecursionError, KeyError, TypeError):
                     pass
 
     pending = [it for it in items if str(it["id"]) not in done_ids]

--- a/skillopt/gradient/aggregate.py
+++ b/skillopt/gradient/aggregate.py
@@ -52,12 +52,21 @@ def _merge_batch(
         )
         merged = extract_json(response)
         key = payload_key(update_mode)
-        if merged and key in merged:
-            for e in merged.get(key, []):
+        items = merged.get(key) if isinstance(merged, dict) else None
+        if isinstance(items, list) and all(isinstance(e, dict) for e in items):
+            for e in items:
                 e["merge_level"] = level
             return merged
-    except Exception as e:  # noqa: BLE001
-        warnings.warn(f"Optimizer call or parsing failed during batch merge: {e}", stacklevel=2)
+    except Exception:  # noqa: BLE001 — optimizer/provider failures must fall back
+        warnings.warn(
+            "Optimizer call or parsing failed during batch merge; using fallback",
+            stacklevel=2,
+        )
+    else:
+        warnings.warn(
+            "Optimizer returned unusable output during batch merge; using fallback",
+            stacklevel=2,
+        )
     # Fallback: concatenate all edits
     all_edits = []
     for p in patches:
@@ -241,15 +250,24 @@ def merge_patches(
         )
         final = extract_json(response)
         key = payload_key(update_mode)
-        if final and key in final:
+        items = final.get(key) if isinstance(final, dict) else None
+        if isinstance(items, list) and all(isinstance(e, dict) for e in items):
             if verbose:
                 print(
                     f"    [aggregate final] "
-                    f"{len(f_edits)}+{len(s_edits)} → {len(final[key])} {payload_label(update_mode)}"
+                    f"{len(f_edits)}+{len(s_edits)} → {len(items)} {payload_label(update_mode)}"
                 )
             return final
-    except Exception as e:  # noqa: BLE001
-        warnings.warn(f"Optimizer call or parsing failed during final merge: {e}", stacklevel=2)
+    except Exception:  # noqa: BLE001 — optimizer/provider failures must fall back
+        warnings.warn(
+            "Optimizer call or parsing failed during final merge; using fallback",
+            stacklevel=2,
+        )
+    else:
+        warnings.warn(
+            "Optimizer returned unusable output during final merge; using fallback",
+            stacklevel=2,
+        )
 
     return {
         "reasoning": "fallback: failure first, then success",

--- a/skillopt_sleep/backend.py
+++ b/skillopt_sleep/backend.py
@@ -904,7 +904,7 @@ def _parse_opencode_jsonl_text(raw: str) -> Tuple[str, str]:
             continue
         try:
             event = json.loads(line)
-        except (json.JSONDecodeError, RecursionError):
+        except (ValueError, RecursionError):
             return "", "malformed_jsonl"
         if not isinstance(event, dict):
             return "", "invalid_event"
@@ -1005,7 +1005,7 @@ class OpenCodeCliBackend(CliBackend):
             return None
         try:
             resolved = json.loads(proc.stdout or "")
-        except (json.JSONDecodeError, RecursionError, TypeError):
+        except (ValueError, RecursionError, TypeError):
             self.last_call_error = f"OpenCode CLI {stage} returned invalid configuration"
             return None
         if not isinstance(resolved, dict):
@@ -1575,7 +1575,7 @@ class CopilotCliBackend(CliBackend):
                 continue
             try:
                 obj = json.loads(line)
-            except (json.JSONDecodeError, TypeError):
+            except (ValueError, RecursionError, TypeError):
                 continue
             if obj.get("type") == "assistant.message":
                 content = (obj.get("data") or {}).get("content")

--- a/tests/test_aggregate_fallback.py
+++ b/tests/test_aggregate_fallback.py
@@ -1,4 +1,3 @@
-import json
 from unittest.mock import patch
 
 import pytest
@@ -33,22 +32,40 @@ def test_merge_batch_fallback_on_runtime_error():
 
 
 def test_merge_batch_fallback_on_malformed_json():
-    """Test that _merge_batch falls back when JSON extraction fails."""
+    """A real non-JSON optimizer response is observable and falls back."""
     patches = [{"reasoning": "r1", "edits": [{"id": "1", "content": "one"}]}]
 
     with patch("skillopt.gradient.aggregate.chat_optimizer", return_value=("not json", None)):
-        with patch("skillopt.gradient.aggregate.extract_json", side_effect=json.JSONDecodeError("Expecting value", "doc", 0)):
-            with pytest.warns(UserWarning, match="Optimizer call or parsing failed during batch merge"):
-                result = _merge_batch(
-                    skill_content="skill content",
-                    patches=patches,
-                    system_prompt="merge this",
-                    update_mode="patch",
-                    level=1,
-                )
+        with pytest.warns(UserWarning, match="unusable output during batch merge"):
+            result = _merge_batch(
+                skill_content="skill content",
+                patches=patches,
+                system_prompt="merge this",
+                update_mode="patch",
+                level=1,
+            )
 
     assert result["reasoning"] == "fallback concatenation"
     assert len(result["edits"]) == 1
+
+
+def test_merge_batch_warning_does_not_expose_exception_text():
+    """Provider response bodies and credentials must not be copied to logs."""
+    secret = "Authorization: Bearer sk-secret-example"
+    patches = [{"reasoning": "r1", "edits": [{"id": "1", "content": "one"}]}]
+
+    with patch("skillopt.gradient.aggregate.chat_optimizer", side_effect=RuntimeError(secret)):
+        with pytest.warns(UserWarning) as caught:
+            result = _merge_batch(
+                skill_content="skill content",
+                patches=patches,
+                system_prompt="merge this",
+                update_mode="patch",
+                level=1,
+            )
+
+    assert result["reasoning"] == "fallback concatenation"
+    assert secret not in "\n".join(str(item.message) for item in caught)
 
 
 def test_merge_patches_fallback_on_runtime_error():
@@ -76,3 +93,52 @@ def test_merge_patches_fallback_on_runtime_error():
     assert len(result["edits"]) == 2
     assert result["edits"][0]["id"] == "1"
     assert result["edits"][1]["id"] == "2"
+
+
+def test_merge_patches_warns_on_unusable_output():
+    """A non-JSON final response is observable and uses the safe fallback."""
+    failure_patches = [{"reasoning": "f1", "edits": [{"id": "1", "content": "f_one"}]}]
+    success_patches = [{"reasoning": "s1", "edits": [{"id": "2", "content": "s_two"}]}]
+
+    def first_patch(_skill_content, patches, *args, **kwargs):
+        return patches[0]
+
+    with patch("skillopt.gradient.aggregate._hierarchical_merge", side_effect=first_patch):
+        with patch("skillopt.gradient.aggregate.chat_optimizer", return_value=("not json", None)):
+            with pytest.warns(UserWarning, match="unusable output during final merge"):
+                result = merge_patches(
+                    skill_content="content",
+                    failure_patches=failure_patches,
+                    success_patches=success_patches,
+                    batch_size=2,
+                    verbose=False,
+                )
+
+    assert result["reasoning"] == "fallback: failure first, then success"
+    assert [edit["id"] for edit in result["edits"]] == ["1", "2"]
+
+
+@pytest.mark.parametrize(
+    "response",
+    ['{"edits": null}', '{"edits": ["not an object"]}'],
+)
+def test_merge_patches_rejects_invalid_payload_shape(response):
+    """A present but invalid payload must not bypass fallback in quiet mode."""
+    failure_patches = [{"reasoning": "f1", "edits": [{"id": "1"}]}]
+    success_patches = [{"reasoning": "s1", "edits": [{"id": "2"}]}]
+
+    def first_patch(_skill_content, patches, *args, **kwargs):
+        return patches[0]
+
+    with patch("skillopt.gradient.aggregate._hierarchical_merge", side_effect=first_patch):
+        with patch("skillopt.gradient.aggregate.chat_optimizer", return_value=(response, None)):
+            with pytest.warns(UserWarning, match="unusable output during final merge"):
+                result = merge_patches(
+                    skill_content="content",
+                    failure_patches=failure_patches,
+                    success_patches=success_patches,
+                    verbose=False,
+                )
+
+    assert result["reasoning"] == "fallback: failure first, then success"
+    assert [edit["id"] for edit in result["edits"]] == ["1", "2"]

--- a/tests/test_backend_opencode.py
+++ b/tests/test_backend_opencode.py
@@ -141,6 +141,7 @@ def test_parse_opencode_jsonl_collects_text_and_ignores_extensions():
     ("raw", "expected_code"),
     [
         ("not json", "malformed_jsonl"),
+        ('{"value":' + "9" * 5000 + "}", "malformed_jsonl"),
         (json.dumps(["not", "an", "object"]), "invalid_event"),
         (json.dumps({"type": "text"}), "invalid_event"),
         (
@@ -424,6 +425,7 @@ def test_new_enabled_mcp_in_final_config_stops_before_model_call():
         (OSError("private config path"), "could not be completed"),
         (_FakeProc("", returncode=3), "exited 3"),
         (_FakeProc("not json"), "invalid configuration"),
+        (_FakeProc('{"mcp":' + "9" * 5000 + "}"), "invalid configuration"),
         (_FakeProc(json.dumps(["not", "an", "object"])), "invalid configuration"),
         (_FakeProc(json.dumps({"mcp": []})), "invalid MCP configuration"),
         (

--- a/tests/test_sleep_engine.py
+++ b/tests/test_sleep_engine.py
@@ -1424,6 +1424,17 @@ class TestCopilotBackend(unittest.TestCase):
             "",
         )
 
+    def test_parse_jsonl_ignores_excessively_nested_json(self):
+        from skillopt_sleep.backend import CopilotCliBackend
+        nested = "[" * 2000 + "0" + "]" * 2000
+        raw = '{"type":"assistant.message","data":' + nested + "}"
+        self.assertEqual(CopilotCliBackend._parse_jsonl_response(raw), "")
+
+    def test_parse_jsonl_ignores_oversized_integer(self):
+        from skillopt_sleep.backend import CopilotCliBackend
+        raw = '{"type":"assistant.message","data":' + "9" * 5000 + "}"
+        self.assertEqual(CopilotCliBackend._parse_jsonl_response(raw), "")
+
     def test_isolated_home_by_default(self):
         from skillopt_sleep.backend import CopilotCliBackend
         be = CopilotCliBackend()

--- a/tests/test_trainer_failure_patterns.py
+++ b/tests/test_trainer_failure_patterns.py
@@ -1,0 +1,37 @@
+"""Regression tests for trainer failure-pattern extraction."""
+
+from skillopt.engine.trainer import _extract_failure_patterns
+
+
+def test_failure_patterns_ignore_excessively_nested_analyst_patch(tmp_path) -> None:
+    """A malformed cached patch must not abort failure-pattern fallback."""
+    patches_dir = tmp_path / "patches"
+    patches_dir.mkdir()
+    nested = "[" * 2000 + "0" + "]" * 2000
+    (patches_dir / "minibatch_fail_0.json").write_text(nested, encoding="utf-8")
+
+    result = _extract_failure_patterns(
+        [{"id": "task-1", "hard": 0, "fail_reason": "timeout: command stalled"}],
+        str(tmp_path),
+    )
+
+    assert result == [
+        {"pattern": "timeout", "count": 1, "task_ids": ["task-1"]},
+    ]
+
+
+def test_failure_patterns_ignore_oversized_integer_in_analyst_patch(tmp_path) -> None:
+    """Python's integer limit is another malformed-JSON boundary condition."""
+    patches_dir = tmp_path / "patches"
+    patches_dir.mkdir()
+    malformed = '{"failure_summary":' + "9" * 5000 + "}"
+    (patches_dir / "minibatch_fail_0.json").write_text(malformed, encoding="utf-8")
+
+    result = _extract_failure_patterns(
+        [{"id": "task-2", "hard": 0, "fail_reason": "crash: invalid output"}],
+        str(tmp_path),
+    )
+
+    assert result == [
+        {"pattern": "crash", "count": 1, "task_ids": ["task-2"]},
+    ]


### PR DESCRIPTION
## Summary

Follow-up hardening for #216 that preserves its narrower exception-handling intent while keeping expected fallbacks safe at external JSON and optimizer boundaries.

- treat oversized integers and excessive nesting as malformed external JSON without aborting training, SpreadsheetBench resume, OpenCode, or Copilot flows
- require aggregate optimizer payloads to be lists of objects; malformed shapes now warn and use the existing deterministic fallback
- avoid copying provider exception text (which may contain credentials or response bodies) into aggregate warnings
- add regression coverage for malformed JSON, invalid optimizer payload shapes, fallback observability, and warning redaction

## Validation

- `165 passed, 2 skipped` across the directly affected test modules
- `1051 passed, 10 skipped, 130 subtests passed` in the full suite before the final commit (same code)
- Ruff passes for the clean directly changed modules/tests; pre-existing lint findings remain in legacy files
- `git -c core.whitespace=cr-at-eol diff --check` passes (trainer.py retains its existing CRLF style)
