### PR TITLE
feat(sleep): add opt-in section_contains rule judge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to SkillOpt are documented here. This project adheres to
 ## [Unreleased]
 
 ### Added
+- Additive `section_contains` rule-judge operator for literal,
+  case-insensitive matching within numbered, bilingual, or annotated ATX
+  Markdown headings. The legacy `section_present` behavior is unchanged.
 - **OpenCode transcript source** (`--source opencode`) for SkillOpt-Sleep. It
   reads visible user/assistant text and tool names from OpenCode's local SQLite
   history without requiring its CLI, login, or a provider connection.

--- a/docs/sleep/README.md
+++ b/docs/sleep/README.md
@@ -35,6 +35,14 @@ candidate; an absent numeric score aborts evaluation. Task-level changes are
 included in `report.md`, `report.json`, `diagnostics.json`, the CLI's `--json`
 output, and the evidence log.
 
+Rule-based heading checks are intentionally additive. `section_present` keeps
+its legacy strict behavior for existing task sets: an ATX heading cannot append
+text after the requested name. Use `section_contains` when a numbered,
+bilingual, or annotated ATX Markdown heading should pass; it matches the
+requested text literally and case-insensitively within the ATX heading only,
+not in bold lines, labels, or ordinary body text. Both operators are shape-only
+checks and should be paired with an outcome check or substantive rubric.
+
 > **Data boundary.** Harvesting is local and read-only. The `mock` backend makes no
 > provider calls. A real backend, however, sends truncated excerpts from harvested
 > sessions and derived tasks to the provider you select for mining, replay, judging,

--- a/skillopt_sleep/backend.py
+++ b/skillopt_sleep/backend.py
@@ -471,6 +471,8 @@ class CliBackend(Backend):
                     return f"the response must be at least {arg} characters long"
                 if op == "section_present":
                     return f"the response must contain a section/heading titled '{arg}'"
+                if op == "section_contains":
+                    return f"a markdown heading must contain the text '{arg}'"
                 if op == "regex":
                     return f"the response must match the pattern /{arg}/ (e.g. include that label)"
                 if op == "contains":

--- a/skillopt_sleep/judges.py
+++ b/skillopt_sleep/judges.py
@@ -4,7 +4,8 @@ Implements the programmatic check operators used by gbrain-evals'
 skillopt-v1 benchmark so we can score skill outputs locally, with NO judge
 API call:
 
-  * section_present <name>   — a markdown heading containing <name> exists
+  * section_present <name>   — legacy strict heading/bold/label check
+  * section_contains <name>  — an ATX markdown heading contains literal <name>
   * regex <pattern>          — the pattern matches the response
   * max_chars <n>            — response length <= n
   * min_chars <n>            — response length >= n
@@ -17,9 +18,9 @@ API call:
 
 Ops divide into two families, and the distinction is load-bearing:
 
-  * *shape* ops (section_present, max_chars, min_chars) constrain how an answer
-    is formatted. They are trivially satisfiable by an optimizer — adding a
-    heading scores 1.0 without the answer improving at all.
+  * *shape* ops (section_present, section_contains, max_chars, min_chars)
+    constrain how an answer is formatted. They are trivially satisfiable by an
+    optimizer — adding a heading scores 1.0 without the answer improving at all.
   * *outcome* ops (contains, not_contains, no_refusal, regex, tool_called)
     constrain what the answer actually does.
 
@@ -47,6 +48,21 @@ def _section_present(response: str, name: str) -> bool:
     # also accept "Name:" style label at line start
     label = re.compile(r"(?im)^\s*%s\s*:" % re.escape(name))
     return bool(label.search(response or ""))
+
+
+def _section_contains(response: str, name: str) -> bool:
+    """Whether an ATX Markdown heading contains ``name`` literally.
+
+    Unlike the legacy ``section_present`` check, this opt-in operator permits
+    text before and after the requested name, such as numbering, translations,
+    or subtitles. Only ATX heading lines with one to six markers and up to three
+    leading spaces are inspected, so body text and other Markdown constructs do
+    not satisfy the check. ``casefold`` gives literal, Unicode-aware,
+    case-insensitive matching without interpreting regex metacharacters.
+    """
+    needle = name.casefold()
+    heading = re.compile(r"(?m)^ {0,3}#{1,6}(?:[ \t]+|$)([^\n]*)$")
+    return any(needle in match.group(1).casefold() for match in heading.finditer(response or ""))
 
 
 _REFUSAL_PREFIXES = (
@@ -94,6 +110,8 @@ def _check(op: str, arg: Any, response: str,
     r = response or ""
     if op == "section_present":
         return _section_present(r, str(arg)), ""
+    if op == "section_contains":
+        return _section_contains(r, str(arg)), ""
     if op == "regex":
         try:
             return bool(re.search(str(arg), r)), ""
@@ -123,13 +141,15 @@ def _check(op: str, arg: Any, response: str,
 
 
 KNOWN_OPS = frozenset({
-    "section_present", "regex", "max_chars", "min_chars", "contains",
-    "not_contains", "no_refusal", "tool_called",
+    "section_present", "section_contains", "regex", "max_chars", "min_chars",
+    "contains", "not_contains", "no_refusal", "tool_called",
 })
 
 # Ops that only constrain formatting. An optimizer satisfies these by editing
 # the output template, which is why a judge made solely of them is gameable.
-SHAPE_OPS = frozenset({"section_present", "max_chars", "min_chars"})
+SHAPE_OPS = frozenset({
+    "section_present", "section_contains", "max_chars", "min_chars",
+})
 
 
 def is_shape_only(judge: Any) -> bool:
@@ -197,7 +217,10 @@ def validate_checks(judge: Any) -> Tuple[List[str], List[str]]:
                 f"check #{i} op must be a string, got {type(op).__name__}"
             )
             continue
-        if op in {"regex", "section_present", "contains", "tool_called", "not_contains"} and (
+        if op in {
+            "regex", "section_present", "section_contains", "contains",
+            "tool_called", "not_contains",
+        } and (
             arg is None or not str(arg).strip()
         ):
             errors.append(f"check #{i} {op} needs a non-empty arg")

--- a/skillopt_sleep/llm_miner.py
+++ b/skillopt_sleep/llm_miner.py
@@ -10,8 +10,9 @@ For each recurring intent it extracts:
   * a `rubric` (what a good answer must satisfy). A rubric, when present, is
     always stored as the reference and scored by the backend's judge() -- it
     resists the reward-hacking that literal/format checks invite. Programmatic
-    `contains`/`regex`/`section_present`/`tool_called` checks are kept only as a
-    fallback reference for the intents where the miner supplies no rubric.
+    `contains`/`regex`/`section_present`/`section_contains`/`tool_called` checks
+    are kept only as a fallback reference for the intents where the miner
+    supplies no rubric.
   * a preference signal (was the user satisfied?) to weight failures
 
 It is deliberately conservative: it only emits a task when it can name a
@@ -58,7 +59,10 @@ def _mk_task(d: SessionDigest, obj: Dict[str, Any], idx: int) -> TaskRecord | No
     # op that needs one) would crash or fail forever. Drop those here, and keep
     # the accepted shapes aligned with validate_checks() so a mined tasks file
     # never fails validation later (it rejects bools and negative bounds).
-    _needs_str_arg = {"section_present", "regex", "contains", "not_contains", "tool_called"}
+    _needs_str_arg = {
+        "section_present", "section_contains", "regex", "contains",
+        "not_contains", "tool_called",
+    }
     # Trimming a regex would change what it matches (leading/trailing spaces are
     # significant in a pattern), so only substring/tool/heading args are stripped.
     _strip_arg = _needs_str_arg - {"regex"}

--- a/skillopt_sleep/prompts.py
+++ b/skillopt_sleep/prompts.py
@@ -48,7 +48,8 @@ For each task return:
      Formatting checks are available but weak, because an assistant can satisfy
      them by reformatting without answering any better. Use them only alongside
      an outcome check, never alone:
-        {"op":"section_present","arg":"<heading text>"}
+        {"op":"section_present","arg":"<strict heading text>"}
+        {"op":"section_contains","arg":"<literal text anywhere in an ATX heading>"}
         {"op":"max_chars","arg":<int>}
         {"op":"min_chars","arg":<int>}
      Only include checks you are confident a GOOD answer must satisfy.

--- a/tests/test_judges.py
+++ b/tests/test_judges.py
@@ -33,6 +33,62 @@ class TestCheckOperators(unittest.TestCase):
         for text in ("## Key Risks", "**Key Risks:**", "Key Risks: something"):
             self.assertEqual(self._score("section_present", "Key Risks", text)[0], 1.0, text)
 
+    def test_section_present_preserves_strict_trailing_text_behavior(self) -> None:
+        self.assertEqual(self._score("section_present", "Key Risks", "### 1. Key Risks")[0], 1.0)
+        self.assertEqual(
+            self._score(
+                "section_present",
+                "Key Risks",
+                "### 1. Key Risks (Риски) — overview",
+            )[0],
+            0.0,
+        )
+
+    def test_section_contains_accepts_numbered_bilingual_and_annotated_headings(self) -> None:
+        headings = (
+            "### 1. Key Risks",
+            "### 1. Key Risks (Риски)",
+            "### Key Risks — likelihood and impact",
+        )
+        for text in headings:
+            self.assertEqual(self._score("section_contains", "Key Risks", text)[0], 1.0, text)
+
+    def test_section_contains_honors_atx_syntax_boundaries(self) -> None:
+        accepted = ("# Key Risks", "###### Key Risks", "   ## Key Risks")
+        rejected = (
+            "    ## Key Risks",
+            "\t## Key Risks",
+            "####### Key Risks",
+            "##Key Risks",
+        )
+        for text in accepted:
+            self.assertEqual(self._score("section_contains", "Key Risks", text)[0], 1.0, text)
+        for text in rejected:
+            self.assertEqual(self._score("section_contains", "Key Risks", text)[0], 0.0, text)
+
+    def test_section_contains_rejects_non_atx_and_body_text(self) -> None:
+        responses = (
+            "The Key Risks section discusses liquidity and execution.",
+            "**Key Risks:**",
+            "Key Risks: liquidity and execution",
+            "Key Risks\n---------",
+            "> ## Key Risks",
+            "Opening paragraph\nThe Key Risks are below.\nClosing paragraph",
+        )
+        for text in responses:
+            self.assertEqual(self._score("section_contains", "Key Risks", text)[0], 0.0, text)
+
+    def test_section_contains_is_literal_and_case_insensitive(self) -> None:
+        name = "Key Risks [P1].*"
+        self.assertEqual(
+            self._score("section_contains", name, "## KEY RISKS [P1].* — overview")[0],
+            1.0,
+        )
+        self.assertEqual(
+            self._score("section_contains", name, "## Key Risks P1 anything")[0],
+            0.0,
+        )
+
     def test_tool_called_via_marker(self) -> None:
         self.assertEqual(self._score("tool_called", "search", "TOOL_CALL: search")[0], 1.0)
         self.assertEqual(self._score("tool_called", "search", "nope", ["search"])[0], 1.0)
@@ -133,7 +189,7 @@ class TestValidateChecks(unittest.TestCase):
         self.assertTrue(any("always passes" in w for w in warnings), warnings)
 
     def test_empty_string_operator_arguments_are_errors(self) -> None:
-        for op in ("regex", "section_present", "contains", "tool_called"):
+        for op in ("regex", "section_present", "section_contains", "contains", "tool_called"):
             errors, _warnings = validate_checks(
                 {"checks": [{"op": op, "arg": "  "}]}
             )

--- a/tests/test_outcome_judges.py
+++ b/tests/test_outcome_judges.py
@@ -106,7 +106,7 @@ def test_not_contains_requires_an_arg() -> None:
 
 
 def test_shape_ops_are_the_formatting_ops() -> None:
-    assert SHAPE_OPS == {"section_present", "max_chars", "min_chars"}
+    assert SHAPE_OPS == {"section_present", "section_contains", "max_chars", "min_chars"}
 
 
 def test_is_shape_only_flags_a_formatting_judge() -> None:
@@ -176,6 +176,22 @@ def test_shape_only_checks_still_used_when_no_rubric_offered() -> None:
     )
     assert task is not None
     assert task.reference_kind == "rule"
+
+
+def test_miner_keeps_section_contains_when_no_rubric_offered() -> None:
+    task = _mk_task(
+        _digest(),
+        {
+            "intent": "write a report with an annotated risks heading",
+            "checks": [{"op": "section_contains", "arg": "  Key Risks  "}],
+            "rubric": "",
+            "satisfied": True,
+        },
+        0,
+    )
+    assert task is not None
+    assert task.reference_kind == "rule"
+    assert task.judge["checks"] == [{"op": "section_contains", "arg": "Key Risks"}]
 
 
 def test_outcome_checks_also_lose_to_the_rubric() -> None:
@@ -399,4 +415,3 @@ def test_char_bound_accepts_integral_forms(arg, expected) -> None:
 def test_char_bound_rejects_non_integers(bad) -> None:
     with pytest.raises((ValueError, TypeError)):
         char_bound(bad)
-


### PR DESCRIPTION
## Summary

Add an opt-in `section_contains` rule-judge operator for permissive heading checks while preserving existing scoring behavior.

- keeps `section_present` unchanged
- registers `section_contains` across scoring, validation, mining, prompts, and backend guidance
- classifies it as a shape-only operator
- documents and tests the strict/permissive distinction

## Contract

`section_contains` performs a literal, Unicode case-insensitive substring match on ATX-heading-shaped lines: up to three leading spaces, one to six `#` markers, then whitespace or end of line.

It accepts numbered, bilingual, and annotated headings such as `### 1. Key Risks (Риски) — overview`, while ordinary body text, bold labels, Setext headings, and blockquoted lines do not match.

Because `section_present` is unchanged, existing task sets retain their current scores.

## Attribution

This implements the additive, compatibility-preserving operator proposed by @koi-lee and accepted by maintainers in #175. Thank you, @koi-lee, for defining the direction and expected behavior.

## Validation

- 97 focused judge/miner tests passed
- 1,054 suite tests and 130 subtests passed; 12 skipped
- one current-`main` Copilot parser regression was deselected after reproducing it unchanged at `a17de4e`
- `python -m mkdocs build --strict` passed
- Ruff passed on the focused files; `backend.py` retains seven pre-existing findings outside this two-line change

Related to #175.
