### PR TITLE
fix(codex_exec): harden config propagation after #220

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@ All notable changes to SkillOpt are documented here. This project adheres to
   implemented by @wilyan09007 in #219).
 
 ### Fixed
+- Apply Codex executable and sandbox aliases consistently across inherited
+  YAML, CLI overrides, training, and eval-only entry points. Codex CLI calls
+  now use explicit sandbox and approval settings instead of the retired
+  `--full-auto` flag (thanks @RohithPariki, #220).
 - Preserve fractional rollout hard scores instead of coercing them to binary
   values (thanks @zixuanguo786-ctrl, #104).
 - Reject duplicate and overlapping IDs while materializing SearchQA manifests

--- a/configs/_base_/default.yaml
+++ b/configs/_base_/default.yaml
@@ -10,15 +10,14 @@ model:
   reasoning_effort: medium
   rewrite_reasoning_effort: ""
   rewrite_max_completion_tokens: 64000
-  codex_exec_path: codex
-  codex_exec_sandbox: workspace-write
+  codex_exec_path: ""       # blank preserves CODEX_EXEC_PATH or the built-in default
+  codex_exec_sandbox: ""    # blank preserves CODEX_EXEC_SANDBOX or workspace-write
   codex_exec_profile: ""
-  codex_exec_full_auto: false
-  codex_exec_reasoning_effort: none
-  codex_exec_use_sdk: auto
-  codex_exec_network_access: false
-  codex_exec_web_search: false
-  codex_exec_approval_policy: never
+  codex_exec_reasoning_effort: ""
+  codex_exec_use_sdk: null
+  codex_exec_network_access: null
+  codex_exec_web_search: null
+  codex_exec_approval_policy: ""
   claude_code_exec_path: claude
   claude_code_exec_profile: ""
   claude_code_exec_use_sdk: auto

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -65,11 +65,8 @@ defaults to `claude` and can be overridden with `CLAUDE_CLI_BIN`.
 | `model.qwen_chat_*` | Shared `base_url`, `api_key`, `temperature`, `timeout_seconds`, `max_tokens`, and `enable_thinking` |
 | `model.optimizer_qwen_chat_*` / `model.target_qwen_chat_*` | Per-role Qwen overrides |
 | `model.minimax_*` | MiniMax `base_url`, `api_key`, shared `minimax_model`, `temperature`, `max_tokens`, and `enable_thinking`; `minimax_model` applies when MiniMax is the target |
-| `model.codex_exec_*` | Codex path (`model.codex_cli_bin` and `model.codex_path` aliases accepted), sandbox (`model.sandbox` and `model.codex_sandbox` aliases accepted), profile, SDK mode, reasoning, network/search, and approval policy |
+| `model.codex_exec_*` | Codex path, sandbox, profile, SDK mode, reasoning, network/search, and approval policy; see compatibility notes below |
 | `model.claude_code_exec_*` | Claude path, profile, SDK mode, effort, and thinking-token cap |
-
-> [!WARNING]
-> When setting the Codex sandbox mode to `danger-full-access` (or using the `CODEX_SANDBOX_MODE="danger-full-access"` environment alias), the model is granted complete and unrestricted write access to the host filesystem. Use this mode with extreme caution, preferably only within an isolated container environment.
 | `model.cursor_exec_path` | Cursor Agent executable path; default `cursor-agent` |
 | `model.cursor_exec_sandbox` | Cursor sandbox mode: `enabled` (default) or `disabled`; file-edit rollouts require `enabled` |
 | `model.copilot_exec_path` | GitHub Copilot CLI executable path; default `copilot` |
@@ -77,6 +74,37 @@ defaults to `claude` and can be overridden with `CLAUDE_CLI_BIN`.
 | `model.copilot_exec_allow_all_tools` | Optional opt-in to `--allow-all-tools`; unset by default so `COPILOT_EXEC_ALLOW_ALL_TOOLS` remains authoritative |
 | `model.copilot_chat_optimizer_model` / `model.copilot_chat_target_model` | Optional per-role `--model` IDs for `copilot_chat` |
 | `model.copilot_chat_timeout` | Per-call timeout in seconds for `copilot_chat` |
+
+For compatibility, `model.codex_bin`, `model.codex_cli_bin`, and
+`model.codex_path` are aliases for `model.codex_exec_path`;
+`model.codex_sandbox` and `model.sandbox` are aliases for
+`model.codex_exec_sandbox`. The canonical `codex_exec_*` name wins when both
+forms occur in the same YAML layer. A child config or command-line override
+still overrides its base config, whichever accepted spelling it uses.
+The aliases may also be supplied without the `model.` prefix through
+`--cfg-options`; with a structured config they are applied to the `model`
+section.
+
+`model.codex_exec_full_auto` and `--codex_exec_full_auto` remain accepted for
+backward compatibility but are deprecated and ignored. Set
+`model.codex_exec_sandbox` and `model.codex_exec_approval_policy` explicitly.
+
+Blank or `null` Codex values in the shipped base config leave the corresponding
+`CODEX_EXEC_*` environment variable in control. The effective precedence is an
+explicit command-line/YAML value, then the environment, then the built-in safe
+default (`codex`, `workspace-write`, and approval policy `never`).
+
+`model.codex_exec_network_access` controls outbound network access only while
+the Codex sandbox is `workspace-write`; it cannot restrict
+`danger-full-access`. `model.codex_exec_web_search` independently selects live
+web search when true and disables web search when false. These settings are
+forwarded consistently to both SDK and CLI execution paths.
+
+> [!WARNING]
+> `danger-full-access` grants the Codex process unrestricted filesystem access.
+> Use it only in an appropriately isolated environment, such as a disposable
+> container. The same warning applies to environment aliases such as
+> `CODEX_SANDBOX_MODE=danger-full-access`.
 
 ## Training (`train`)
 

--- a/scripts/eval_only.py
+++ b/scripts/eval_only.py
@@ -33,7 +33,7 @@ force_utf8_stdout_stderr()
 from skillopt.model import (
     configure_azure_openai,
     configure_claude_code_exec,
-    configure_codex_exec,
+    configure_codex_exec_from_config,
     configure_copilot_chat,
     configure_copilot_exec,
     configure_cursor_exec,
@@ -192,7 +192,14 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--codex_exec_path", type=str)
     p.add_argument("--codex_exec_sandbox", type=str)
     p.add_argument("--codex_exec_profile", type=str)
-    p.add_argument("--codex_exec_full_auto", type=_BOOL)
+    p.add_argument(
+        "--codex_exec_full_auto",
+        type=_BOOL,
+        help=(
+            "Deprecated and ignored; use --codex_exec_sandbox and "
+            "--codex_exec_approval_policy"
+        ),
+    )
     p.add_argument("--codex_exec_reasoning_effort", type=str)
     p.add_argument("--codex_exec_use_sdk", type=str)
     p.add_argument("--codex_exec_network_access", type=_BOOL)
@@ -487,17 +494,7 @@ def main() -> None:
     set_target_backend(cfg.get("target_backend", "openai_chat"))
     set_optimizer_deployment(cfg.get("optimizer_model", default_model_for_backend(backend)))
     set_target_deployment(cfg.get("target_model", default_model_for_backend(backend)))
-    configure_codex_exec(
-        path=cfg.get("codex_exec_path") or cfg.get("codex_path") or cfg.get("codex_cli_bin") or cfg.get("codex_bin") or None,
-        sandbox=cfg.get("codex_exec_sandbox") or cfg.get("sandbox") or cfg.get("codex_sandbox") or None,
-        profile=cfg.get("codex_exec_profile") or None,
-        full_auto=cfg.get("codex_exec_full_auto"),
-        reasoning_effort=cfg.get("codex_exec_reasoning_effort") or None,
-        use_sdk=cfg.get("codex_exec_use_sdk"),
-        network_access=cfg.get("codex_exec_network_access"),
-        web_search=cfg.get("codex_exec_web_search"),
-        approval_policy=cfg.get("codex_exec_approval_policy") or None,
-    )
+    configure_codex_exec_from_config(cfg)
     configure_claude_code_exec(
         path=cfg.get("claude_code_exec_path", "claude"),
         profile=cfg.get("claude_code_exec_profile", ""),

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -201,7 +201,14 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--codex_exec_path", type=str)
     p.add_argument("--codex_exec_sandbox", type=str)
     p.add_argument("--codex_exec_profile", type=str)
-    p.add_argument("--codex_exec_full_auto", type=_BOOL)
+    p.add_argument(
+        "--codex_exec_full_auto",
+        type=_BOOL,
+        help=(
+            "Deprecated and ignored; use --codex_exec_sandbox and "
+            "--codex_exec_approval_policy"
+        ),
+    )
     p.add_argument("--codex_exec_reasoning_effort", type=str)
     p.add_argument("--codex_exec_use_sdk", type=str)
     p.add_argument("--codex_exec_network_access", type=_BOOL)

--- a/skillopt/config.py
+++ b/skillopt/config.py
@@ -26,6 +26,19 @@ _STRUCTURED_SECTIONS = frozenset({
     "model", "train", "gradient", "optimizer", "evaluation", "env",
 })
 
+# Canonical Codex config keys and their legacy aliases, in fallback order.
+# Aliases are normalized within each YAML layer before inheritance is merged so
+# a child alias can override a canonical value inherited from its base.
+_CODEX_CONFIG_ALIASES: dict[str, tuple[str, ...]] = {
+    "codex_exec_path": ("codex_path", "codex_cli_bin", "codex_bin"),
+    "codex_exec_sandbox": ("sandbox", "codex_sandbox"),
+}
+_CODEX_ALIAS_TO_CANONICAL = {
+    alias: canonical
+    for canonical, aliases in _CODEX_CONFIG_ALIASES.items()
+    for alias in aliases
+}
+
 # ── Structured → flat key mapping ────────────────────────────────────────
 
 _FLATTEN_MAP: dict[str, str] = {
@@ -38,11 +51,7 @@ _FLATTEN_MAP: dict[str, str] = {
     "model.rewrite_reasoning_effort": "rewrite_reasoning_effort",
     "model.rewrite_max_completion_tokens": "rewrite_max_completion_tokens",
     "model.codex_exec_path": "codex_exec_path",
-    "model.codex_path": "codex_exec_path",
-    "model.codex_cli_bin": "codex_exec_path",
     "model.codex_exec_sandbox": "codex_exec_sandbox",
-    "model.codex_sandbox": "codex_exec_sandbox",
-    "model.sandbox": "codex_exec_sandbox",
     "model.codex_exec_profile": "codex_exec_profile",
     "model.codex_exec_full_auto": "codex_exec_full_auto",
     "model.codex_exec_reasoning_effort": "codex_exec_reasoning_effort",
@@ -147,6 +156,11 @@ _FLATTEN_MAP: dict[str, str] = {
     "env.out_root": "out_root",
 }
 
+_FLAT_TO_STRUCTURED = {
+    flat_key: dotted
+    for dotted, flat_key in _FLATTEN_MAP.items()
+}
+
 
 # ── Deep merge ───────────────────────────────────────────────────────────
 
@@ -159,6 +173,58 @@ def _deep_merge(base: dict, override: dict) -> dict:
         else:
             result[key] = copy.deepcopy(val)
     return result
+
+
+def _normalize_codex_aliases_in_mapping(mapping: dict) -> None:
+    """Replace Codex aliases in one config layer with canonical keys."""
+    for canonical, aliases in _CODEX_CONFIG_ALIASES.items():
+        if canonical not in mapping:
+            for alias in aliases:
+                if alias in mapping:
+                    mapping[canonical] = mapping[alias]
+                    break
+        for alias in aliases:
+            mapping.pop(alias, None)
+
+
+def _normalize_codex_config_aliases(cfg: dict) -> dict:
+    """Return a deep copy with structured and legacy Codex aliases resolved."""
+    normalized = copy.deepcopy(cfg)
+    _normalize_codex_aliases_in_mapping(normalized)
+    model = normalized.get("model")
+    if isinstance(model, dict):
+        _normalize_codex_aliases_in_mapping(model)
+    return normalized
+
+
+def _nested_key_present(cfg: dict, dotted: str) -> bool:
+    """Return whether *cfg* explicitly contains one structured key."""
+    section, key = dotted.split(".", 1)
+    section_cfg = cfg.get(section)
+    return isinstance(section_cfg, dict) and key in section_cfg
+
+
+def _remove_nested_key(cfg: dict, dotted: str) -> None:
+    """Remove one structured key without changing the config's shape."""
+    section, key = dotted.split(".", 1)
+    section_cfg = cfg.get(section)
+    if isinstance(section_cfg, dict):
+        section_cfg.pop(key, None)
+
+
+def _resolve_layer_format_duplicates(cfg: dict) -> None:
+    """Prefer canonical structured keys over equivalent flat keys in a layer."""
+    for dotted, flat_key in _FLATTEN_MAP.items():
+        if _nested_key_present(cfg, dotted):
+            cfg.pop(flat_key, None)
+
+
+def _drop_base_keys_overridden_by_layer(base: dict, override: dict) -> None:
+    """Honor child precedence when inheritance mixes flat and structured YAML."""
+    for dotted, flat_key in _FLATTEN_MAP.items():
+        if flat_key in override or _nested_key_present(override, dotted):
+            base.pop(flat_key, None)
+            _remove_nested_key(base, dotted)
 
 
 # ── YAML loading with _base_ inheritance ─────────────────────────────────
@@ -176,9 +242,18 @@ def _load_yaml(path: str, _visited: set[str] | None = None) -> dict:
         cfg = yaml.safe_load(f) or {}
 
     base_ref = cfg.pop("_base_", None)
+    # Normalize this layer before merging it with its base.  Otherwise a base
+    # canonical key would incorrectly mask the equivalent alias in a child.
+    cfg = _normalize_codex_config_aliases(cfg)
+    _resolve_layer_format_duplicates(cfg)
     if base_ref:
         base_path = os.path.join(os.path.dirname(abs_path), base_ref)
         base_cfg = _load_yaml(base_path, _visited)
+        # A child value must win even when the child and base use opposite
+        # representations of the same setting (for example ``batch_size`` vs
+        # ``train.batch_size`` or ``codex_path`` vs
+        # ``model.codex_exec_path``).
+        _drop_base_keys_overridden_by_layer(base_cfg, cfg)
         cfg = _deep_merge(base_cfg, cfg)
 
     return cfg
@@ -199,12 +274,20 @@ def is_structured(cfg: dict) -> bool:
 def flatten_config(cfg: dict) -> dict:
     """Convert a structured config to the flat dict expected by the trainer.
 
-    If *cfg* is already flat, returns a shallow copy unchanged.
+    If *cfg* is already flat, returns a normalized copy.
     """
+    cfg = _normalize_codex_config_aliases(cfg)
     if not is_structured(cfg):
         return dict(cfg)
 
-    flat: dict[str, Any] = {}
+    # A mixed inheritance chain can legitimately contain legacy top-level
+    # values alongside structured sections.  Preserve those values; explicit
+    # structured keys below take precedence within the same YAML layer.
+    flat: dict[str, Any] = {
+        key: val
+        for key, val in cfg.items()
+        if key not in _STRUCTURED_SECTIONS
+    }
 
     # Apply the explicit mapping
     for dotted, flat_key in _FLATTEN_MAP.items():
@@ -253,6 +336,11 @@ def apply_overrides(cfg: dict, overrides: list[str]) -> None:
     Supports both ``section.key=value`` (for structured configs) and
     ``key=value`` (for flat configs or flat keys in env section).
     """
+    # Keep the source file's format stable across the whole override list.  A
+    # dotted override on a legacy flat file must not create a section that then
+    # causes all of its existing top-level settings to be discarded.
+    structured = is_structured(cfg)
+
     for item in overrides:
         if "=" not in item:
             raise ValueError(f"Invalid override (expected key=value): {item!r}")
@@ -261,13 +349,25 @@ def apply_overrides(cfg: dict, overrides: list[str]) -> None:
 
         if "." in key:
             section, subkey = key.split(".", 1)
-            if section in cfg and isinstance(cfg[section], dict):
+            if section == "model":
+                subkey = _CODEX_ALIAS_TO_CANONICAL.get(subkey, subkey)
+            dotted = f"{section}.{subkey}"
+            if not structured and dotted in _FLATTEN_MAP:
+                cfg[_FLATTEN_MAP[dotted]] = val
+            elif not structured and section == "env":
+                cfg[subkey] = val
+            elif section in cfg and isinstance(cfg[section], dict):
                 cfg[section][subkey] = val
             else:
                 cfg.setdefault(section, {})[subkey] = val
         else:
-            # Flat key — apply to top level (for legacy compat)
-            cfg[key] = val
+            canonical = _CODEX_ALIAS_TO_CANONICAL.get(key, key)
+            dotted = _FLAT_TO_STRUCTURED.get(canonical)
+            if structured and dotted:
+                section, subkey = dotted.split(".", 1)
+                cfg.setdefault(section, {})[subkey] = val
+            else:
+                cfg[canonical] = val
 
 
 # ── Public API ───────────────────────────────────────────────────────────

--- a/skillopt/engine/trainer.py
+++ b/skillopt/engine/trainer.py
@@ -62,7 +62,7 @@ from skillopt.model import (
     chat_optimizer,
     configure_azure_openai,
     configure_claude_code_exec,
-    configure_codex_exec,
+    configure_codex_exec_from_config,
     configure_copilot_chat,
     configure_copilot_exec,
     configure_cursor_exec,
@@ -671,6 +671,18 @@ class ReflACTTrainer:
         out_root = cfg["out_root"]
         os.makedirs(out_root, exist_ok=True)
 
+        # Backends must be visible during adapter setup.  SpreadsheetBench, for
+        # example, validates its mode against the configured target backend.
+        backend = cfg.get("model_backend", "azure_openai")
+        optimizer_backend, target_backend = _resolve_role_backends(
+            backend, cfg.get("optimizer_backend"), cfg.get("target_backend")
+        )
+        cfg["optimizer_backend"] = optimizer_backend
+        cfg["target_backend"] = target_backend
+        set_optimizer_backend(optimizer_backend)
+        set_target_backend(target_backend)
+        configure_codex_exec_from_config(cfg)
+
         # ── Adapter setup (one-time init) ────────────────────────────
         adapter.setup(cfg)
         dataloader = adapter.get_dataloader()
@@ -700,7 +712,6 @@ class ReflACTTrainer:
             return env_manager, batch.batch_size
 
         # ── Configure models ─────────────────────────────────────────────
-        backend = cfg.get("model_backend", "azure_openai")
         configure_azure_openai(
             endpoint=(
                 cfg.get("azure_openai_endpoint")
@@ -737,26 +748,8 @@ class ReflACTTrainer:
                 cfg.get("target_azure_openai_managed_identity_client_id") or None
             ),
         )
-        optimizer_backend, target_backend = _resolve_role_backends(
-            backend, cfg.get("optimizer_backend"), cfg.get("target_backend")
-        )
-        cfg["optimizer_backend"] = optimizer_backend
-        cfg["target_backend"] = target_backend
-        set_optimizer_backend(optimizer_backend)
-        set_target_backend(target_backend)
         set_optimizer_deployment(cfg["optimizer_model"])
         set_target_deployment(cfg["target_model"])
-        configure_codex_exec(
-            path=cfg.get("codex_exec_path") or cfg.get("codex_path") or cfg.get("codex_cli_bin") or cfg.get("codex_bin") or None,
-            sandbox=cfg.get("codex_exec_sandbox") or cfg.get("sandbox") or cfg.get("codex_sandbox") or None,
-            profile=cfg.get("codex_exec_profile") or None,
-            full_auto=cfg.get("codex_exec_full_auto"),
-            reasoning_effort=cfg.get("codex_exec_reasoning_effort") or None,
-            use_sdk=cfg.get("codex_exec_use_sdk"),
-            network_access=cfg.get("codex_exec_network_access"),
-            web_search=cfg.get("codex_exec_web_search"),
-            approval_policy=cfg.get("codex_exec_approval_policy") or None,
-        )
         configure_claude_code_exec(
             path=cfg.get("claude_code_exec_path", "claude"),
             profile=cfg.get("claude_code_exec_profile", ""),

--- a/skillopt/model/__init__.py
+++ b/skillopt/model/__init__.py
@@ -14,6 +14,7 @@ from skillopt.model import qwen_backend as _qwen
 from skillopt.model.backend_config import (  # noqa: F401
     configure_claude_code_exec,
     configure_codex_exec,
+    configure_codex_exec_from_config,
     configure_copilot_chat,
     configure_copilot_exec,
     configure_cursor_exec,

--- a/skillopt/model/backend_config.py
+++ b/skillopt/model/backend_config.py
@@ -1,7 +1,11 @@
 """Runtime backend configuration for optimizer/target model calls."""
 from __future__ import annotations
 
+import json
 import os
+import warnings
+from collections.abc import Mapping
+from typing import Any
 
 from skillopt.model.common import normalize_backend_name
 
@@ -12,13 +16,34 @@ def _parse_bool(value: str | None, default: bool) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _coerce_bool_setting(value: Any, *, name: str) -> bool:
+    """Parse a config boolean without treating non-empty strings as true."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    elif isinstance(value, int) and value in {0, 1}:
+        return bool(value)
+    raise ValueError(
+        f"Invalid {name}: {value!r}. Expected a boolean or one of "
+        "true/false, yes/no, on/off, or 1/0."
+    )
+
+
 OPTIMIZER_BACKEND = normalize_backend_name(os.environ.get("OPTIMIZER_BACKEND", "openai_chat"))
 TARGET_BACKEND = normalize_backend_name(os.environ.get("TARGET_BACKEND", "openai_chat"))
 
 CODEX_EXEC_PATH = os.environ.get("CODEX_EXEC_PATH") or os.environ.get("CODEX_CLI_BIN") or os.environ.get("CODEX_PATH") or "codex"
 CODEX_EXEC_SANDBOX = os.environ.get("CODEX_EXEC_SANDBOX") or os.environ.get("CODEX_SANDBOX_MODE") or os.environ.get("CODEX_SANDBOX") or "workspace-write"
 CODEX_EXEC_PROFILE = os.environ.get("CODEX_EXEC_PROFILE", "")
-CODEX_EXEC_FULL_AUTO = _parse_bool(os.environ.get("CODEX_EXEC_FULL_AUTO"), True)
+_CODEX_EXEC_FULL_AUTO_ENV = os.environ.get("CODEX_EXEC_FULL_AUTO")
+# Kept as a compatibility symbol only.  The retired --full-auto flag is never
+# emitted, regardless of the deprecated environment/config value.
+CODEX_EXEC_FULL_AUTO = False
 CODEX_EXEC_REASONING_EFFORT = os.environ.get("CODEX_EXEC_REASONING_EFFORT", "none")
 CODEX_EXEC_USE_SDK = os.environ.get("CODEX_EXEC_USE_SDK", "auto")
 CODEX_EXEC_NETWORK_ACCESS = _parse_bool(os.environ.get("CODEX_EXEC_NETWORK_ACCESS"), False)
@@ -38,6 +63,47 @@ COPILOT_EXEC_ALLOW_ALL_TOOLS = (
 COPILOT_CHAT_OPTIMIZER_MODEL = os.environ.get("COPILOT_CHAT_OPTIMIZER_MODEL", "")
 COPILOT_CHAT_TARGET_MODEL = os.environ.get("COPILOT_CHAT_TARGET_MODEL", "")
 COPILOT_CHAT_TIMEOUT = os.environ.get("COPILOT_CHAT_TIMEOUT", "600")
+
+if _CODEX_EXEC_FULL_AUTO_ENV is not None:
+    warnings.warn(
+        "CODEX_EXEC_FULL_AUTO is deprecated and ignored; use "
+        "CODEX_EXEC_SANDBOX and CODEX_EXEC_APPROVAL_POLICY instead",
+        FutureWarning,
+        stacklevel=2,
+    )
+
+
+# A train/eval configuration is a complete runtime snapshot.  Preserve the
+# environment-derived values from process startup so loading a later config
+# cannot inherit path or permission settings applied by an earlier run in the
+# same process.
+_CODEX_EXEC_BASELINE = {
+    "path": CODEX_EXEC_PATH,
+    "sandbox": CODEX_EXEC_SANDBOX,
+    "profile": CODEX_EXEC_PROFILE,
+    "reasoning_effort": CODEX_EXEC_REASONING_EFFORT,
+    "use_sdk": CODEX_EXEC_USE_SDK,
+    "network_access": CODEX_EXEC_NETWORK_ACCESS,
+    "web_search": CODEX_EXEC_WEB_SEARCH,
+    "approval_policy": CODEX_EXEC_APPROVAL_POLICY,
+}
+_CODEX_EXEC_MUTATED_ENV_KEYS = (
+    "CODEX_EXEC_PATH",
+    "CODEX_CLI_BIN",
+    "CODEX_EXEC_SANDBOX",
+    "CODEX_SANDBOX_MODE",
+    "CODEX_EXEC_PROFILE",
+    "CODEX_EXEC_REASONING_EFFORT",
+    "CODEX_EXEC_USE_SDK",
+    "CODEX_EXEC_NETWORK_ACCESS",
+    "CODEX_EXEC_WEB_SEARCH",
+    "CODEX_EXEC_APPROVAL_POLICY",
+)
+_CODEX_EXEC_ENV_BASELINE = {
+    key: os.environ[key]
+    for key in _CODEX_EXEC_MUTATED_ENV_KEYS
+    if key in os.environ
+}
 
 
 def _parse_int(value: str | None, default: int) -> int:
@@ -138,11 +204,21 @@ def configure_codex_exec(
     full_auto: bool | None = None,
     reasoning_effort: str | None = None,
     use_sdk: str | None = None,
-    network_access: bool | None = None,
-    web_search: bool | None = None,
+    network_access: bool | str | int | None = None,
+    web_search: bool | str | int | None = None,
     approval_policy: str | None = None,
 ) -> None:
-    global CODEX_EXEC_PATH, CODEX_EXEC_SANDBOX, CODEX_EXEC_PROFILE, CODEX_EXEC_FULL_AUTO, CODEX_EXEC_REASONING_EFFORT, CODEX_EXEC_USE_SDK, CODEX_EXEC_NETWORK_ACCESS, CODEX_EXEC_WEB_SEARCH, CODEX_EXEC_APPROVAL_POLICY
+    global CODEX_EXEC_PATH, CODEX_EXEC_SANDBOX, CODEX_EXEC_PROFILE, CODEX_EXEC_REASONING_EFFORT, CODEX_EXEC_USE_SDK, CODEX_EXEC_NETWORK_ACCESS, CODEX_EXEC_WEB_SEARCH, CODEX_EXEC_APPROVAL_POLICY
+    parsed_network_access = (
+        None
+        if network_access is None
+        else _coerce_bool_setting(network_access, name="codex_exec_network_access")
+    )
+    parsed_web_search = (
+        None
+        if web_search is None
+        else _coerce_bool_setting(web_search, name="codex_exec_web_search")
+    )
     if path is not None:
         CODEX_EXEC_PATH = str(path).strip() or "codex"
         os.environ["CODEX_EXEC_PATH"] = CODEX_EXEC_PATH
@@ -157,23 +233,84 @@ def configure_codex_exec(
         CODEX_EXEC_PROFILE = str(profile).strip()
         os.environ["CODEX_EXEC_PROFILE"] = CODEX_EXEC_PROFILE
     if full_auto is not None:
-        CODEX_EXEC_FULL_AUTO = bool(full_auto)
-        os.environ["CODEX_EXEC_FULL_AUTO"] = "true" if CODEX_EXEC_FULL_AUTO else "false"
+        warnings.warn(
+            "codex_exec_full_auto is deprecated and ignored; use "
+            "codex_exec_sandbox and codex_exec_approval_policy instead",
+            FutureWarning,
+            stacklevel=2,
+        )
     if reasoning_effort is not None:
         CODEX_EXEC_REASONING_EFFORT = str(reasoning_effort).strip() or "none"
         os.environ["CODEX_EXEC_REASONING_EFFORT"] = CODEX_EXEC_REASONING_EFFORT
     if use_sdk is not None:
         CODEX_EXEC_USE_SDK = str(use_sdk).strip().lower() or "auto"
         os.environ["CODEX_EXEC_USE_SDK"] = CODEX_EXEC_USE_SDK
-    if network_access is not None:
-        CODEX_EXEC_NETWORK_ACCESS = bool(network_access)
+    if parsed_network_access is not None:
+        CODEX_EXEC_NETWORK_ACCESS = parsed_network_access
         os.environ["CODEX_EXEC_NETWORK_ACCESS"] = "true" if CODEX_EXEC_NETWORK_ACCESS else "false"
-    if web_search is not None:
-        CODEX_EXEC_WEB_SEARCH = bool(web_search)
+    if parsed_web_search is not None:
+        CODEX_EXEC_WEB_SEARCH = parsed_web_search
         os.environ["CODEX_EXEC_WEB_SEARCH"] = "true" if CODEX_EXEC_WEB_SEARCH else "false"
     if approval_policy is not None:
         CODEX_EXEC_APPROVAL_POLICY = str(approval_policy).strip() or "never"
         os.environ["CODEX_EXEC_APPROVAL_POLICY"] = CODEX_EXEC_APPROVAL_POLICY
+
+
+def _first_nonempty(config: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = config.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _restore_codex_exec_baseline() -> None:
+    """Restore process-start globals and the exact environment-key state."""
+    global CODEX_EXEC_PATH, CODEX_EXEC_SANDBOX, CODEX_EXEC_PROFILE, CODEX_EXEC_REASONING_EFFORT, CODEX_EXEC_USE_SDK, CODEX_EXEC_NETWORK_ACCESS, CODEX_EXEC_WEB_SEARCH, CODEX_EXEC_APPROVAL_POLICY
+    CODEX_EXEC_PATH = _CODEX_EXEC_BASELINE["path"]
+    CODEX_EXEC_SANDBOX = _CODEX_EXEC_BASELINE["sandbox"]
+    CODEX_EXEC_PROFILE = _CODEX_EXEC_BASELINE["profile"]
+    CODEX_EXEC_REASONING_EFFORT = _CODEX_EXEC_BASELINE["reasoning_effort"]
+    CODEX_EXEC_USE_SDK = _CODEX_EXEC_BASELINE["use_sdk"]
+    CODEX_EXEC_NETWORK_ACCESS = _CODEX_EXEC_BASELINE["network_access"]
+    CODEX_EXEC_WEB_SEARCH = _CODEX_EXEC_BASELINE["web_search"]
+    CODEX_EXEC_APPROVAL_POLICY = _CODEX_EXEC_BASELINE["approval_policy"]
+    for key in _CODEX_EXEC_MUTATED_ENV_KEYS:
+        if key in _CODEX_EXEC_ENV_BASELINE:
+            os.environ[key] = _CODEX_EXEC_ENV_BASELINE[key]
+        else:
+            os.environ.pop(key, None)
+
+
+def configure_codex_exec_from_config(config: Mapping[str, Any]) -> None:
+    """Configure Codex exec from a flattened train/eval configuration.
+
+    Dedicated ``codex_exec_*`` keys take precedence over legacy aliases.  The
+    ordering is centralized here so training and eval-only cannot drift.
+    """
+    _restore_codex_exec_baseline()
+    configure_codex_exec(
+        path=_first_nonempty(
+            config,
+            "codex_exec_path",
+            "codex_path",
+            "codex_cli_bin",
+            "codex_bin",
+        ),
+        sandbox=_first_nonempty(
+            config,
+            "codex_exec_sandbox",
+            "sandbox",
+            "codex_sandbox",
+        ),
+        profile=_first_nonempty(config, "codex_exec_profile"),
+        full_auto=config.get("codex_exec_full_auto"),
+        reasoning_effort=_first_nonempty(config, "codex_exec_reasoning_effort"),
+        use_sdk=_first_nonempty(config, "codex_exec_use_sdk"),
+        network_access=config.get("codex_exec_network_access"),
+        web_search=config.get("codex_exec_web_search"),
+        approval_policy=_first_nonempty(config, "codex_exec_approval_policy"),
+    )
 
 
 def get_codex_exec_config() -> dict[str, str | bool | int]:
@@ -189,6 +326,27 @@ def get_codex_exec_config() -> dict[str, str | bool | int]:
         "approval_policy": CODEX_EXEC_APPROVAL_POLICY,
         "empty_response_retries": EXEC_EMPTY_RESPONSE_RETRIES,
     }
+
+
+def build_codex_exec_cli_config_overrides(
+    config: Mapping[str, Any] | None = None,
+) -> list[str]:
+    """Translate shared network/search settings to Codex CLI overrides."""
+    effective = get_codex_exec_config() if config is None else config
+    network_enabled = _coerce_bool_setting(
+        effective.get("network_access", False),
+        name="codex_exec_network_access",
+    )
+    search_enabled = _coerce_bool_setting(
+        effective.get("web_search", False),
+        name="codex_exec_web_search",
+    )
+    network_access = "true" if network_enabled else "false"
+    web_search = "live" if search_enabled else "disabled"
+    return [
+        f"sandbox_workspace_write.network_access={network_access}",
+        f"web_search={json.dumps(web_search)}",
+    ]
 
 
 def configure_claude_code_exec(

--- a/skillopt/model/codex_backend.py
+++ b/skillopt/model/codex_backend.py
@@ -12,14 +12,16 @@ import uuid
 from typing import Any
 from urllib.parse import unquote, urlparse
 
-from skillopt.model.backend_config import get_codex_exec_config
+from skillopt.model.backend_config import (
+    build_codex_exec_cli_config_overrides,
+    get_codex_exec_config,
+)
 from skillopt.model.common import (
     CompatAssistantMessage,
     CompatToolCall,
     CompatToolFunction,
     TokenTracker,
 )
-
 
 CODEX_BIN = os.environ.get("CODEX_EXEC_PATH") or os.environ.get("CODEX_CLI_BIN") or "codex"
 CODEX_PROFILE = os.environ.get("CODEX_EXEC_PROFILE") or os.environ.get("CODEX_PROFILE") or "review"
@@ -311,6 +313,9 @@ def _run_codex_exec(
             "--output-last-message",
             output_path,
         ]
+
+        for override in build_codex_exec_cli_config_overrides(config):
+            command.extend(["-c", override])
 
         if profile:
             command.extend(["--profile", profile])

--- a/skillopt/model/codex_harness.py
+++ b/skillopt/model/codex_harness.py
@@ -9,9 +9,11 @@ import shutil
 import subprocess
 import threading
 import traceback
+import warnings
 from typing import Any
 
 from skillopt.model.backend_config import (
+    build_codex_exec_cli_config_overrides,
     get_claude_code_exec_config,
     get_codex_exec_config,
     get_copilot_exec_config,
@@ -936,7 +938,6 @@ def _run_codex_cli_exec(
     images: list[str] | None = None,
     data_dirs: list[str] | None = None,
     sandbox: str | None = None,
-    full_auto: bool | None = None,
 ) -> tuple[str, str]:
     config = get_codex_exec_config()
     last_message_path = os.path.join(work_dir, "codex_last_message.txt")
@@ -961,6 +962,8 @@ def _run_codex_cli_exec(
     approval_policy = str(config.get("approval_policy", "never")).strip()
     if approval_policy:
         cmd.extend(["-c", f'approval_policy="{approval_policy}"'])
+    for override in build_codex_exec_cli_config_overrides(config):
+        cmd.extend(["-c", override])
     if model:
         cmd.extend(["-m", model])
     for data_dir in data_dirs or []:
@@ -1020,6 +1023,13 @@ def run_codex_exec(
     sandbox: str | None = None,
     full_auto: bool | None = None,
 ) -> tuple[str, str]:
+    if full_auto is not None:
+        warnings.warn(
+            "full_auto is deprecated and ignored; configure sandbox and "
+            "approval_policy explicitly instead",
+            FutureWarning,
+            stacklevel=2,
+        )
     config = get_codex_exec_config()
     mode = _sdk_mode(config.get("use_sdk"))
     retries = int(config.get("empty_response_retries", 0) or 0)
@@ -1064,7 +1074,6 @@ def run_codex_exec(
                 images=images,
                 data_dirs=data_dirs,
                 sandbox=sandbox,
-                full_auto=full_auto,
             )
             all_raw.append(f"===== CODEX CLI ATTEMPT {attempt + 1} =====\n{raw}")
             last_response = response

--- a/tests/test_codex_config_aliases.py
+++ b/tests/test_codex_config_aliases.py
@@ -1,11 +1,73 @@
-import importlib
+import json
 import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
 
-from skillopt.config import flatten_config
-from skillopt.model.backend_config import configure_codex_exec, validate_exec_sandbox
+import skillopt.model.backend_config as backend_config
+from skillopt.config import flatten_config, is_structured, load_config
+from skillopt.model.backend_config import (
+    configure_codex_exec,
+    configure_codex_exec_from_config,
+    validate_exec_sandbox,
+)
+
+_CODEX_ENV_KEYS = (
+    "CODEX_EXEC_PATH",
+    "CODEX_CLI_BIN",
+    "CODEX_EXEC_SANDBOX",
+    "CODEX_SANDBOX_MODE",
+    "CODEX_EXEC_PROFILE",
+    "CODEX_EXEC_FULL_AUTO",
+    "CODEX_EXEC_REASONING_EFFORT",
+    "CODEX_EXEC_USE_SDK",
+    "CODEX_EXEC_NETWORK_ACCESS",
+    "CODEX_EXEC_WEB_SEARCH",
+    "CODEX_EXEC_APPROVAL_POLICY",
+)
+_CODEX_CONFIG_GLOBALS = (
+    "CODEX_EXEC_PATH",
+    "CODEX_EXEC_SANDBOX",
+    "CODEX_EXEC_PROFILE",
+    "CODEX_EXEC_FULL_AUTO",
+    "CODEX_EXEC_REASONING_EFFORT",
+    "CODEX_EXEC_USE_SDK",
+    "CODEX_EXEC_NETWORK_ACCESS",
+    "CODEX_EXEC_WEB_SEARCH",
+    "CODEX_EXEC_APPROVAL_POLICY",
+    "EXEC_EMPTY_RESPONSE_RETRIES",
+)
+_DEFAULT_CONFIG = Path(__file__).parents[1] / "configs" / "_base_" / "default.yaml"
+
+
+def _command_config_overrides(command: list[str]) -> list[str]:
+    return [
+        command[index + 1]
+        for index, argument in enumerate(command)
+        if argument == "-c"
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _restore_codex_runtime_state():
+    """Configuration tests must not alter later tests in the same process."""
+    env_before = {key: os.environ[key] for key in _CODEX_ENV_KEYS if key in os.environ}
+    globals_before = {
+        key: getattr(backend_config, key)
+        for key in _CODEX_CONFIG_GLOBALS
+    }
+    yield
+    for key in _CODEX_ENV_KEYS:
+        if key in env_before:
+            os.environ[key] = env_before[key]
+        else:
+            os.environ.pop(key, None)
+    for key, value in globals_before.items():
+        setattr(backend_config, key, value)
 
 
 def test_codex_config_aliases_flatten_config():
@@ -20,30 +82,322 @@ def test_codex_config_aliases_flatten_config():
     assert flat["codex_exec_path"] == "/custom/path/codex"
 
 
-def test_codex_backend_env_aliases(monkeypatch):
-    monkeypatch.setenv("CODEX_CLI_BIN", "/env/path/codex")
-    monkeypatch.setenv("CODEX_SANDBOX_MODE", "danger-full-access")
+def test_canonical_structured_codex_config_wins_over_aliases():
+    structured_cfg = {
+        "model": {
+            "codex_bin": "/legacy/bin",
+            "codex_cli_bin": "/legacy/cli",
+            "codex_path": "/legacy/path",
+            "codex_exec_path": "/canonical/codex",
+            "codex_sandbox": "workspace-write",
+            "sandbox": "danger-full-access",
+            "codex_exec_sandbox": "read-only",
+        }
+    }
 
-    import skillopt.model.backend_config
-    import skillopt.model.codex_backend
+    flat = flatten_config(structured_cfg)
 
-    importlib.reload(skillopt.model.backend_config)
-    importlib.reload(skillopt.model.codex_backend)
+    assert flat["codex_exec_path"] == "/canonical/codex"
+    assert flat["codex_exec_sandbox"] == "read-only"
 
-    assert skillopt.model.codex_backend.CODEX_BIN == "/env/path/codex"
-    assert skillopt.model.codex_backend.CODEX_SANDBOX_MODE == "danger-full-access"
+
+def test_child_aliases_override_base_canonical_values(tmp_path):
+    base = tmp_path / "base.yaml"
+    base.write_text(
+        "model:\n"
+        "  codex_exec_path: /base/codex\n"
+        "  codex_exec_sandbox: read-only\n",
+        encoding="utf-8",
+    )
+    child = tmp_path / "child.yaml"
+    child.write_text(
+        "_base_: base.yaml\n"
+        "model:\n"
+        "  codex_cli_bin: /child/codex\n"
+        "  sandbox: danger-full-access\n",
+        encoding="utf-8",
+    )
+
+    cfg = load_config(str(child))
+
+    assert cfg["model"]["codex_exec_path"] == "/child/codex"
+    assert cfg["model"]["codex_exec_sandbox"] == "danger-full-access"
+    assert "codex_cli_bin" not in cfg["model"]
+    assert "sandbox" not in cfg["model"]
+
+
+def test_dotted_alias_overrides_replace_inherited_canonical_values(tmp_path):
+    base = tmp_path / "base.yaml"
+    base.write_text(
+        "model:\n"
+        "  codex_exec_path: /base/codex\n"
+        "  codex_exec_sandbox: read-only\n",
+        encoding="utf-8",
+    )
+
+    cfg = load_config(
+        str(base),
+        overrides=[
+            "model.codex_path=/override/codex",
+            "model.sandbox=workspace-write",
+        ],
+    )
+
+    assert flatten_config(cfg)["codex_exec_path"] == "/override/codex"
+    assert flatten_config(cfg)["codex_exec_sandbox"] == "workspace-write"
+
+
+def test_dotted_codex_override_keeps_legacy_flat_config_flat(tmp_path):
+    config = tmp_path / "flat.yaml"
+    config.write_text(
+        "batch_size: 7\n"
+        "optimizer_model: keep-me\n"
+        "codex_exec_sandbox: read-only\n",
+        encoding="utf-8",
+    )
+
+    cfg = load_config(
+        str(config),
+        overrides=["model.codex_path=/override/codex"],
+    )
+
+    assert not is_structured(cfg)
+    assert cfg == {
+        "batch_size": 7,
+        "optimizer_model": "keep-me",
+        "codex_exec_sandbox": "read-only",
+        "codex_exec_path": "/override/codex",
+    }
+
+
+@pytest.mark.parametrize("child_format", ["flat", "structured"])
+def test_mixed_format_inheritance_preserves_child_precedence(
+    tmp_path,
+    child_format,
+):
+    base = tmp_path / "base.yaml"
+    child = tmp_path / "child.yaml"
+
+    if child_format == "flat":
+        base.write_text(
+            "model:\n"
+            "  codex_exec_path: /base/codex\n"
+            "train:\n"
+            "  batch_size: 3\n",
+            encoding="utf-8",
+        )
+        child.write_text(
+            "_base_: base.yaml\n"
+            "codex_path: /child/codex\n"
+            "batch_size: 9\n"
+            "custom_runtime_value: preserved\n",
+            encoding="utf-8",
+        )
+    else:
+        base.write_text(
+            "codex_exec_path: /base/codex\n"
+            "batch_size: 3\n"
+            "custom_runtime_value: preserved\n",
+            encoding="utf-8",
+        )
+        child.write_text(
+            "_base_: base.yaml\n"
+            "model:\n"
+            "  codex_path: /child/codex\n"
+            "train:\n"
+            "  batch_size: 9\n",
+            encoding="utf-8",
+        )
+
+    flat = flatten_config(load_config(str(child)))
+
+    assert flat["codex_exec_path"] == "/child/codex"
+    assert flat["batch_size"] == 9
+    assert flat["custom_runtime_value"] == "preserved"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_path", "expected_sandbox"),
+    [
+        (
+            ["codex_path=/override/codex", "sandbox=workspace-write"],
+            "/override/codex",
+            "workspace-write",
+        ),
+        (
+            [
+                "codex_exec_path=/canonical/codex",
+                "codex_exec_sandbox=danger-full-access",
+            ],
+            "/canonical/codex",
+            "danger-full-access",
+        ),
+    ],
+)
+def test_flat_codex_overrides_apply_to_structured_config(
+    tmp_path,
+    overrides,
+    expected_path,
+    expected_sandbox,
+):
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "model:\n"
+        "  codex_exec_path: /base/codex\n"
+        "  codex_exec_sandbox: read-only\n",
+        encoding="utf-8",
+    )
+
+    cfg = load_config(str(config), overrides=overrides)
+    flat = flatten_config(cfg)
+
+    assert flat["codex_exec_path"] == expected_path
+    assert flat["codex_exec_sandbox"] == expected_sandbox
+    assert "codex_exec_path" not in cfg
+    assert "codex_exec_sandbox" not in cfg
+
+
+def test_all_flat_canonical_codex_overrides_apply_to_structured_config(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "model:\n"
+        "  backend: codex\n",
+        encoding="utf-8",
+    )
+    expected = {
+        "codex_exec_path": "/override/codex",
+        "codex_exec_sandbox": "read-only",
+        "codex_exec_profile": "override-profile",
+        "codex_exec_full_auto": True,
+        "codex_exec_reasoning_effort": "high",
+        "codex_exec_use_sdk": "cli",
+        "codex_exec_network_access": True,
+        "codex_exec_web_search": False,
+        "codex_exec_approval_policy": "on-request",
+    }
+
+    cfg = load_config(
+        str(config),
+        overrides=[f"{key}={str(value).lower()}" for key, value in expected.items()],
+    )
+    flat = flatten_config(cfg)
+
+    for key, value in expected.items():
+        assert flat[key] == value
+        assert key not in cfg
+
+
+def test_legacy_flat_child_alias_overrides_base_canonical_value(tmp_path):
+    base = tmp_path / "base.yaml"
+    base.write_text("codex_exec_path: /base/codex\n", encoding="utf-8")
+    child = tmp_path / "child.yaml"
+    child.write_text(
+        "_base_: base.yaml\n"
+        "codex_bin: /child/codex\n",
+        encoding="utf-8",
+    )
+
+    cfg = load_config(str(child))
+
+    assert cfg["codex_exec_path"] == "/child/codex"
+    assert "codex_bin" not in cfg
+
+
+def test_default_config_preserves_preloaded_codex_environment():
+    env = os.environ.copy()
+    for key in _CODEX_ENV_KEYS:
+        env.pop(key, None)
+    env.update(
+        {
+            "CODEX_CLI_BIN": "/env/codex",
+            "CODEX_SANDBOX_MODE": "danger-full-access",
+            "CODEX_EXEC_PROFILE": "env-profile",
+            "CODEX_EXEC_REASONING_EFFORT": "high",
+            "CODEX_EXEC_USE_SDK": "cli",
+            "CODEX_EXEC_NETWORK_ACCESS": "true",
+            "CODEX_EXEC_WEB_SEARCH": "true",
+            "CODEX_EXEC_APPROVAL_POLICY": "on-request",
+        }
+    )
+    code = f"""
+import json
+from skillopt.config import flatten_config, load_config
+from skillopt.model.backend_config import (
+    configure_codex_exec_from_config,
+    get_codex_exec_config,
+)
+configure_codex_exec_from_config(flatten_config(load_config({str(_DEFAULT_CONFIG)!r})))
+print(json.dumps(get_codex_exec_config()))
+"""
+
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    loaded = json.loads(proc.stdout)
+
+    assert loaded["path"] == "/env/codex"
+    assert loaded["sandbox"] == "danger-full-access"
+    assert loaded["profile"] == "env-profile"
+    assert loaded["reasoning_effort"] == "high"
+    assert loaded["use_sdk"] == "cli"
+    assert loaded["network_access"] is True
+    assert loaded["web_search"] is True
+    assert loaded["approval_policy"] == "on-request"
+
+
+def test_codex_backend_env_aliases_are_isolated_in_subprocess():
+    env = os.environ.copy()
+    for key in (
+        "CODEX_EXEC_PATH",
+        "CODEX_PATH",
+        "CODEX_CLI_BIN",
+        "CODEX_EXEC_SANDBOX",
+        "CODEX_SANDBOX_MODE",
+        "CODEX_SANDBOX",
+    ):
+        env.pop(key, None)
+    env["CODEX_CLI_BIN"] = "/env/path/codex"
+    env["CODEX_SANDBOX_MODE"] = "danger-full-access"
+    code = """
+import json
+from skillopt.model import backend_config, codex_backend
+print(json.dumps({
+    "config_path": backend_config.CODEX_EXEC_PATH,
+    "config_sandbox": backend_config.CODEX_EXEC_SANDBOX,
+    "backend_path": codex_backend.CODEX_BIN,
+    "backend_sandbox": codex_backend.CODEX_SANDBOX_MODE,
+}))
+"""
+
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    loaded = json.loads(proc.stdout)
+
+    assert loaded == {
+        "config_path": "/env/path/codex",
+        "config_sandbox": "danger-full-access",
+        "backend_path": "/env/path/codex",
+        "backend_sandbox": "danger-full-access",
+    }
 
 
 def test_configure_codex_exec_sets_aliases(monkeypatch):
-    monkeypatch.setattr("skillopt.model.backend_config.CODEX_EXEC_PATH", "")
-    monkeypatch.setattr("skillopt.model.backend_config.CODEX_EXEC_SANDBOX", "")
-    monkeypatch.setattr("skillopt.model.backend_config.CODEX_EXEC_APPROVAL_POLICY", "")
+    monkeypatch.setattr(backend_config, "CODEX_EXEC_PATH", "")
+    monkeypatch.setattr(backend_config, "CODEX_EXEC_SANDBOX", "")
 
     configure_codex_exec(path="/configured/codex", sandbox="danger-full-access")
 
     assert os.environ["CODEX_EXEC_PATH"] == "/configured/codex"
     assert os.environ["CODEX_CLI_BIN"] == "/configured/codex"
-
     assert os.environ["CODEX_EXEC_SANDBOX"] == "danger-full-access"
     assert os.environ["CODEX_SANDBOX_MODE"] == "danger-full-access"
 
@@ -60,53 +414,289 @@ def test_validate_exec_sandbox():
         configure_codex_exec(sandbox="unrestricted-bad-mode")
 
 
-def test_entry_points_alias_precedence(monkeypatch):
-    # Test precedence: codex_exec_sandbox > sandbox > codex_sandbox
-    cfg = {
-        "codex_exec_sandbox": "danger-full-access",
-        "sandbox": "workspace-write",
-        "codex_sandbox": "read-only",
-        "codex_exec_path": "/path/exec",
-        "codex_path": "/path/codex",
-        "codex_cli_bin": "/path/cli",
-    }
-    sandbox = cfg.get("codex_exec_sandbox") or cfg.get("sandbox") or cfg.get("codex_sandbox")
-    path = cfg.get("codex_exec_path") or cfg.get("codex_path") or cfg.get("codex_cli_bin")
-    assert sandbox == "danger-full-access"
-    assert path == "/path/exec"
+@pytest.mark.parametrize(
+    ("cfg", "expected_path", "expected_sandbox"),
+    [
+        (
+            {
+                "codex_exec_path": "/path/exec",
+                "codex_path": "/path/codex",
+                "codex_cli_bin": "/path/cli",
+                "codex_bin": "/path/bin",
+                "codex_exec_sandbox": "read-only",
+                "sandbox": "danger-full-access",
+                "codex_sandbox": "workspace-write",
+            },
+            "/path/exec",
+            "read-only",
+        ),
+        (
+            {
+                "codex_cli_bin": "/path/cli",
+                "sandbox": "danger-full-access",
+            },
+            "/path/cli",
+            "danger-full-access",
+        ),
+    ],
+)
+def test_shared_config_entry_point_alias_precedence(cfg, expected_path, expected_sandbox):
+    with mock.patch.object(backend_config, "configure_codex_exec") as configure:
+        configure_codex_exec_from_config(cfg)
 
-    # Fallback to sandbox alias
-    cfg_alias = {
-        "sandbox": "danger-full-access",
-        "codex_cli_bin": "/path/cli",
+    assert configure.call_args.kwargs["path"] == expected_path
+    assert configure.call_args.kwargs["sandbox"] == expected_sandbox
+
+
+class _EntryPointReached(Exception):
+    pass
+
+
+def test_trainer_uses_shared_codex_config_entry_point(monkeypatch, tmp_path):
+    import skillopt.engine.trainer as trainer_module
+
+    cfg = {
+        "out_root": str(tmp_path),
+        "model_backend": "azure_openai",
+        "optimizer_backend": "openai_chat",
+        "target_backend": "openai_chat",
+        "optimizer_model": "optimizer",
+        "target_model": "target",
+        "codex_exec_sandbox": "read-only",
     }
-    sandbox_alias = cfg_alias.get("codex_exec_sandbox") or cfg_alias.get("sandbox") or cfg_alias.get("codex_sandbox")
-    path_alias = cfg_alias.get("codex_exec_path") or cfg_alias.get("codex_path") or cfg_alias.get("codex_cli_bin")
-    assert sandbox_alias == "danger-full-access"
-    assert path_alias == "/path/cli"
+    adapter = mock.Mock()
+    adapter.get_dataloader.return_value = None
+    for name in (
+        "configure_azure_openai",
+        "set_optimizer_backend",
+        "set_target_backend",
+        "set_optimizer_deployment",
+        "set_target_deployment",
+    ):
+        monkeypatch.setattr(trainer_module, name, mock.Mock())
+
+    def stop_at_codex_config(actual_cfg):
+        assert actual_cfg is cfg
+        raise _EntryPointReached
+
+    monkeypatch.setattr(
+        trainer_module,
+        "configure_codex_exec_from_config",
+        stop_at_codex_config,
+    )
+
+    with pytest.raises(_EntryPointReached):
+        trainer_module.ReflACTTrainer(cfg, adapter).train()
+
+
+def test_trainer_configures_target_backend_before_adapter_setup(
+    monkeypatch,
+    tmp_path,
+):
+    import skillopt.engine.trainer as trainer_module
+
+    cfg = {
+        "out_root": str(tmp_path),
+        "model_backend": "azure_openai",
+        "optimizer_backend": "openai_chat",
+        "target_backend": "codex_exec",
+    }
+    for name in ("OPTIMIZER_BACKEND", "TARGET_BACKEND"):
+        monkeypatch.setattr(backend_config, name, getattr(backend_config, name))
+        # Record even an originally absent environment key so teardown removes
+        # the value written by the real backend setter.
+        monkeypatch.setenv(name, os.environ.get(name, ""))
+
+    adapter = mock.Mock()
+
+    def assert_backend_is_ready(actual_cfg):
+        assert actual_cfg is cfg
+        assert backend_config.get_target_backend() == "codex_exec"
+        raise _EntryPointReached
+
+    adapter.setup.side_effect = assert_backend_is_ready
+
+    with pytest.raises(_EntryPointReached):
+        trainer_module.ReflACTTrainer(cfg, adapter).train()
+
+
+def test_eval_only_uses_shared_codex_config_entry_point(monkeypatch, tmp_path):
+    import scripts.eval_only as eval_script
+
+    skill_path = tmp_path / "skill.md"
+    skill_path.write_text("# Test skill\n", encoding="utf-8")
+    cfg = {
+        "out_root": str(tmp_path / "output"),
+        "model_backend": "azure_openai",
+        "optimizer_backend": "openai_chat",
+        "target_backend": "openai_chat",
+        "optimizer_model": "optimizer",
+        "target_model": "target",
+        "codex_exec_sandbox": "read-only",
+    }
+    args = SimpleNamespace(
+        config="unused.yaml",
+        skill=str(skill_path),
+        split=None,
+        cfg_options=[],
+        backend=None,
+    )
+    monkeypatch.setattr(eval_script, "parse_args", lambda: args)
+    monkeypatch.setattr("skillopt.config.load_config", lambda *args, **kwargs: dict(cfg))
+    for name in (
+        "configure_azure_openai",
+        "set_optimizer_backend",
+        "set_target_backend",
+        "set_optimizer_deployment",
+        "set_target_deployment",
+    ):
+        monkeypatch.setattr(eval_script, name, mock.Mock())
+
+    def stop_at_codex_config(actual_cfg):
+        assert actual_cfg["codex_exec_sandbox"] == "read-only"
+        raise _EntryPointReached
+
+    monkeypatch.setattr(
+        eval_script,
+        "configure_codex_exec_from_config",
+        stop_at_codex_config,
+    )
+
+    with pytest.raises(_EntryPointReached):
+        eval_script.main()
+
+
+@pytest.mark.parametrize("full_auto_setting", [True, False])
+def test_configure_full_auto_is_deprecated_and_does_not_mutate_state(
+    monkeypatch,
+    full_auto_setting,
+):
+    original_setting = not full_auto_setting
+    monkeypatch.setattr(backend_config, "CODEX_EXEC_FULL_AUTO", original_setting)
+    monkeypatch.setenv("CODEX_EXEC_FULL_AUTO", "unchanged")
+
+    with pytest.warns(FutureWarning, match="deprecated and ignored"):
+        configure_codex_exec(full_auto=full_auto_setting)
+
+    assert backend_config.CODEX_EXEC_FULL_AUTO is original_setting
+    assert os.environ["CODEX_EXEC_FULL_AUTO"] == "unchanged"
+
+
+def test_sequential_configs_restore_process_startup_baseline():
+    baseline = backend_config.get_codex_exec_config()
+    environment_baseline = {
+        key: os.environ[key]
+        for key in backend_config._CODEX_EXEC_MUTATED_ENV_KEYS
+        if key in os.environ
+    }
+    configured = {
+        "codex_exec_path": "/first-run/codex",
+        "codex_exec_sandbox": "danger-full-access",
+        "codex_exec_profile": "first-run",
+        "codex_exec_reasoning_effort": "high",
+        "codex_exec_use_sdk": "cli",
+        "codex_exec_network_access": True,
+        "codex_exec_web_search": True,
+        "codex_exec_approval_policy": "on-request",
+    }
+
+    configure_codex_exec_from_config(configured)
+    assert backend_config.get_codex_exec_config()["sandbox"] == "danger-full-access"
+
+    configure_codex_exec_from_config({})
+    restored = backend_config.get_codex_exec_config()
+
+    for key in (
+        "path",
+        "sandbox",
+        "profile",
+        "reasoning_effort",
+        "use_sdk",
+        "network_access",
+        "web_search",
+        "approval_policy",
+    ):
+        assert restored[key] == baseline[key]
+    for key in backend_config._CODEX_EXEC_MUTATED_ENV_KEYS:
+        if key in environment_baseline:
+            assert os.environ[key] == environment_baseline[key]
+        else:
+            assert key not in os.environ
+
+
+@pytest.mark.parametrize("disabled_value", ["false", "0", "off", "no"])
+def test_codex_permission_strings_are_parsed_as_false(disabled_value):
+    configure_codex_exec(
+        network_access=disabled_value,
+        web_search=disabled_value,
+    )
+
+    configured = backend_config.get_codex_exec_config()
+    assert configured["network_access"] is False
+    assert configured["web_search"] is False
+
+
+@pytest.mark.parametrize(
+    "setting_name",
+    ["network_access", "web_search"],
+)
+def test_invalid_codex_permission_strings_are_rejected(setting_name):
+    with pytest.raises(ValueError, match=f"codex_exec_{setting_name}"):
+        configure_codex_exec(**{setting_name: "sometimes"})
+
+
+def test_full_auto_environment_variable_warns_in_subprocess():
+    env = os.environ.copy()
+    env["CODEX_EXEC_FULL_AUTO"] = "true"
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "always::FutureWarning",
+            "-c",
+            (
+                "from skillopt.model.backend_config import get_codex_exec_config; "
+                "print(get_codex_exec_config()['full_auto'])"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert "CODEX_EXEC_FULL_AUTO is deprecated and ignored" in proc.stderr
+    assert proc.stdout.strip() == "False"
 
 
 @pytest.mark.parametrize("full_auto_setting", [True, False])
 @mock.patch("skillopt.model.codex_harness.subprocess.run")
-def test_codex_harness_command_construction(mock_run, monkeypatch, full_auto_setting):
-    from skillopt.model.codex_harness import _run_codex_cli_exec
+def test_codex_harness_full_auto_is_ignored(
+    mock_run,
+    monkeypatch,
+    tmp_path,
+    full_auto_setting,
+):
+    from skillopt.model.codex_harness import run_codex_exec
 
-    monkeypatch.setattr("skillopt.model.backend_config.CODEX_EXEC_SANDBOX", "workspace-write")
-    monkeypatch.setattr("skillopt.model.backend_config.CODEX_EXEC_FULL_AUTO", True)
-    monkeypatch.setattr("skillopt.model.backend_config.CODEX_EXEC_APPROVAL_POLICY", "never")
+    configure_codex_exec(
+        sandbox="danger-full-access",
+        use_sdk="cli",
+        approval_policy="never",
+    )
+    monkeypatch.setattr(backend_config, "EXEC_EMPTY_RESPONSE_RETRIES", 0)
 
-    configure_codex_exec(sandbox="danger-full-access", full_auto=full_auto_setting, approval_policy="never")
-
-    mock_proc = mock.MagicMock()
-    mock_proc.returncode = 0
-    mock_proc.stdout = ""
-    mock_proc.stderr = ""
+    mock_proc = mock.MagicMock(returncode=0, stdout="", stderr="")
     mock_run.return_value = mock_proc
 
-    with mock.patch("skillopt.model.codex_harness._persist_codex_artifacts"), \
-         mock.patch("skillopt.model.azure_openai.tracker.record", create=True):
-        _run_codex_cli_exec(
-            work_dir=".",
+    with (
+        mock.patch("skillopt.model.codex_harness._persist_codex_artifacts"),
+        mock.patch("skillopt.model.azure_openai.tracker.record", create=True),
+        pytest.warns(FutureWarning, match="deprecated and ignored"),
+    ):
+        run_codex_exec(
+            work_dir=str(tmp_path),
             prompt="test",
             model="test-model",
             timeout=10,
@@ -114,17 +704,106 @@ def test_codex_harness_command_construction(mock_run, monkeypatch, full_auto_set
         )
 
     mock_run.assert_called_once()
-    args = mock_run.call_args[0][0]
+    command = mock_run.call_args.args[0]
 
-    assert "--sandbox" in args
-    sandbox_idx = args.index("--sandbox")
-    assert args[sandbox_idx + 1] == "danger-full-access"
-
-    # Must NOT use deprecated flags --approval-policy or --full-auto
-    assert "--approval-policy" not in args
-    assert "--full-auto" not in args
-
-    # Approval policy must be passed via config override -c approval_policy="..."
-    assert "-c" in args
-    config_overrides = [args[i + 1] for i, arg in enumerate(args) if arg == "-c"]
+    assert command[command.index("--sandbox") + 1] == "danger-full-access"
+    assert "--approval-policy" not in command
+    assert "--full-auto" not in command
+    config_overrides = _command_config_overrides(command)
     assert 'approval_policy="never"' in config_overrides
+
+
+@pytest.mark.parametrize(
+    ("network_access", "web_search", "expected_network", "expected_search"),
+    [
+        (False, False, "false", "disabled"),
+        (False, True, "false", "live"),
+        (True, False, "true", "disabled"),
+        (True, True, "true", "live"),
+    ],
+)
+@mock.patch("skillopt.model.codex_harness.subprocess.run")
+def test_codex_harness_cli_forwards_network_and_web_search(
+    mock_run,
+    monkeypatch,
+    tmp_path,
+    network_access,
+    web_search,
+    expected_network,
+    expected_search,
+):
+    from skillopt.model.codex_harness import run_codex_exec
+
+    configure_codex_exec(
+        use_sdk="cli",
+        network_access=network_access,
+        web_search=web_search,
+    )
+    monkeypatch.setattr(backend_config, "EXEC_EMPTY_RESPONSE_RETRIES", 0)
+    mock_run.return_value = mock.MagicMock(returncode=0, stdout="", stderr="")
+
+    with (
+        mock.patch("skillopt.model.codex_harness._persist_codex_artifacts"),
+        mock.patch("skillopt.model.azure_openai.tracker.record", create=True),
+    ):
+        run_codex_exec(
+            work_dir=str(tmp_path),
+            prompt="test",
+            model="test-model",
+            timeout=10,
+        )
+
+    command = mock_run.call_args.args[0]
+    overrides = _command_config_overrides(command)
+    assert (
+        f"sandbox_workspace_write.network_access={expected_network}" in overrides
+    )
+    assert f'web_search="{expected_search}"' in overrides
+
+
+@pytest.mark.parametrize(
+    ("network_access", "web_search", "expected_network", "expected_search"),
+    [
+        (False, False, "false", "disabled"),
+        (False, True, "false", "live"),
+        (True, False, "true", "disabled"),
+        (True, True, "true", "live"),
+    ],
+)
+def test_codex_optimizer_cli_forwards_network_and_web_search(
+    monkeypatch,
+    network_access,
+    web_search,
+    expected_network,
+    expected_search,
+):
+    from skillopt.model import codex_backend
+
+    configure_codex_exec(
+        network_access=network_access,
+        web_search=web_search,
+    )
+    commands = []
+
+    def fake_run(command, **_kwargs):
+        commands.append(command)
+        output_path = command[command.index("--output-last-message") + 1]
+        Path(output_path).write_text("ok", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(codex_backend.subprocess, "run", fake_run)
+
+    response, _usage = codex_backend._run_codex_exec(
+        model="test-model",
+        prompt="test",
+        attachments=[],
+        output_schema=None,
+        timeout=10,
+    )
+
+    assert response == "ok"
+    overrides = _command_config_overrides(commands[0])
+    assert (
+        f"sandbox_workspace_write.network_access={expected_network}" in overrides
+    )
+    assert f'web_search="{expected_search}"' in overrides


### PR DESCRIPTION
## Summary

Follow-up maintenance for #220 by @RohithPariki. This keeps the original Codex CLI integration and contributor attribution intact while tightening its configuration contract:

- prevent Codex settings from leaking across consecutive runs and restore the process-start environment exactly
- centralize config resolution across train, eval, and trainer entry points
- preserve `full_auto` as a deprecated compatibility input, but ignore it instead of emitting the deprecated CLI flag
- normalize YAML aliases, inheritance, mixed flat/structured config, and string booleans
- propagate `sandbox_workspace_write.network_access` and `web_search = "live" | "disabled"` through both CLI execution paths
- configure model backends before adapter setup
- update defaults, reference docs, changelog, and regression coverage

## Validation

- full suite: 1097 passed, 10 skipped, 130 subtests passed
- targeted Codex config tests: 55 passed on two consecutive runs
- `mkdocs build --strict`
- whitespace validation with the repository's CRLF handling
- Codex CLI 0.146.0 strict smoke tests with both network/search enabled and disabled
- independent read-only Codex review found no semantic or security blocker
