### PR TITLE
fix(model): resolve CLI exec paths for Windows .cmd shims

### DIFF
--- a/skillopt/model/backend_config.py
+++ b/skillopt/model/backend_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import warnings
 from collections.abc import Mapping
 from typing import Any
@@ -34,10 +35,23 @@ def _coerce_bool_setting(value: Any, *, name: str) -> bool:
     )
 
 
+def _resolve_cli_path(value: str) -> str:
+    """Resolve a CLI name/executable via PATH + PATHEXT.
+
+    On Windows these npm CLIs install as ``.cmd`` shims, and CreateProcess does
+    not search PATHEXT for a bare name (so a bare ``codex`` spawn raises
+    WinError 2). ``shutil.which`` finds the real executable; fall back to the
+    given value so a configured path still passes through unchanged when it
+    cannot be resolved (e.g. a name that is not on this PATH).
+    """
+    resolved = shutil.which(value)
+    return resolved or value
+
+
 OPTIMIZER_BACKEND = normalize_backend_name(os.environ.get("OPTIMIZER_BACKEND", "openai_chat"))
 TARGET_BACKEND = normalize_backend_name(os.environ.get("TARGET_BACKEND", "openai_chat"))
 
-CODEX_EXEC_PATH = os.environ.get("CODEX_EXEC_PATH") or os.environ.get("CODEX_CLI_BIN") or os.environ.get("CODEX_PATH") or "codex"
+CODEX_EXEC_PATH = _resolve_cli_path(os.environ.get("CODEX_EXEC_PATH") or os.environ.get("CODEX_CLI_BIN") or os.environ.get("CODEX_PATH") or "codex")
 CODEX_EXEC_SANDBOX = os.environ.get("CODEX_EXEC_SANDBOX") or os.environ.get("CODEX_SANDBOX_MODE") or os.environ.get("CODEX_SANDBOX") or "workspace-write"
 CODEX_EXEC_PROFILE = os.environ.get("CODEX_EXEC_PROFILE", "")
 _CODEX_EXEC_FULL_AUTO_ENV = os.environ.get("CODEX_EXEC_FULL_AUTO")
@@ -49,13 +63,13 @@ CODEX_EXEC_USE_SDK = os.environ.get("CODEX_EXEC_USE_SDK", "auto")
 CODEX_EXEC_NETWORK_ACCESS = _parse_bool(os.environ.get("CODEX_EXEC_NETWORK_ACCESS"), False)
 CODEX_EXEC_WEB_SEARCH = _parse_bool(os.environ.get("CODEX_EXEC_WEB_SEARCH"), False)
 CODEX_EXEC_APPROVAL_POLICY = os.environ.get("CODEX_EXEC_APPROVAL_POLICY", "never")
-CLAUDE_CODE_EXEC_PATH = os.environ.get("CLAUDE_CODE_EXEC_PATH", "claude")
+CLAUDE_CODE_EXEC_PATH = _resolve_cli_path(os.environ.get("CLAUDE_CODE_EXEC_PATH", "claude"))
 CLAUDE_CODE_EXEC_PROFILE = os.environ.get("CLAUDE_CODE_EXEC_PROFILE", "")
 CLAUDE_CODE_EXEC_USE_SDK = os.environ.get("CLAUDE_CODE_EXEC_USE_SDK", "auto")
 CLAUDE_CODE_EXEC_EFFORT = os.environ.get("CLAUDE_CODE_EXEC_EFFORT", "medium")
-CURSOR_EXEC_PATH = os.environ.get("CURSOR_EXEC_PATH", "cursor-agent")
+CURSOR_EXEC_PATH = _resolve_cli_path(os.environ.get("CURSOR_EXEC_PATH", "cursor-agent"))
 CURSOR_EXEC_SANDBOX = os.environ.get("CURSOR_EXEC_SANDBOX", "enabled")
-COPILOT_EXEC_PATH = os.environ.get("COPILOT_EXEC_PATH", "copilot")
+COPILOT_EXEC_PATH = _resolve_cli_path(os.environ.get("COPILOT_EXEC_PATH", "copilot"))
 COPILOT_EXEC_HOME = os.environ.get("COPILOT_EXEC_HOME", "")
 COPILOT_EXEC_ALLOW_ALL_TOOLS = (
     "1" if _parse_bool(os.environ.get("COPILOT_EXEC_ALLOW_ALL_TOOLS"), False) else "0"
@@ -222,7 +236,7 @@ def configure_codex_exec(
         else _coerce_bool_setting(web_search, name="codex_exec_web_search")
     )
     if path is not None:
-        CODEX_EXEC_PATH = str(path).strip() or "codex"
+        CODEX_EXEC_PATH = _resolve_cli_path(str(path).strip() or "codex")
         os.environ["CODEX_EXEC_PATH"] = CODEX_EXEC_PATH
         os.environ["CODEX_CLI_BIN"] = CODEX_EXEC_PATH
     if sandbox is not None:
@@ -361,7 +375,7 @@ def configure_claude_code_exec(
 ) -> None:
     global CLAUDE_CODE_EXEC_PATH, CLAUDE_CODE_EXEC_PROFILE, CLAUDE_CODE_EXEC_USE_SDK, CLAUDE_CODE_EXEC_EFFORT, CLAUDE_CODE_EXEC_MAX_THINKING_TOKENS
     if path is not None:
-        CLAUDE_CODE_EXEC_PATH = str(path).strip() or "claude"
+        CLAUDE_CODE_EXEC_PATH = _resolve_cli_path(str(path).strip() or "claude")
         os.environ["CLAUDE_CODE_EXEC_PATH"] = CLAUDE_CODE_EXEC_PATH
     if profile is not None:
         CLAUDE_CODE_EXEC_PROFILE = str(profile).strip()
@@ -398,7 +412,7 @@ def configure_cursor_exec(
 ) -> None:
     global CURSOR_EXEC_PATH, CURSOR_EXEC_SANDBOX
     if path is not None:
-        CURSOR_EXEC_PATH = str(path).strip() or "cursor-agent"
+        CURSOR_EXEC_PATH = _resolve_cli_path(str(path).strip() or "cursor-agent")
         os.environ["CURSOR_EXEC_PATH"] = CURSOR_EXEC_PATH
     if sandbox is not None:
         normalized_sandbox = str(sandbox).strip().lower() or "enabled"
@@ -433,7 +447,7 @@ def configure_copilot_exec(
     """
     global COPILOT_EXEC_PATH, COPILOT_EXEC_HOME, COPILOT_EXEC_ALLOW_ALL_TOOLS
     if path is not None:
-        COPILOT_EXEC_PATH = str(path).strip() or "copilot"
+        COPILOT_EXEC_PATH = _resolve_cli_path(str(path).strip() or "copilot")
         os.environ["COPILOT_EXEC_PATH"] = COPILOT_EXEC_PATH
     if home is not None:
         COPILOT_EXEC_HOME = str(home).strip()
@@ -478,7 +492,7 @@ def configure_copilot_chat(
     global COPILOT_EXEC_PATH, COPILOT_EXEC_HOME
     global COPILOT_CHAT_OPTIMIZER_MODEL, COPILOT_CHAT_TARGET_MODEL, COPILOT_CHAT_TIMEOUT
     if path is not None:
-        COPILOT_EXEC_PATH = str(path).strip() or "copilot"
+        COPILOT_EXEC_PATH = _resolve_cli_path(str(path).strip() or "copilot")
         os.environ["COPILOT_EXEC_PATH"] = COPILOT_EXEC_PATH
     if home is not None:
         COPILOT_EXEC_HOME = str(home).strip()

--- a/skillopt/model/codex_harness.py
+++ b/skillopt/model/codex_harness.py
@@ -120,7 +120,16 @@ def prepare_workspace(
             parent = os.path.dirname(dst)
             if parent:
                 os.makedirs(parent, exist_ok=True)
-            os.symlink(os.path.abspath(src), dst)
+            src_abs = os.path.abspath(src)
+            try:
+                os.symlink(src_abs, dst, target_is_directory=os.path.isdir(src_abs))
+            except OSError:
+                # Windows symlinks need SeCreateSymbolicLinkPrivilege (Developer
+                # Mode/elevation); copying is fine inside a private work dir.
+                if os.path.isdir(src_abs):
+                    shutil.copytree(src_abs, dst, dirs_exist_ok=True)
+                else:
+                    shutil.copy2(src_abs, dst)
 
     attachment_lines: list[str] = []
     if images:
@@ -1771,14 +1780,15 @@ def run_copilot_exec(
 
         stdout = proc.stdout or ""
         stderr = proc.stderr or ""
-        safe_raw = stdout
+        safe_raw = _redact_cursor_error(stdout)
         if stderr:
-            safe_raw = f"{safe_raw}\n[stderr]\n{stderr}" if safe_raw else f"[stderr]\n{stderr}"
+            safe_stderr = _redact_cursor_error(stderr)
+            safe_raw = f"{safe_raw}\n[stderr]\n{safe_stderr}" if safe_raw else f"[stderr]\n{safe_stderr}"
         all_raw.append(f"===== COPILOT CLI ATTEMPT {attempt + 1} =====\n{safe_raw}")
         combined = "\n\n".join(all_raw)
 
         if proc.returncode != 0:
-            detail = (stderr or stdout).strip()[:4000]
+            detail = _redact_cursor_error((stderr or stdout).strip())[:4000]
             raise RuntimeError(
                 f"Copilot CLI failed with exit code {proc.returncode}: {detail}"
             )

--- a/skillopt/model/codex_harness.py
+++ b/skillopt/model/codex_harness.py
@@ -1514,8 +1514,37 @@ _CURSOR_SECRET_TRACE_FIELDS = {
 }
 
 
+# ``"token": "..."`` / ``"accessToken": {...}`` quoted JSON pairs, matched in
+# arbitrary (possibly non-JSON) text. Value may be a string, number, bool, or a
+# nested object/array literal quoted as a unit — we redact the whole payload.
+# Applied FIRST inside ``_redact_cursor_error``: the unquoted keyword regex below
+# stops at the first whitespace, so ``"token": "a b c"`` would otherwise leak
+# ``b c"``. Capturing the whole quoted payload up front fixes that, and since
+# ``_redact_cursor_error`` is the single shared string redactor, one change
+# covers the copilot fallback, the cursor stderr paths, and string leaves.
+# ponytail: the object branch is single-level only; deep-nested values under a
+# secret key in non-JSON text are not stripped (valid-JSON lines already go
+# through the structural walker). Add an unbounded nest parser if that ever
+# appears in real stderr.
+_COPILOT_QUOTED_JSON_KEY = re.compile(
+    r'(?i)"([^"\\]*(?:token|apikey|api[_-]?key|secret|password|authorization|'
+    r'bearer|cookie|setcookie)[^"\\]*)"\s*:\s*(?P<val>'
+    r'"(?:\\.|[^"\\])*"'  # JSON string value
+    r'|\[[^\]]*\]'  # JSON array literal
+    r'|\{[^{}]*\}'  # JSON object literal (single level)
+    r'|[^\s,]+'  # bare token / number / bool
+    r')'
+)
+
+
+def _redact_quoted_json_pair(match: re.Match) -> str:
+    return f'{match.group(1)}: "[REDACTED]"'
+
+
 def _redact_cursor_error(value: str) -> str:
-    text = _CURSOR_SECRET_ASSIGNMENT.sub(r"\1\2[REDACTED]", value or "")
+    text = value or ""
+    text = _COPILOT_QUOTED_JSON_KEY.sub(_redact_quoted_json_pair, text)
+    text = _CURSOR_SECRET_ASSIGNMENT.sub(r"\1\2[REDACTED]", text)
     return _CURSOR_SECRET_TOKEN.sub("[REDACTED]", text)
 
 

--- a/skillopt/model/codex_harness.py
+++ b/skillopt/model/codex_harness.py
@@ -1526,6 +1526,33 @@ _CURSOR_SECRET_TRACE_FIELDS = {
 # secret key in non-JSON text are not stripped (valid-JSON lines already go
 # through the structural walker). Add an unbounded nest parser if that ever
 # appears in real stderr.
+_COPILOT_SECRET_KEY_SUFFIXES = (
+    "apikey",
+    "accesstoken",
+    "refreshtoken",
+    "token",
+    "password",
+    "passwd",
+    "clientsecret",
+    "secret",
+    "secretkey",
+    "secretaccesskey",
+    "sharedaccesskey",
+    "privatekey",
+    "accountkey",
+    "cookie",
+    "setcookie",
+)
+_COPILOT_SECRET_KEY_EXACT = {"pwd", "sig", "authorization"}
+
+# Matching is two-level: the regex only ENGAGES quoted keys containing a
+# secret seed (so it never swallows a non-secret object like ``"a": {...}``),
+# and the callback decides with the project's endswith-based rule so
+# token_count / token_budget / secret_version diagnostics are NOT scrubbed.
+# ponytail: the object branch is single-level only; deep-nested values under a
+# secret key in non-JSON text are not stripped (valid-JSON lines already go
+# through the structural walker). Add an unbounded nest parser if that ever
+# appears in real stderr.
 _COPILOT_QUOTED_JSON_KEY = re.compile(
     r'(?i)"([^"\\]*(?:token|apikey|api[_-]?key|secret|password|authorization|'
     r'bearer|cookie|setcookie)[^"\\]*)"\s*:\s*(?P<val>'
@@ -1538,6 +1565,13 @@ _COPILOT_QUOTED_JSON_KEY = re.compile(
 
 
 def _redact_quoted_json_pair(match: re.Match) -> str:
+    key = match.group(1)
+    compact = re.sub(r"[^a-z0-9]", "", key.strip().casefold())
+    if not (
+        compact in _COPILOT_SECRET_KEY_EXACT
+        or compact.endswith(_COPILOT_SECRET_KEY_SUFFIXES)
+    ):
+        return match.group(0)
     return f'{match.group(1)}: "[REDACTED]"'
 
 

--- a/skillopt/model/codex_harness.py
+++ b/skillopt/model/codex_harness.py
@@ -1545,39 +1545,83 @@ _COPILOT_SECRET_KEY_SUFFIXES = (
 )
 _COPILOT_SECRET_KEY_EXACT = {"pwd", "sig", "authorization", "bearer"}
 
-# Matching is two-level: the regex only ENGAGES quoted keys containing a
-# secret seed (so it never swallows a non-secret object like ``"a": {...}``),
-# and the callback decides with the project's endswith-based rule so
-# token_count / token_budget / secret_version diagnostics are NOT scrubbed.
-# ponytail: the object branch is single-level only; deep-nested values under a
-# secret key in non-JSON text are not stripped (valid-JSON lines already go
-# through the structural walker). Add an unbounded nest parser if that ever
-# appears in real stderr.
-_COPILOT_QUOTED_JSON_KEY = re.compile(
-    r'(?i)"([^"\\]*(?:token|apikey|api[_-]?key|secret|password|authorization|'
-    r'bearer|cookie|setcookie)[^"\\]*)"\s*:\s*(?P<val>'
-    r'"(?:\\.|[^"\\])*"'  # JSON string value
-    r'|\[[^\]]*\]'  # JSON array literal
-    r'|\{[^{}]*\}'  # JSON object literal (single level)
-    r'|[^\s,]+'  # bare token / number / bool
-    r')'
-)
+def _is_copilot_secret_key(field: str) -> bool:
+    """The single mapping-aware secret-key policy for the Copilot path.
+
+    Uses endswith on the compacted key (mirroring ``_is_secret_mapping_key``), so
+    ``token`` / ``api_key`` / ``refreshToken`` / ``bearer`` / ``cookie`` are
+    redacted, but ``token_count`` / ``token_budget`` / ``secret_version``
+    diagnostics are preserved.
+    """
+    compact = re.sub(r"[^a-z0-9]", "", (field or "").casefold())
+    return compact in _COPILOT_SECRET_KEY_EXACT or compact.endswith(_COPILOT_SECRET_KEY_SUFFIXES)
 
 
-def _redact_quoted_json_pair(match: re.Match) -> str:
-    key = match.group(1)
-    compact = re.sub(r"[^a-z0-9]", "", key.strip().casefold())
-    if not (
-        compact in _COPILOT_SECRET_KEY_EXACT
-        or compact.endswith(_COPILOT_SECRET_KEY_SUFFIXES)
-    ):
-        return match.group(0)
-    return f'{match.group(1)}: "[REDACTED]"'
+def _find_json_end(text: str, start: int) -> int | None:
+    """Bracket-match a JSON object/array starting at ``start`` (unbounded nesting).
+
+    String-aware (handles quotes and escapes), so a ``{`` inside a string value
+    does not confuse the matching.
+    """
+    open_ch = text[start]
+    close_ch = "}" if open_ch == "{" else "]"
+    depth = 0
+    in_str = False
+    escaped = False
+    for k in range(start, len(text)):
+        ch = text[k]
+        if in_str:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_str = False
+        else:
+            if ch == '"':
+                in_str = True
+            elif ch == open_ch:
+                depth += 1
+            elif ch == close_ch:
+                depth -= 1
+                if depth == 0:
+                    return k
+    return None
+
+
+def _redact_embedded_json(text: str) -> str:
+    """Structurally redact JSON objects/arrays embedded in plain text.
+
+    Finds balanced JSON fragments (unbounded nesting, string-aware) and walks
+    each with the mapping-aware redactor, so deeply nested or pretty-printed
+    JSON embedded in a non-JSON line no longer leaks. Non-JSON text is preserved.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in "{[":
+            end = _find_json_end(text, i)
+            if end is not None:
+                frag = text[i:end + 1]
+                try:
+                    obj = json.loads(frag)
+                except (ValueError, TypeError):
+                    out.append(ch)
+                    i += 1
+                    continue
+                out.append(json.dumps(_redact_copilot_json(obj), ensure_ascii=False))
+                i = end + 1
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
 
 
 def _redact_cursor_error(value: str) -> str:
     text = value or ""
-    text = _COPILOT_QUOTED_JSON_KEY.sub(_redact_quoted_json_pair, text)
+    text = _redact_embedded_json(text)
     text = _CURSOR_SECRET_ASSIGNMENT.sub(r"\1\2[REDACTED]", text)
     return _CURSOR_SECRET_TOKEN.sub("[REDACTED]", text)
 
@@ -1609,12 +1653,10 @@ def _redact_copilot_json(value: Any, *, field: str = "") -> Any:
     Unlike the cursor trace sanitizer, this does NOT omit ``content``/``prompt``
     (those are the CLI output we want to keep debuggable); it redacts by secret
     field name and applies the string-level redactor to remaining string leaves.
+    Uses the SAME key policy as the embedded-JSON fallback so valid JSON and
+    non-JSON fragments agree on what a secret field is.
     """
-    normalized_field = re.sub(r"[^a-z0-9]", "", field.lower())
-    if (
-        normalized_field in _CURSOR_SECRET_TRACE_FIELDS
-        or normalized_field.endswith("apikey")
-    ):
+    if _is_copilot_secret_key(field):
         return "[REDACTED]"
     if isinstance(value, dict):
         return {
@@ -1629,28 +1671,16 @@ def _redact_copilot_json(value: Any, *, field: str = "") -> Any:
 
 
 def _redact_copilot_trace(raw: str | bytes) -> str:
-    """Structurally sanitize Copilot JSONL output (mapping-key aware).
+    """Sanitize Copilot JSONL output (mapping-key aware, unbounded nesting).
 
-    ``_redact_cursor_error`` catches unquoted ``key=value`` forms, but the
-    Copilot JSONL stream carries ``"token": "..."`` objects. Parse each line
-    and walk it with the field-name-aware sanitizer; non-JSON lines still fall
-    through the string-level redactor.
+    The whole text is scanned for JSON objects/arrays (single-line, multiple
+    fragments, or pretty-printed / deeply nested) and each is walked with the
+    mapping-aware redactor; remaining non-JSON text gets string-level redaction
+    for ``key=value`` and token patterns. This replaces the old line-by-line
+    regex, which only handled single-level object values.
     """
     text = _cursor_process_text(raw)
-    lines_out: list[str] = []
-    for line in text.splitlines():
-        stripped = line.strip()
-        if not stripped:
-            lines_out.append(line)
-            continue
-        try:
-            obj = json.loads(stripped)
-        except (ValueError, TypeError):
-            lines_out.append(_redact_cursor_error(line))
-            continue
-        obj = _redact_copilot_json(obj)
-        lines_out.append(json.dumps(obj, ensure_ascii=False))
-    return "\n".join(lines_out)
+    return _redact_cursor_error(text)
 
 
 def _cursor_process_text(value: str | bytes) -> str:

--- a/skillopt/model/codex_harness.py
+++ b/skillopt/model/codex_harness.py
@@ -1543,7 +1543,7 @@ _COPILOT_SECRET_KEY_SUFFIXES = (
     "cookie",
     "setcookie",
 )
-_COPILOT_SECRET_KEY_EXACT = {"pwd", "sig", "authorization"}
+_COPILOT_SECRET_KEY_EXACT = {"pwd", "sig", "authorization", "bearer"}
 
 # Matching is two-level: the regex only ENGAGES quoted keys containing a
 # secret seed (so it never swallows a non-secret object like ``"a": {...}``),

--- a/skillopt/model/codex_harness.py
+++ b/skillopt/model/codex_harness.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import json
 import os
 import re
@@ -73,6 +74,25 @@ def render_skill_md(
     return "\n".join(chunks)
 
 
+def _is_symlink_privilege_error(exc: OSError) -> bool:
+    """Return True only for the Windows 'symlink privilege not held' case.
+
+    We must not mask a real collision/error by silently falling back to a copy;
+    only the case where the OS refuses to create a symlink because the caller
+    lacks SeCreateSymbolicLinkPrivilege (Windows Developer Mode / elevation)
+    should fall back to a copy inside a private work dir.
+    """
+    if getattr(exc, "winerror", None) in (1314,):  # ERROR_PRIVILEGE_NOT_HELD
+        return True
+    if isinstance(exc, OSError):
+        return exc.errno in {
+            getattr(errno, "EPERM", -1),
+            getattr(errno, "ENOTSUP", -1),
+            getattr(errno, "EOPNOTSUPP", -1),
+        }
+    return False
+
+
 def prepare_workspace(
     *,
     work_dir: str,
@@ -121,13 +141,19 @@ def prepare_workspace(
             if parent:
                 os.makedirs(parent, exist_ok=True)
             src_abs = os.path.abspath(src)
+            if os.path.lexists(dst):
+                raise FileExistsError(
+                    f"link destination already exists: {dst} (from {src})"
+                )
             try:
                 os.symlink(src_abs, dst, target_is_directory=os.path.isdir(src_abs))
-            except OSError:
-                # Windows symlinks need SeCreateSymbolicLinkPrivilege (Developer
-                # Mode/elevation); copying is fine inside a private work dir.
+            except OSError as exc:
+                # Fail closed: only fall back for the Windows symlink-privilege
+                # case, and never merge into an existing destination.
+                if not _is_symlink_privilege_error(exc):
+                    raise
                 if os.path.isdir(src_abs):
-                    shutil.copytree(src_abs, dst, dirs_exist_ok=True)
+                    shutil.copytree(src_abs, dst)
                 else:
                     shutil.copy2(src_abs, dst)
 
@@ -1514,6 +1540,56 @@ def _sanitize_cursor_json(value: Any, *, field: str = "") -> Any:
     return value
 
 
+def _redact_copilot_json(value: Any, *, field: str = "") -> Any:
+    """Mapping-key-aware redaction for Copilot JSONL.
+
+    Unlike the cursor trace sanitizer, this does NOT omit ``content``/``prompt``
+    (those are the CLI output we want to keep debuggable); it redacts by secret
+    field name and applies the string-level redactor to remaining string leaves.
+    """
+    normalized_field = re.sub(r"[^a-z0-9]", "", field.lower())
+    if (
+        normalized_field in _CURSOR_SECRET_TRACE_FIELDS
+        or normalized_field.endswith("apikey")
+    ):
+        return "[REDACTED]"
+    if isinstance(value, dict):
+        return {
+            str(key): _redact_copilot_json(item, field=str(key))
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_copilot_json(item) for item in value]
+    if isinstance(value, str):
+        return _redact_cursor_error(value)
+    return value
+
+
+def _redact_copilot_trace(raw: str | bytes) -> str:
+    """Structurally sanitize Copilot JSONL output (mapping-key aware).
+
+    ``_redact_cursor_error`` catches unquoted ``key=value`` forms, but the
+    Copilot JSONL stream carries ``"token": "..."`` objects. Parse each line
+    and walk it with the field-name-aware sanitizer; non-JSON lines still fall
+    through the string-level redactor.
+    """
+    text = _cursor_process_text(raw)
+    lines_out: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            lines_out.append(line)
+            continue
+        try:
+            obj = json.loads(stripped)
+        except (ValueError, TypeError):
+            lines_out.append(_redact_cursor_error(line))
+            continue
+        obj = _redact_copilot_json(obj)
+        lines_out.append(json.dumps(obj, ensure_ascii=False))
+    return "\n".join(lines_out)
+
+
 def _cursor_process_text(value: str | bytes) -> str:
     if isinstance(value, bytes):
         return value.decode("utf-8", errors="replace")
@@ -1780,15 +1856,15 @@ def run_copilot_exec(
 
         stdout = proc.stdout or ""
         stderr = proc.stderr or ""
-        safe_raw = _redact_cursor_error(stdout)
+        safe_raw = _redact_copilot_trace(stdout)
         if stderr:
-            safe_stderr = _redact_cursor_error(stderr)
+            safe_stderr = _redact_copilot_trace(stderr)
             safe_raw = f"{safe_raw}\n[stderr]\n{safe_stderr}" if safe_raw else f"[stderr]\n{safe_stderr}"
         all_raw.append(f"===== COPILOT CLI ATTEMPT {attempt + 1} =====\n{safe_raw}")
         combined = "\n\n".join(all_raw)
 
         if proc.returncode != 0:
-            detail = _redact_cursor_error((stderr or stdout).strip())[:4000]
+            detail = _redact_copilot_trace((stderr or stdout).strip())[:4000]
             raise RuntimeError(
                 f"Copilot CLI failed with exit code {proc.returncode}: {detail}"
             )

--- a/tests/test_cli_path_resolution.py
+++ b/tests/test_cli_path_resolution.py
@@ -1,0 +1,29 @@
+"""Tests for CLI exec-path resolution (Windows bare-name .cmd shims)."""
+
+from __future__ import annotations
+
+from skillopt.model.backend_config import _resolve_cli_path
+
+
+def test_resolve_cli_path_uses_shutil_which(monkeypatch):
+    """A name found on PATH resolves to its real executable."""
+    monkeypatch.setattr("shutil.which", lambda v: f"/resolved/{v}")
+    assert _resolve_cli_path("codex") == "/resolved/codex"
+
+
+def test_resolve_cli_path_falls_back_to_original(monkeypatch):
+    """A name not on PATH (or a bare name on a host without it) passes through."""
+    monkeypatch.setattr("shutil.which", lambda v: None)
+    assert _resolve_cli_path("codex") == "codex"
+
+
+def test_resolve_cli_path_keeps_configured_absolute_path(monkeypatch):
+    """An absolute configured path that cannot be resolved is preserved."""
+    monkeypatch.setattr("shutil.which", lambda v: None)
+    assert _resolve_cli_path("/opt/bin/codex") == "/opt/bin/codex"
+
+
+def test_resolve_cli_path_not_called_with_empty(monkeypatch):
+    """Empty input is not handed to shutil.which in a way that corrupts."""
+    monkeypatch.setattr("shutil.which", lambda v: None)
+    assert _resolve_cli_path("") == ""

--- a/tests/test_copilot_exec_backend.py
+++ b/tests/test_copilot_exec_backend.py
@@ -546,6 +546,24 @@ def test_sanitize_cursor_trace_redacts_quoted_json_in_stderr() -> None:
     assert "[REDACTED]" in out
 
 
+def test_redact_cursor_error_keeps_token_budget_diagnostics() -> None:
+    # Endswith-based key detection must NOT scrub non-credential diagnostics that
+    # merely contain a secret-ish substring (token_count / token_budget /
+    # secret_version), while still scrubbing real credential keys.
+    out = harness._redact_cursor_error(
+        '{"token_count": 3, "token_budget": 10, "secret_version": "v1", '
+        '"api_key": "x", "refreshToken": "y"}'
+    )
+    # Non-credential diagnostics with a secret-ish substring are KEPT.
+    assert '"token_count": 3' in out
+    assert '"token_budget": 10' in out
+    assert '"secret_version": "v1"' in out
+    # Real credential keys are still scrubbed.
+    assert '"api_key": "x"' not in out
+    assert '"refreshToken": "y"' not in out
+    assert out.count("[REDACTED]") == 2
+
+
 
 def test_run_target_exec_dispatches_to_copilot(monkeypatch, tmp_path) -> None:
     model.set_backend("copilot_exec")

--- a/tests/test_copilot_exec_backend.py
+++ b/tests/test_copilot_exec_backend.py
@@ -458,6 +458,95 @@ def test_nonzero_exit_raises_with_detail(monkeypatch, tmp_path) -> None:
         harness.run_copilot_exec(work_dir=str(tmp_path), prompt="p", model="", timeout=30)
 
 
+# --- copilot trace redaction: quoted JSON embedded in non-JSON surf --------
+
+
+def _fake_run_with_stderr(captured: dict, stderr: str, stdout: str = "", returncode: int = 0):
+    def _run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs.get("env") or {}
+        captured["cwd"] = kwargs.get("cwd")
+        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+    return _run
+
+
+def test_copilot_trace_redacts_prefixed_quoted_json() -> None:
+    # The CLI prefixes real-stream stderr with non-JSON text (e.g. "warning:"),
+    # so the whole line is NOT valid JSON and used to fall back to the
+    # unquoted-keyword redactor, leaking quoted JSON secret payloads.
+    raw = 'warning: {"token":"plain-secret"}\nstill here {"api_key": "ghp_abcdef"}\n'
+    out = harness._redact_copilot_trace(raw)
+    assert "plain-secret" not in out
+    assert "ghp_abcdef" not in out
+    assert "[REDACTED]" in out
+
+
+def test_copilot_trace_redacts_quoted_json_across_valid_and_prefixed_lines() -> None:
+    # One structurally-valid JSON line + one non-JSON prefixed line; both carry
+    # a quoted secret and both must be stripped.
+    raw = (
+        '{"token": "first-secret"}\n'
+        'warning: {"a": {"refreshToken": "second-secret"}}\n'
+    )
+    out = harness._redact_copilot_trace(raw)
+    assert "first-secret" not in out
+    assert "second-secret" not in out
+    assert "[REDACTED]" in out
+
+
+def test_run_copilot_exec_redacts_secret_in_stderr_trace(monkeypatch, tmp_path) -> None:
+    model.set_backend("copilot")
+    model.configure_copilot_exec(path="copilot", home="", allow_all_tools=False)
+    captured: dict = {}
+    stdout = json.dumps({"type": "assistant.message", "data": {"content": "ok"}})
+    stderr = 'warning: {"token":"plain-secret"}\n'
+    monkeypatch.setattr(harness.subprocess, "run", _fake_run_with_stderr(captured, stderr, stdout=stdout))
+
+    response, raw = harness.run_copilot_exec(work_dir=str(tmp_path), prompt="p", model="", timeout=30)
+
+    assert response == "ok"
+    assert "plain-secret" not in raw
+    assert "[REDACTED]" in raw
+
+
+def test_run_copilot_exec_redacts_secret_in_error_detail(monkeypatch, tmp_path) -> None:
+    model.set_backend("copilot")
+    model.configure_copilot_exec(path="copilot", home="", allow_all_tools=False)
+    captured: dict = {}
+    stderr = 'warning: {"token":"plain-secret"}\n'
+    monkeypatch.setattr(harness.subprocess, "run", _fake_run_with_stderr(captured, stderr, returncode=3))
+
+    with pytest.raises(RuntimeError) as exc:
+        harness.run_copilot_exec(work_dir=str(tmp_path), prompt="p", model="", timeout=30)
+
+    assert "plain-secret" not in str(exc.value)
+    assert "[REDACTED]" in str(exc.value)
+
+
+def test_redact_cursor_error_redacts_quoted_json_with_spaces() -> None:
+    # The unquoted keyword regex truncates at the FIRST whitespace, so a quoted
+    # JSON value that contains spaces used to leak its remainder. This is the
+    # shared string redactor used by the copilot fallback AND cursor stderr.
+    out = harness._redact_cursor_error('warning: {"token": "ab cd ef"}')
+    assert "ab cd ef" not in out
+    assert "[REDACTED]" in out
+
+
+def test_sanitize_cursor_trace_redacts_quoted_json_in_stderr() -> None:
+    # Cursor's trace redactor routes real stderr lines through the same shared
+    # `_redact_cursor_error`; it must not leak quoted JSON values with spaces.
+    raw = (
+        "===== CURSOR CLI ATTEMPT 1 =====\n"
+        "[stderr]\n"
+        'warning: {"token": "a b c"}\n'
+    )
+    out = harness._sanitize_cursor_trace(raw, preserve_markers=True)
+    assert "a b c" not in out
+    assert "[REDACTED]" in out
+
+
+
 def test_run_target_exec_dispatches_to_copilot(monkeypatch, tmp_path) -> None:
     model.set_backend("copilot_exec")
     called: dict = {}

--- a/tests/test_copilot_exec_backend.py
+++ b/tests/test_copilot_exec_backend.py
@@ -564,6 +564,15 @@ def test_redact_cursor_error_keeps_token_budget_diagnostics() -> None:
     assert out.count("[REDACTED]") == 2
 
 
+def test_redact_cursor_error_redacts_bare_bearer_key() -> None:
+    # A standalone "bearer" key is a credential marker (the exact set covers it);
+    # the common "Authorization": "Bearer ..." form is also scrubbed via the
+    # authorization key.
+    out = harness._redact_cursor_error('{"bearer": "mysecrettoken"}')
+    assert '"bearer": "mysecrettoken"' not in out
+    assert "[REDACTED]" in out
+
+
 
 def test_run_target_exec_dispatches_to_copilot(monkeypatch, tmp_path) -> None:
     model.set_backend("copilot_exec")

--- a/tests/test_copilot_exec_backend.py
+++ b/tests/test_copilot_exec_backend.py
@@ -524,7 +524,37 @@ def test_run_copilot_exec_redacts_secret_in_error_detail(monkeypatch, tmp_path) 
     assert "[REDACTED]" in str(exc.value)
 
 
-def test_redact_cursor_error_redacts_quoted_json_with_spaces() -> None:
+def test_run_copilot_exec_redacts_camelcase_key_in_stderr_trace(monkeypatch, tmp_path) -> None:
+    # A camelCase secret key (githubToken) in valid JSON must be redacted (the
+    # structural walker used to miss it).
+    model.set_backend("copilot")
+    model.configure_copilot_exec(path="copilot", home="", allow_all_tools=False)
+    captured: dict = {}
+    stdout = json.dumps({"type": "assistant.message", "data": {"content": "ok"}})
+    stderr = '{"githubToken":"plain-secret"}\n'
+    monkeypatch.setattr(harness.subprocess, "run", _fake_run_with_stderr(captured, stderr, stdout=stdout))
+
+    response, raw = harness.run_copilot_exec(work_dir=str(tmp_path), prompt="p", model="", timeout=30)
+
+    assert response == "ok"
+    assert "plain-secret" not in raw
+    assert "[REDACTED]" in raw
+
+
+def test_run_copilot_exec_redacts_deep_nested_embedded_json_in_error_detail(monkeypatch, tmp_path) -> None:
+    # A deeply nested JSON fragment embedded in a non-JSON error line must not
+    # leak (the old single-level regex could not).
+    model.set_backend("copilot")
+    model.configure_copilot_exec(path="copilot", home="", allow_all_tools=False)
+    captured: dict = {}
+    stderr = 'warning: {"a":{"b":{"token":"deep-secret"}}}\n'
+    monkeypatch.setattr(harness.subprocess, "run", _fake_run_with_stderr(captured, stderr, returncode=3))
+
+    with pytest.raises(RuntimeError) as exc:
+        harness.run_copilot_exec(work_dir=str(tmp_path), prompt="p", model="", timeout=30)
+
+    assert "deep-secret" not in str(exc.value)
+    assert "[REDACTED]" in str(exc.value)
     # The unquoted keyword regex truncates at the FIRST whitespace, so a quoted
     # JSON value that contains spaces used to leak its remainder. This is the
     # shared string redactor used by the copilot fallback AND cursor stderr.

--- a/tests/test_workspace_symlink.py
+++ b/tests/test_workspace_symlink.py
@@ -1,0 +1,131 @@
+"""Tests for workspace-prep symlink fail-closed behavior + Copilot trace redaction."""
+
+from __future__ import annotations
+
+import errno
+import os
+from pathlib import Path
+
+import pytest
+
+from skillopt.model.codex_harness import (
+    _is_symlink_privilege_error,
+    _redact_copilot_trace,
+    prepare_workspace,
+)
+
+
+def _mk_src(tmp_path, name="srcdir", content="source-content") -> Path:
+    src = tmp_path / name
+    src.mkdir()
+    (src / "data.txt").write_text(content, encoding="utf-8")
+    return src
+
+
+def _privilege_error() -> OSError:
+    e = OSError()
+    e.winerror = 1314  # ERROR_PRIVILEGE_NOT_HELD
+    return e
+
+
+def test_is_symlink_privilege_error():
+    assert _is_symlink_privilege_error(_privilege_error()) is True
+    e = OSError()
+    e.errno = errno.EPERM
+    assert _is_symlink_privilege_error(e) is True
+    e2 = OSError()
+    e2.errno = errno.EACCES
+    assert _is_symlink_privilege_error(e2) is False
+    assert _is_symlink_privilege_error(OSError()) is False
+
+
+def test_symlink_privilege_fallback_copies_and_leaves_source(monkeypatch, tmp_path):
+    src = _mk_src(tmp_path)
+    work = tmp_path / "work"
+    work.mkdir()
+
+    def fake_symlink(a, b, **kw):
+        raise _privilege_error()
+
+    monkeypatch.setattr("skillopt.model.codex_harness.os.symlink", fake_symlink)
+    prepare_workspace(work_dir=str(work), skill_md="x", link_dirs=[(str(src), "docs/data")])
+
+    # Source is not modified.
+    assert (src / "data.txt").read_text(encoding="utf-8") == "source-content"
+    # The fallback copied into the private work dir.
+    assert (work / "docs" / "data" / "data.txt").read_text(encoding="utf-8") == "source-content"
+
+
+def test_existing_destination_fails_closed(monkeypatch, tmp_path):
+    src = _mk_src(tmp_path)
+    work = tmp_path / "work"
+    work.mkdir()
+
+    # extra_files creates the destination directory before link_dirs runs.
+    with pytest.raises(FileExistsError):
+        prepare_workspace(
+            work_dir=str(work),
+            skill_md="x",
+            extra_files={"docs/data/file.txt": "stale"},
+            link_dirs=[(str(src), "docs/data")],
+        )
+    # extra_files content was not overwritten by a merge.
+    assert (work / "docs" / "data" / "file.txt").read_text(encoding="utf-8") == "stale"
+
+
+def test_duplicate_destination_fails_closed(monkeypatch, tmp_path):
+    src_a = _mk_src(tmp_path, "A")
+    src_b = _mk_src(tmp_path, "B", content="B-content")
+    work = tmp_path / "work"
+    work.mkdir()
+
+    # Force the first to succeed via a dir symlink stub, then assert the second
+    # duplicate destination is refused rather than merged.
+    def fake_symlink(a, b, **kw):
+        Path(b).mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr("skillopt.model.codex_harness.os.symlink", fake_symlink)
+    with pytest.raises(FileExistsError):
+        prepare_workspace(
+            work_dir=str(work),
+            skill_md="x",
+            link_dirs=[(str(src_a), "shared"), (str(src_b), "shared")],
+        )
+    # src_b (the second source) must not have been copied over the first.
+    assert not (work / "shared" / "data.txt").exists() or (
+        src_b / "data.txt"
+    ).read_text(encoding="utf-8") == "B-content"
+
+
+def test_non_privilege_symlink_error_reraises(monkeypatch, tmp_path):
+    src = _mk_src(tmp_path)
+    work = tmp_path / "work"
+    work.mkdir()
+
+    def fake_symlink(a, b, **kw):
+        e = OSError()
+        e.errno = errno.EACCES
+        raise e
+
+    monkeypatch.setattr("skillopt.model.codex_harness.os.symlink", fake_symlink)
+    with pytest.raises(OSError):
+        prepare_workspace(work_dir=str(work), skill_md="x", link_dirs=[(str(src), "docs/data")])
+
+
+def test_redact_copilot_trace_redacts_json_secret_fields():
+    line = '{"type":"message","token":"plain-secret","content":"hi"}'
+    out = _redact_copilot_trace(line)
+    assert "plain-secret" not in out
+    # Non-secret fields survive (content is an omitted trace field by design).
+    assert "message" in out
+
+
+def test_redact_copilot_trace_preserves_normal_strings():
+    out = _redact_copilot_trace('{"type":"assistant","message":"hello"}')
+    # Normal field names are preserved.
+    assert "hello" in out
+
+
+def test_redact_copilot_trace_redacts_string_key_forms():
+    out = _redact_copilot_trace("token = plain-secret")
+    assert "plain-secret" not in out


### PR DESCRIPTION
Cross-platform exec fixes for the model backends.

- Resolve codex/claude/cursor/copilot exec paths via shutil.which at config load, so bare npm .cmd shims spawn on Windows (bare 'codex' -> codex.CMD; CreateProcess does not search PATHEXT, so bare names raise WinError 2). Mirrors the proven pattern in the sleep layer.
- os.symlink uses target_is_directory + copytree/copy2 fallback (fixes OfficeQA on Windows).
- Scrub the copilot exec stdout/stderr trace (was unredacted, unlike cursor/codex/claude).
- Add tests for _resolve_cli_path.

Verified: _resolve_cli_path('codex') -> codex.CMD on Windows; targeted tests pass.