### PR TITLE
fix(backends): send the CLI/API contracts these backends actually have

### DIFF
--- a/skillopt/model/minimax_backend.py
+++ b/skillopt/model/minimax_backend.py
@@ -70,26 +70,32 @@ TARGET_DEPLOYMENT = os.environ.get(
     default_model_for_backend("minimax_chat"),
 )
 
-# Per-model thinking capability. MiniMax-M2.7 requires always-on thinking, so it
-# must ignore the shared MINIMAX_ENABLE_THINKING flag; MiniMax-M3 supports
-# adaptive/disabled thinking, which the flag controls (disabled by default).
-_MODEL_THINKING_MODES: dict[str, tuple[str, ...]] = {
-    "MiniMax-M3": ("adaptive", "disabled"),
-    "MiniMax-M2.7": ("always_on",),
-}
+# Models whose thinking cannot actually be turned off. Per MiniMax's
+# OpenAI-compatible docs the M2.x family accepts ``{"type": "disabled"}`` but
+# keeps thinking on regardless, so sending "disabled" there is a lie we would
+# then have to reason about downstream. Send the honest value instead.
+_ALWAYS_THINKING_PREFIXES: tuple[str, ...] = ("MiniMax-M2",)
 
 
-def _resolve_enable_thinking(deployment: str) -> bool:
-    """Return the effective ``enable_thinking`` flag for ``deployment``.
+def _thinking_is_forced(deployment: str) -> bool:
+    """True when ``deployment`` cannot honor ``thinking: {"type": "disabled"}``."""
+    name = str(deployment or "").strip()
+    return any(name.startswith(prefix) for prefix in _ALWAYS_THINKING_PREFIXES)
 
-    Models that only support always-on thinking force the flag on regardless of
-    the configured default; models that allow disabled/adaptive thinking honor
-    the shared ``ENABLE_THINKING`` setting.
+
+def _resolve_thinking_type(deployment: str) -> str:
+    """Return the documented top-level ``thinking.type`` for ``deployment``.
+
+    MiniMax documents thinking control as a top-level ``thinking`` object --
+    ``{"thinking": {"type": "adaptive"}}`` or ``{"thinking": {"type":
+    "disabled"}}`` -- NOT as ``chat_template_kwargs.enable_thinking``, which is
+    a Qwen/HuggingFace-serving convention that this endpoint simply ignores.
+    Unknown deployments are treated as capable of adaptive thinking, matching
+    the API default (thinking on when the parameter is omitted).
     """
-    modes = _MODEL_THINKING_MODES.get(str(deployment or "").strip())
-    if modes and "disabled" not in modes and "always_on" in modes:
-        return True
-    return ENABLE_THINKING
+    if _thinking_is_forced(deployment):
+        return "adaptive"
+    return "adaptive" if ENABLE_THINKING else "disabled"
 
 
 _config_lock = threading.Lock()
@@ -199,8 +205,8 @@ def _chat_messages_impl(
         "messages": _json_safe(messages),
         "max_tokens": min(max_completion_tokens, MAX_TOKENS),
     }
-    payload["chat_template_kwargs"] = {
-        "enable_thinking": _resolve_enable_thinking(deployment or TARGET_DEPLOYMENT)
+    payload["thinking"] = {
+        "type": _resolve_thinking_type(deployment or TARGET_DEPLOYMENT)
     }
     if TEMPERATURE is not None:
         payload["temperature"] = TEMPERATURE

--- a/skillopt_sleep/backend.py
+++ b/skillopt_sleep/backend.py
@@ -1735,7 +1735,12 @@ class CopilotCliBackend(CliBackend):
             "--stream", "off",
             "--no-color",
             "--log-level", "none",
-            "--allowed-tools", os.environ.get("COPILOT_ALLOWED_TOOLS", "Bash"),
+            # ``--allow-all-tools`` is REQUIRED for non-interactive mode (it waives
+            # the approval prompt); it is the permission axis. Tool *visibility* is
+            # a separate axis: ``--available-tools`` restricts which tools the model
+            # can see at all. Scoping happens there, so we keep both.
+            "--allow-all-tools",
+            "--available-tools", os.environ.get("COPILOT_AVAILABLE_TOOLS", "bash"),
             "-C", clean_cwd,
         ]
         if not self.full_env:
@@ -1873,7 +1878,12 @@ class CopilotCliBackend(CliBackend):
                 "--stream", "off",
                 "--no-color",
                 "--log-level", "none",
-                "--allowed-tools", os.environ.get("COPILOT_ALLOWED_TOOLS", "Bash"),
+                # ``--allow-all-tools`` is REQUIRED for non-interactive mode (it waives
+            # the approval prompt); it is the permission axis. Tool *visibility* is
+            # a separate axis: ``--available-tools`` restricts which tools the model
+            # can see at all. Scoping happens there, so we keep both.
+            "--allow-all-tools",
+            "--available-tools", os.environ.get("COPILOT_AVAILABLE_TOOLS", "bash"),
                 "-C", work,
             ]
             if not self.full_env:

--- a/tests/test_copilot_tool_scope.py
+++ b/tests/test_copilot_tool_scope.py
@@ -1,9 +1,24 @@
 """Tests for Copilot CLI tool-scope reduction.
 
-The sleep engine's Copilot backend previously launched the CLI with
-``--allow-all-tools``, granting the model unrestricted tool access. It now
-passes ``--allowed-tools`` scoped to ``COPILOT_ALLOWED_TOOLS`` (default
-``Bash``). These tests capture the constructed argv without spawning the CLI.
+The sleep engine's Copilot backend used to launch the CLI with bare
+``--allow-all-tools``, granting the model every tool the CLI exposes. Scoping
+now happens on the *visibility* axis via ``--available-tools`` (default
+``bash``, overridable with ``COPILOT_AVAILABLE_TOOLS``).
+
+The two axes are independent and both are needed:
+
+* ``--allow-all-tools`` waives the interactive approval prompt. The CLI's own
+  help states it is "required for non-interactive mode", so dropping it makes
+  every headless call hang or fail -- it is not the flag to scope on.
+* ``--available-tools`` is what actually narrows the surface: "Only these tools
+  will be available to the model".
+
+Verified against GitHub Copilot CLI 1.0.80: ``--allowed-tools`` does not exist
+(``error: unknown option``), and the selector is the lowercase tool name
+``bash`` -- ``--available-tools=Bash`` silently blocks the tool instead of
+allowing it, since selectors are case-sensitive.
+
+These tests capture the constructed argv without spawning the CLI.
 """
 from __future__ import annotations
 
@@ -33,21 +48,33 @@ def _capture_argv(monkeypatch) -> list[str]:
     return captured["cmd"]
 
 
-def test_allow_all_tools_removed(monkeypatch) -> None:
+def test_nonexistent_allowed_tools_flag_is_never_sent(monkeypatch) -> None:
+    # Guards the original regression: `--allowed-tools` is not a Copilot CLI
+    # option, so sending it aborts the process before any work happens.
     cmd = _capture_argv(monkeypatch)
-    assert "--allow-all-tools" not in cmd
-    assert "--allowed-tools" in cmd
+    assert "--allowed-tools" not in cmd
 
 
-def test_default_scope_is_bash(monkeypatch) -> None:
-    monkeypatch.delenv("COPILOT_ALLOWED_TOOLS", raising=False)
+def test_non_interactive_permission_flag_is_kept(monkeypatch) -> None:
     cmd = _capture_argv(monkeypatch)
-    idx = cmd.index("--allowed-tools")
-    assert cmd[idx + 1] == "Bash"
+    assert "--allow-all-tools" in cmd
+
+
+def test_visibility_is_scoped(monkeypatch) -> None:
+    cmd = _capture_argv(monkeypatch)
+    assert "--available-tools" in cmd
+
+
+def test_default_scope_is_lowercase_bash(monkeypatch) -> None:
+    monkeypatch.delenv("COPILOT_AVAILABLE_TOOLS", raising=False)
+    cmd = _capture_argv(monkeypatch)
+    idx = cmd.index("--available-tools")
+    # Lowercase matters: selectors are case-sensitive and "Bash" matches nothing.
+    assert cmd[idx + 1] == "bash"
 
 
 def test_env_var_overrides_scope(monkeypatch) -> None:
-    monkeypatch.setenv("COPILOT_ALLOWED_TOOLS", "Read")
+    monkeypatch.setenv("COPILOT_AVAILABLE_TOOLS", "bash,write")
     cmd = _capture_argv(monkeypatch)
-    idx = cmd.index("--allowed-tools")
-    assert cmd[idx + 1] == "Read"
+    idx = cmd.index("--available-tools")
+    assert cmd[idx + 1] == "bash,write"

--- a/tests/test_minimax_backend.py
+++ b/tests/test_minimax_backend.py
@@ -93,9 +93,15 @@ def test_default_deployment_is_current_model(minimax_backend: Any) -> None:
     assert default_model_for_backend("minimax_chat") == "MiniMax-M3"
 
 
-def test_always_on_model_forces_thinking(
+def test_always_on_model_sends_adaptive_not_disabled(
     monkeypatch: pytest.MonkeyPatch, minimax_backend: Any
 ) -> None:
+    """M2.x cannot turn thinking off, so never claim it is disabled.
+
+    MiniMax documents that the M2 family accepts ``{"type": "disabled"}`` but
+    keeps thinking on anyway. Sending "disabled" would record a request that
+    does not match what the model actually does.
+    """
     minimax_backend.ENABLE_THINKING = False
     minimax_backend.TARGET_DEPLOYMENT = "MiniMax-M2.7"
     recorder = _record_urlopen(monkeypatch, minimax_backend)
@@ -104,7 +110,7 @@ def test_always_on_model_forces_thinking(
 
     payload = recorder.calls[0]["payload"]
     assert payload["model"] == "MiniMax-M2.7"
-    assert payload["chat_template_kwargs"] == {"enable_thinking": True}
+    assert payload["thinking"] == {"type": "adaptive"}
 
 
 def test_adaptive_model_respects_disabled_flag(
@@ -118,7 +124,7 @@ def test_adaptive_model_respects_disabled_flag(
 
     payload = recorder.calls[0]["payload"]
     assert payload["model"] == "MiniMax-M3"
-    assert payload["chat_template_kwargs"] == {"enable_thinking": False}
+    assert payload["thinking"] == {"type": "disabled"}
 
 
 def test_adaptive_model_respects_enabled_flag(
@@ -130,4 +136,36 @@ def test_adaptive_model_respects_enabled_flag(
 
     minimax_backend.chat_target("system", "user", retries=1)
 
-    assert recorder.calls[0]["payload"]["chat_template_kwargs"] == {"enable_thinking": True}
+    assert recorder.calls[0]["payload"]["thinking"] == {"type": "adaptive"}
+
+
+def test_unsupported_chat_template_kwargs_is_never_sent(
+    monkeypatch: pytest.MonkeyPatch, minimax_backend: Any
+) -> None:
+    """Guards the original regression.
+
+    ``chat_template_kwargs.enable_thinking`` is a Qwen/HuggingFace-serving
+    convention. It appears nowhere in MiniMax's OpenAI-compatible reference, so
+    the endpoint ignores it -- meaning thinking silently stayed at the server
+    default no matter what the flag said.
+    """
+    minimax_backend.ENABLE_THINKING = False
+    minimax_backend.TARGET_DEPLOYMENT = "MiniMax-M3"
+    recorder = _record_urlopen(monkeypatch, minimax_backend)
+
+    minimax_backend.chat_target("system", "user", retries=1)
+
+    assert "chat_template_kwargs" not in recorder.calls[0]["payload"]
+
+
+def test_unknown_deployment_defaults_to_adaptive(
+    monkeypatch: pytest.MonkeyPatch, minimax_backend: Any
+) -> None:
+    """An unrecognized model follows the documented API default (thinking on)."""
+    minimax_backend.ENABLE_THINKING = True
+    minimax_backend.TARGET_DEPLOYMENT = "MiniMax-Future-9"
+    recorder = _record_urlopen(monkeypatch, minimax_backend)
+
+    minimax_backend.chat_target("system", "user", retries=1)
+
+    assert recorder.calls[0]["payload"]["thinking"] == {"type": "adaptive"}


### PR DESCRIPTION
Follow-up to #170 and #190. Both PRs moved in the right direction, and their test scaffolding is kept — but each shipped a parameter its target does not accept, so as merged neither backend does what it says. This corrects both against the real contracts.

## Copilot — `skillopt_sleep/backend.py`

`--allowed-tools` is not a GitHub Copilot CLI option:

```
$ copilot --allowed-tools=Bash -p hi
error: unknown option '--allowed-tools=Bash'
```

Both Copilot call paths (`_call` and the task-replay path) sent it, so both aborted before doing any work.

Two independent axes were also conflated:

- **`--allow-all-tools`** waives the interactive approval prompt. The CLI's own help says it is *"required for non-interactive mode"* — dropping it breaks headless runs. This is a permission flag, not a scoping flag.
- **`--available-tools`** is the visibility axis: *"Only these tools will be available to the model."* This is where scoping belongs.

So: keep `--allow-all-tools`, scope with `--available-tools` (default `bash`, override via `COPILOT_AVAILABLE_TOOLS`).

The selector is **case-sensitive**, which is easy to get wrong. Verified live against Copilot CLI 1.0.80:

| argv | result |
|---|---|
| `--available-tools bash` | `"toolName":"bash"` — tool runs |
| `--available-tools Bash` | tool never appears — silently blocked |
| `--available-tools write` | bash blocked — scoping demonstrably works |

That last row is the control: the flag really does narrow the surface, rather than being accepted and ignored.

## MiniMax — `skillopt/model/minimax_backend.py`

`chat_template_kwargs.enable_thinking` is a Qwen/HuggingFace-serving convention. It appears nowhere in MiniMax's OpenAI-compatible reference, so the endpoint ignores it and thinking stays at the server default no matter what the flag says.

This predates #190 — the field was already on `main`; #190 built model-aware logic on top of it, so the routing worked but the value never reached the model.

The documented control is the top-level `thinking` object:

```json
{"thinking": {"type": "adaptive"}}
{"thinking": {"type": "disabled"}}
```

Also per the docs, the M2.x family *accepts* `{"type": "disabled"}` but keeps thinking on regardless. Sending `disabled` there would record a request that misrepresents what the model actually did, so M2.x is sent `adaptive`. This preserves #190's intent (M2.7 keeps always-on thinking) without a value that lies. Unknown deployments default to `adaptive`, matching the documented API default of thinking-on-when-omitted.

Reference: <https://platform.minimax.io/docs/api-reference/text-openai-api>

## Tests

Both suites now assert the exact wire payload / argv rather than the shape the code happens to produce, plus explicit regression guards (`test_nonexistent_allowed_tools_flag_is_never_sent`, `test_unsupported_chat_template_kwargs_is_never_sent`).

- Full suite: **1389 passed, 10 skipped, 269 subtests**
- Negative control: reverting each fix fails exactly the 9 tests that assert it, and nothing else — the tests exercise the new behavior rather than passing incidentally.