### PR TITLE
fix: Windows shell quoting + PowerShell call operator for dsh adapter

### DIFF
--- a/plugins/dsh/scripts/audit-control-chars.mjs
+++ b/plugins/dsh/scripts/audit-control-chars.mjs
@@ -1,10 +1,13 @@
-// 安全审核：控制字符/换行不能逃逸单引号边界，且不产生副作用。
-// 修复后的期望：控制字符被剥离为空格，值仍作为单个参数到达，无文件/命令执行。
+// Security audit: control characters/newlines cannot escape the quoting
+// boundary of the HOST shell, and produce no side effects. Expected after the
+// fix: control chars are folded to spaces, the value still arrives as a single
+// argument, no file or command runs.
 import { execFileSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 const m = await import('../src/index.js')
-const { quoteArgv } = m
-const BASH = process.env.BASH_PATH || 'C:/Program Files/Git/bin/bash.exe'
+const { quoteArgv, IS_WINDOWS } = m
+
 const payloads = [
   'x\n touch /tmp/nl-pwned',
   'x\r echo PWNED',
@@ -14,20 +17,39 @@ const payloads = [
   "'; touch /tmp/semi-pwned;'",
   'normal\r\ntouch /tmp/crnl-pwned',
 ]
+
+function expandArgs(quoted) {
+  if (IS_WINDOWS) {
+    const candidates = [
+      process.env.PWSH_PATH,
+      process.env.ProgramFiles ? join(process.env.ProgramFiles, 'PowerShell', '7', 'pwsh.exe') : '',
+      join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+    ].filter(Boolean)
+    const shell = candidates.find((p) => existsSync(p))
+    if (!shell) throw new Error('no PowerShell executable found for control-char audit')
+    const args = quoted.replace(/^& /, '')
+    const script = `Write-Output ${args} | ForEach-Object { "[$_]" }`
+    const out = execFileSync(shell, ['-NoProfile', '-Command', script], { encoding: 'utf8' })
+    // PowerShell emits CRLF; strip \r before slicing the [..] markers.
+    return out.trim().split('\n').map((l) => l.replace(/\r$/, '').slice(1, -1))
+  }
+  const script = `for a in ${quoted}; do printf '[%s]\\n' "$a"; done`
+  const out = execFileSync(process.env.BASH_PATH || '/bin/bash', ['-c', script], { encoding: 'utf8' })
+  return out.trim().split('\n').map((l) => l.slice(1, -1))
+}
+
 let fail = 0
 for (const p of payloads) {
   const argv = ['python', '-m', 'skillopt_sleep', 'run', '--preferences', p]
   const quoted = quoteArgv(argv)
-  const script = `for a in ${quoted}; do printf '[%s]\\n' "$a"; done`
-  const out = execFileSync(BASH, ['-c', script], { encoding: 'utf8' })
-  const args = out.trim().split('\n').map((l) => l.slice(1, -1))
-  // 安全断言 1：--preferences 后恰好一个参数（无参数分裂）
+  const args = expandArgs(quoted)
+  // Safety assertion 1: exactly one argument after --preferences (no split).
   const idx = args.indexOf('--preferences')
   const singleArg = idx >= 0 && idx + 1 < args.length && idx + 2 === args.length
-  // 安全断言 2：到达的值不含原始控制字符（已被剥离为空格）
+  // Safety assertion 2: the arrived value has no raw control chars (folded to space).
   const arrived = idx >= 0 ? args[idx + 1] : ''
   const stripped = !/[\r\n\t\x00]/.test(arrived)
-  // 安全断言 3：没有注入命令出现在参数列表外
+  // Safety assertion 3: no injected command outside the argument list.
   const noInjection = !args.some((a) => /touch|PWNED|rm\s/.test(a) && a !== arrived)
   if (!singleArg || !stripped || !noInjection) {
     fail++

--- a/plugins/dsh/scripts/audit-injection.mjs
+++ b/plugins/dsh/scripts/audit-injection.mjs
@@ -1,9 +1,13 @@
-// 独立注入审计：各种恶意 payload 过 quoteArgv → 真实 bash → 验证不逃逸
+// Injection audit: malicious payloads through quoteArgv -> the HOST shell ->
+// verify none escape. On win32 the host shell is PowerShell (5.1 or pwsh 7);
+// on POSIX it is bash. Each payload must arrive as exactly one argument, and
+// no command may run.
 import { execFileSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 const m = await import('../src/index.js')
-const { quoteArgv } = m
-const BASH = process.env.BASH_PATH || 'C:/Program Files/Git/bin/bash.exe'
+const { quoteArgv, IS_WINDOWS } = m
+
 const payloads = [
   'x; touch /tmp/pwned',
   'x$(touch /tmp/pwned2)',
@@ -13,13 +17,41 @@ const payloads = [
   "' OR 1=1 --",
   'x > /tmp/redirected',
 ]
+
+// Render `quoted` as one argument per line and return the array. The command
+// is passed to the host shell as ONE string; each argv element arrives quoted,
+// so the script only needs to echo every received argument back verbatim.
+function expandArgs(quoted) {
+  if (IS_WINDOWS) {
+    // Windows PowerShell (5.1 or pwsh 7): single-quoted args parse the same on
+    // both. Write-Output pipes each argument through ForEach-Object as one
+    // pipeline object, so the round-trip is the real parse.
+    const candidates = [
+      process.env.PWSH_PATH,
+      process.env.ProgramFiles ? join(process.env.ProgramFiles, 'PowerShell', '7', 'pwsh.exe') : '',
+      join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+    ].filter(Boolean)
+    const shell = candidates.find((p) => existsSync(p))
+    if (!shell) throw new Error('no PowerShell executable found for injection audit')
+    // quoteArgv now prepends "& " (the PS call operator) on win32. Strip it
+    // before echoing the argument array; PowerShell would reject `&` in the
+    // middle of a pipeline expression.
+    const args = quoted.replace(/^& /, '')
+    const script = `Write-Output ${args} | ForEach-Object { "[$_]" }`
+    const out = execFileSync(shell, ['-NoProfile', '-Command', script], { encoding: 'utf8' })
+    // PowerShell emits CRLF; strip \r before slicing the [..] markers.
+    return out.trim().split('\n').map((l) => l.replace(/\r$/, '').slice(1, -1))
+  }
+  const script = `for a in ${quoted}; do printf '[%s]\\n' "$a"; done`
+  const out = execFileSync(process.env.BASH_PATH || '/bin/bash', ['-c', script], { encoding: 'utf8' })
+  return out.trim().split('\n').map((l) => l.slice(1, -1))
+}
+
 let fail = 0
 for (const p of payloads) {
   const argv = ['python', '-m', 'skillopt_sleep', 'run', '--preferences', p]
   const quoted = quoteArgv(argv)
-  const script = `for a in ${quoted}; do printf '[%s]\\n' "$a"; done`
-  const out = execFileSync(BASH, ['-c', script], { encoding: 'utf8' })
-  const args = out.trim().split('\n').map((l) => l.slice(1, -1))
+  const args = expandArgs(quoted)
   const pref = args[args.indexOf('--preferences') + 1]
   const ok = pref === p
   if (!ok) { fail++; console.log('FAIL:', JSON.stringify(p), '->', JSON.stringify(pref)) }

--- a/plugins/dsh/scripts/canary.mjs
+++ b/plugins/dsh/scripts/canary.mjs
@@ -196,16 +196,20 @@ check('spill path present', trig.includes('C:/spill/stdout.log'))
 // ---------------------------------------------------------------------------
 // 6. argv quoting: spaces and metacharacters cannot break out
 // ---------------------------------------------------------------------------
-console.log('6. argv quoting is shell-safe')
-const { buildArgv, quoteArgv } = await import(pathToFileURL(join(packedRoot, 'src/index.js')).href)
+console.log('6. argv quoting is shell-safe (platform-aware)')
+const { buildArgv, quoteArgv, q, IS_WINDOWS } = await import(pathToFileURL(join(packedRoot, 'src/index.js')).href)
 // Verify quoting directly: a preference with spaces and metacharacters must stay
-// inside one argument (single-quoted, embedded quotes doubled).
+// inside one argument (single-quoted, embedded quotes escaped per platform).
 const argv = buildArgv({}, 'run', { preferences: "never ' rm -rf /" })
 const quoted = quoteArgv(argv)
 const prefArg = argv[argv.indexOf('--preferences') + 1]
 check('preference stays one argv element', argv.includes('--preferences') && argv[argv.indexOf('--preferences') + 1] === "never ' rm -rf /")
-check('quoted form uses bash-safe escape', quoted.includes("'never '\\'' rm -rf /'"))
+// pwsh escapes an embedded quote by doubling it (''); bash closes/reopens ('\'').
+const expected = IS_WINDOWS ? "'never '' rm -rf /'" : "'never '\\'' rm -rf /'"
+check('quoted form uses the host shell escape', quoted.includes(expected), `expected ${expected} got ...${quoted.slice(-40)}`)
+check('embedded quote escaped exactly once', (IS_WINDOWS ? quoted.split("''").length - 1 : quoted.split("'\\''").length - 1) === 1)
 check('no unquoted shell metacharacters', !/;\s*rm\s+-rf/.test(quoted))
+check('q() control chars folded to single spaces', q("a\r\nb\x00c") === "'a b c'")
 
 // ---------------------------------------------------------------------------
 // 7. auto-adopt is OPERATOR-ONLY: the model cannot set it

--- a/plugins/dsh/src/index.js
+++ b/plugins/dsh/src/index.js
@@ -18,7 +18,7 @@ export const name = 'skillopt'
 const PLUGIN_DIR = dirname(fileURLToPath(import.meta.url)) + '/..'
 
 // Exported for the canary test (scripts/canary.mjs).
-export { buildArgv, quoteArgv }
+export { buildArgv, quoteArgv, q, IS_WINDOWS }
 
 // Wait for the tool registry and the shell executor before applying.
 export const inject = ['tools', 'shell']
@@ -66,20 +66,31 @@ export const Config = Schema.object({
 // Helpers
 // ---------------------------------------------------------------------------
 
-// Quote one argv element for a POSIX shell (bash). Single quotes are literal;
-// an embedded single quote is expressed as '\'' (close quote, escaped quote,
-// reopen quote) — the only portable POSIX spelling. PowerShell is not a target
-// here: dsh's ctx.shell executes via `bash -c` (LocalBashExecutor), so the
-// quoting only needs to be bash-correct.
+// Quote one argv element for the HOST's shell. dsh's ctx.shell is the
+// platform executor: on win32 the bash stack is disabled and ctx.shell is a
+// pwsh executor (`pwsh -Command <one argv>`), on POSIX it is bash (`bash -c
+// <one argv>`). PowerShell and POSIX shell quoting differ, so the quoting
+// follows the platform:
+//
+//   - POSIX (bash): single quotes are literal; an embedded single quote is
+//     expressed as '\'' (close quote, escaped quote, reopen quote) — the only
+//     portable POSIX spelling.
+//   - Windows (pwsh): single-quoted strings are literal too, but an embedded
+//     single quote is expressed as '' (doubled quote).
 //
 // Control characters are stripped as defense in depth: \r and \r\n inside a
-// single-quoted word would otherwise split the value into multiple argv words
+// quoted word would otherwise split the value into multiple argv words
 // (broken command, not RCE — quotes never execute), and \n would corrupt the
 // engine's own arg parsing. Model-controlled values must arrive as exactly
-// one argument.
+// one argument under either shell.
+const IS_WINDOWS = process.platform === 'win32'
+
 function q(value) {
-  const s = String(value).replace(/[\r\n\u0000-\u001f\u007f]/g, ' ')
-  return `'${s.replace(/'/g, "'\\''")}'`
+  // Fold \r\n and lone \r into ONE space (not two), then strip remaining C0.
+  const s = String(value)
+    .replace(/\r\n?/g, ' ')
+    .replace(/[\n\u0000-\u001f\u007f]/g, ' ')
+  return IS_WINDOWS ? `'${s.replace(/'/g, "''")}'` : `'${s.replace(/'/g, "'\\''")}'`
 }
 
 /**
@@ -136,7 +147,12 @@ function buildArgv(config, action, explicit = {}, extras = [], allowed = null) {
 
 /** Join argv with safe quoting for the platform shell. */
 function quoteArgv(argv) {
-  return argv.map(q).join(' ')
+  const quoted = argv.map(q).join(' ')
+  // Windows PowerShell: a bare string is not a command invocation — `'python'
+  // 'args'` parses as a string-array expression and errors. Prepend the `&`
+  // call operator so the quoted argv runs as a command (same as bash, where
+  // the quote is the whole word and the first word is the command).
+  return IS_WINDOWS ? `& ${quoted}` : quoted
 }
 
 // Pick exactly the parameters a tool declares. dsh's parameter schema does


### PR DESCRIPTION
Adds Windows support to the dsh integration. After the original PR (#237) merged, the plugin worked on POSIX but every tool command failed on Windows - dsh's ctx.shell is a PowerShell executor on win32 (the bash stack is disabled by `!!js process.platform === 'win32'` in the base profile), and the plugin emitted POSIX quoting unconditionally, so `'python' 'args'` was parsed as a PowerShell string-array expression and errored with "missing call operator".

**Changes**

- `q()`: platform-aware quoting - PowerShell single-quote escaping (an embedded quote is doubled `''`) on win32, POSIX (`'\''` close/reopen) elsewhere. CRLF/lone CR folded to one space and C0 stripped before quoting.
- `quoteArgv()`: prepend the `&` call operator on win32 so the quoted argv runs as a command (PowerShell needs an explicit invocation; bash treats the first quoted word as the command).
- `canary.mjs` / `audit-injection.mjs` / `audit-control-chars.mjs`: host-shell aware - the audits now run payloads against the real host shell (discover PowerShell 5.1 / pwsh 7 like `dsh-pwsh-local`, or bash), and the canary asserts the platform-specific escape.

**Verification**

- canary 40/40 (platform-aware quoting, whitelist, value-domain guard, clock guard).
- injection 7/7 + control-char 7/7 payloads inert under real Windows PowerShell (5.1).
- real dsh 0.1.1-rc.2: `skillopt_status` now returns real output through the actual PowerShell executor (was "missing call operator" before).
- POSIX (bash) path unchanged - existing quoting suite still passes.