### PR TITLE
style: fix comment indentation at the second Copilot call site

### DIFF
--- a/skillopt_sleep/backend.py
+++ b/skillopt_sleep/backend.py
@@ -1878,12 +1878,13 @@ class CopilotCliBackend(CliBackend):
                 "--stream", "off",
                 "--no-color",
                 "--log-level", "none",
-                # ``--allow-all-tools`` is REQUIRED for non-interactive mode (it waives
-            # the approval prompt); it is the permission axis. Tool *visibility* is
-            # a separate axis: ``--available-tools`` restricts which tools the model
-            # can see at all. Scoping happens there, so we keep both.
-            "--allow-all-tools",
-            "--available-tools", os.environ.get("COPILOT_AVAILABLE_TOOLS", "bash"),
+                # ``--allow-all-tools`` is REQUIRED for non-interactive mode (it
+                # waives the approval prompt); it is the permission axis. Tool
+                # *visibility* is a separate axis: ``--available-tools`` restricts
+                # which tools the model can see at all. Scoping happens there, so
+                # we keep both.
+                "--allow-all-tools",
+                "--available-tools", os.environ.get("COPILOT_AVAILABLE_TOOLS", "bash"),
                 "-C", work,
             ]
             if not self.full_env:


### PR DESCRIPTION
Cosmetic follow-up to #243.

The block comment and its two argv entries in the task-replay call path were left at the *first* call site's indentation (12 spaces) instead of the 16 that the surrounding list literal uses — an artifact of the scripted edit that patched both sites at once.

Python does not care about indentation inside a list literal, so behavior is unchanged and the suite is unaffected; it simply read as a mistake. No functional change.