### PR TITLE
fix(sleep): add Windows AppData support for default OpenCode database discovery (#56)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -223,8 +223,8 @@ login, or contact a model provider. Source selection remains explicit:
 `--source auto` keeps Codex-then-Claude precedence and does not select OpenCode.
 
 The database path is selected from `--opencode-db` or the `opencode_db` config
-key, then `OPENCODE_DB`, then
-`${XDG_DATA_HOME:-~/.local/share}/opencode/opencode.db`. A relative
+key, then `OPENCODE_DB`, then `%LOCALAPPDATA%\opencode\opencode.db` or `%APPDATA%\opencode\opencode.db` on Windows or
+`${XDG_DATA_HOME:-~/.local/share}/opencode/opencode.db` on POSIX. A relative
 `OPENCODE_DB` value is resolved below OpenCode's data directory;
 `OPENCODE_DB=:memory:` has no persistent history to harvest.
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -145,7 +145,7 @@ Common implemented flags include:
 | `--pi-home PATH` | `~/.pi` | select the parent directory containing `agent/sessions` |
 | `--pi-path PATH` | auto-detect `pi` | select the Pi coding-agent CLI executable |
 | `--opencode-path PATH` | `SKILLOPT_SLEEP_OPENCODE_PATH`, then `opencode` on `PATH`/`PATHEXT` | select the OpenCode CLI executable |
-| `--opencode-db PATH` | `OPENCODE_DB`, then `${XDG_DATA_HOME:-~/.local/share}/opencode/opencode.db` | select the OpenCode SQLite history database |
+| `--opencode-db PATH` | `OPENCODE_DB`, `%LOCALAPPDATA%`/`%APPDATA%` (Windows), or `${XDG_DATA_HOME:-~/.local/share}/opencode/opencode.db` | select the OpenCode SQLite history database |
 | `--project PATH` | current directory | select the project and invoked harvest scope |
 | `--scope invoked\|all` | `invoked` | limit transcript harvesting |
 | `--target-skill-path PATH` | managed skill | select a specific `SKILL.md` to stage/adopt |

--- a/skillopt_sleep/harvest_opencode.py
+++ b/skillopt_sleep/harvest_opencode.py
@@ -13,6 +13,7 @@ import json
 import os
 import re
 import sqlite3
+import sys
 from datetime import datetime, timezone
 from typing import Any, Iterable, List, Optional
 from urllib.request import pathname2url
@@ -48,6 +49,9 @@ def default_opencode_db() -> str:
     data_home = os.environ.get("XDG_DATA_HOME", "")
     if data_home:
         data_dir = os.path.abspath(os.path.expanduser(data_home))
+    elif sys.platform == "win32" and (os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")):
+        win_appdata = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA") or ""
+        data_dir = os.path.abspath(os.path.expanduser(win_appdata))
     else:
         data_dir = os.path.join(os.path.expanduser("~"), ".local", "share")
     opencode_data = os.path.join(data_dir, "opencode")

--- a/tests/test_harvest_opencode.py
+++ b/tests/test_harvest_opencode.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import sqlite3
+import sys
 from collections.abc import Iterable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -913,10 +914,23 @@ def test_default_database_honors_xdg_and_opencode_db(monkeypatch, tmp_path: Path
     assert default_opencode_db() == ""
 
 
+def test_default_database_honors_windows_appdata(monkeypatch, tmp_path: Path) -> None:
+    local_app_data = tmp_path / "LocalAppData"
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.delenv("OPENCODE_DB", raising=False)
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("LOCALAPPDATA", str(local_app_data))
+    monkeypatch.delenv("APPDATA", raising=False)
+
+    assert default_opencode_db() == os.path.abspath(local_app_data / "opencode" / "opencode.db")
+
+
 def test_default_database_falls_back_to_home_local_share(monkeypatch, tmp_path: Path) -> None:
     home = tmp_path / "home"
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     monkeypatch.delenv("OPENCODE_DB", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    monkeypatch.delenv("APPDATA", raising=False)
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("USERPROFILE", str(home))
 


### PR DESCRIPTION
### Summary

Fixes #56 by adding native Windows `%LOCALAPPDATA%` and `%APPDATA%` environment variable resolution to `default_opencode_db()`.

When running on Windows systems with `XDG_DATA_HOME` unset, `skillopt-sleep --source opencode` previously defaulted to `~/.local/share/opencode/opencode.db` (a POSIX path that does not exist on native Windows). OpenCode on Windows stores its database under `%LOCALAPPDATA%\opencode\opencode.db` or `%APPDATA%\opencode\opencode.db`.

---

### Key Changes :-

1. **`skillopt_sleep/harvest_opencode.py`**:
   - Updated `default_opencode_db()` to inspect `sys.platform == "win32"` and check `LOCALAPPDATA` and `APPDATA` environment variables before falling back to `~/.local/share`.

2. **`tests/test_harvest_opencode.py`**:
   - Added `test_default_database_honors_windows_appdata` to verify Windows environment variable path resolution for `default_opencode_db()`.

3. **Documentation (`docs/reference/cli.md` & `plugins/README.md`)**:
   - Documented the Windows `%LOCALAPPDATA%` / `%APPDATA%` default database path auto-discovery.

---

### Verification

- Ran unit tests: `pytest tests/test_harvest_opencode.py` (**28/28 passed**).
- Ran code style check: `ruff check skillopt_sleep/harvest_opencode.py tests/test_harvest_opencode.py` (**All checks passed!**).
