### PR TITLE
fix(sleep): skip assistant.message events with non-dict data

### DIFF
--- a/skillopt_sleep/backend.py
+++ b/skillopt_sleep/backend.py
@@ -1570,6 +1570,24 @@ class CopilotCliBackend(CliBackend):
 
     @staticmethod
     def _parse_jsonl_response(raw: str) -> str:
+        """Concatenate assistant text from a Copilot JSONL event stream.
+
+        Behaviourally identical to ``skillopt.model.copilot_backend``'s
+        ``parse_copilot_jsonl``; vendored because this package keeps ZERO
+        dependency on the research package (see the module docstring of
+        ``skillopt_sleep.gate`` for the same arrangement). Keep the two in sync.
+
+        A malformed event must never take down the whole stream: the CLI emits
+        one JSON object per line, so a single bad line loses at most that line's
+        text while the surrounding ``assistant.message`` events still parse.
+        ``data`` is therefore type-checked rather than assumed to be an object.
+        A truthy non-dict (``"text"``, ``5``, a non-empty list) would otherwise
+        raise ``AttributeError`` from the field access, which no caller catches.
+
+        The exception list is deliberately wider than the research-package copy:
+        ``json.loads`` raises ``RecursionError`` rather than ``JSONDecodeError``
+        on a deeply nested payload.
+        """
         parts: List[str] = []
         for line in raw.splitlines():
             line = line.strip()
@@ -1579,8 +1597,13 @@ class CopilotCliBackend(CliBackend):
                 obj = json.loads(line)
             except (ValueError, RecursionError, TypeError):
                 continue
+            if not isinstance(obj, dict):
+                continue
             if obj.get("type") == "assistant.message":
-                content = (obj.get("data") or {}).get("content")
+                data = obj.get("data")
+                if not isinstance(data, dict):
+                    continue
+                content = data.get("content")
                 if isinstance(content, str) and content:
                     parts.append(content)
         return "\n".join(parts).strip()

--- a/tests/test_sleep_engine.py
+++ b/tests/test_sleep_engine.py
@@ -1435,6 +1435,26 @@ class TestCopilotBackend(unittest.TestCase):
         raw = '{"type":"assistant.message","data":' + "9" * 5000 + "}"
         self.assertEqual(CopilotCliBackend._parse_jsonl_response(raw), "")
 
+    def test_parse_jsonl_skips_non_dict_data_without_losing_stream(self):
+        # A malformed event must cost only its own line: the surrounding
+        # assistant.message events still have to reach the caller. Mirrors
+        # tests/test_copilot_exec_backend.py for the research-package copy.
+        from skillopt_sleep.backend import CopilotCliBackend
+        for bad in ('"text"', "5", "[1,2]", "true"):
+            raw = "\n".join([
+                '{"type":"assistant.message","data":{"content":"first"}}',
+                '{"type":"assistant.message","data":' + bad + "}",
+                '{"type":"assistant.message","data":{"content":"second"}}',
+            ])
+            with self.subTest(data=bad):
+                self.assertEqual(
+                    CopilotCliBackend._parse_jsonl_response(raw), "first\nsecond"
+                )
+
+    def test_parse_jsonl_ignores_non_object_top_level(self):
+        from skillopt_sleep.backend import CopilotCliBackend
+        self.assertEqual(CopilotCliBackend._parse_jsonl_response("[]\nnull\n"), "")
+
     def test_isolated_home_by_default(self):
         from skillopt_sleep.backend import CopilotCliBackend
         be = CopilotCliBackend()


### PR DESCRIPTION
Closes #231

### Problem

`CopilotCliBackend._parse_jsonl_response` treated the `data` field of an `assistant.message` event as an object:

```python
content = (obj.get("data") or {}).get("content")
```

A truthy non-dict value (`"text"`, `5`, a non-empty list) raises `AttributeError` on the field access. That happens outside the per-line `try`, which only wraps `json.loads`, so a single malformed line aborts the parse of the whole stream and the backend returns nothing for that call. `data: []` slipped through only because `[] or {}` falls back to `{}`.

### Fix

Port the guard that `skillopt/model/copilot_backend.py::parse_copilot_jsonl` already applies to the same event format:

```python
data = obj.get("data")
if not isinstance(data, dict):
    continue
content = data.get("content")
```

That guard landed in 5497a31 ("harden and deduplicate JSONL parsing"), which removed this exact line from `copilot_backend.py` and `codex_harness.py` and folded all three copies into one helper. `skillopt_sleep/backend.py` predates it and was left behind, since the sleep package deliberately keeps zero dependency on the research package.

I kept the vendored copy rather than importing the shared helper, to preserve that decoupling. The docstring now records the relationship and asks for the two to be kept in sync, matching how `skillopt_sleep/gate.py` documents its own vendoring of the validation gate.

One intentional difference from the research-package copy: the wider `except (ValueError, RecursionError, TypeError)` stays. `json.loads` raises `RecursionError`, not `JSONDecodeError`, on a deeply nested payload, so narrowing it to match would reintroduce a crash the sleep copy already handles. The docstring calls this out so it does not read as accidental drift.

### Tests

Added two focused cases to `TestCopilotBackend`:

- `test_parse_jsonl_skips_non_dict_data_without_losing_stream` places a bad `data` value between two good messages and asserts `"first\nsecond"` still comes through, so a malformed event costs only its own line. Runs as subtests over `"text"`, `5`, `[1,2]` and `true`. This mirrors the existing coverage in `tests/test_copilot_exec_backend.py` for the research-package parser.
- `test_parse_jsonl_ignores_non_object_top_level` covers non-object top-level lines.

This also fixes the pre-existing failure in `test_parse_jsonl_ignores_excessively_nested_json`. That test builds a 2000 deep nested array expecting `RecursionError` from `json.loads`, but on Python 3.14 it parses fine, reaches the field access and hits the `AttributeError` instead.

### Verification

- Focused: `154 passed, 1 skipped` across `tests/test_sleep_engine.py` and `tests/test_copilot_exec_backend.py`.
- Full suite: `1097 passed, 10 skipped, 2 failed`, down from 3 failures on `main`.
- `ruff check` on both changed files reports 17 errors before and after, none on the touched lines. They are pre-existing (`import tempfile, shutil, stat`, trailing whitespace in tests, an unused `logging` import) and left alone to keep the diff reviewable.

No documentation changes, so `mkdocs build --strict` was not run.

### Environment

macOS 15, Python 3.14.6, branched from `main` at 9c776fc