### PR TITLE
fix(openclaw): de-hardcode /home/ethanclaw paths

### DIFF
--- a/plugins/openclaw/run_sleep.py
+++ b/plugins/openclaw/run_sleep.py
@@ -23,7 +23,7 @@ import sys
 from pathlib import Path
 
 # Ensure the skillopt_sleep package is importable (it lives in the cloned repo)
-REPO = Path("/home/ethanclaw/.openclaw/workspace/SkillOpt")
+REPO = Path(os.environ.get("SKILLOPT_REPO", os.path.expanduser("~/.openclaw/workspace/SkillOpt")))
 sys.path.insert(0, str(REPO))
 
 # Register our backend before importing cycle
@@ -72,7 +72,7 @@ from skillopt_sleep.config import load_config
 def main() -> int:
     ap = argparse.ArgumentParser(description="OpenClaw SkillOpt-Sleep nightly cycle")
     ap.add_argument("--dry-run", action="store_true", help="Compute but don't stage")
-    ap.add_argument("--config", default="/home/ethanclaw/.openclaw/workspace/skills/skillopt-sleep/config.json")
+    ap.add_argument("--config", default=os.path.expanduser("~/.openclaw/workspace/skills/skillopt-sleep/config.json"))
     ap.add_argument("--tasks", default=None, help="Path to pre-built tasks JSON")
     ap.add_argument("--verbose", action="store_true")
     args = ap.parse_args()

--- a/plugins/openclaw/run_sleep_cron.sh
+++ b/plugins/openclaw/run_sleep_cron.sh
@@ -6,11 +6,11 @@
 #   With args: run only on listed categories (research-cron, devops, wiki)
 #
 # Cron (3am MYT daily):
-#   0 3 * * * cd /home/ethanclaw/.openclaw/workspace/skills/skillopt-sleep && bash run_sleep_cron.sh >> ~/.skillopt-sleep/nightly.log 2>&1
+#   0 3 * * * cd "$HOME/.openclaw/workspace/skills/skillopt-sleep" && bash run_sleep_cron.sh >> ~/.skillopt-sleep/nightly.log 2>&1
 
 set -euo pipefail
 
-SKILL_DIR="/home/ethanclaw/.openclaw/workspace/skills/skillopt-sleep"
+SKILL_DIR="$HOME/.openclaw/workspace/skills/skillopt-sleep"
 TESTS_DIR="$SKILL_DIR/tests"
 LOG_DIR="$HOME/.skillopt-sleep/logs"
 mkdir -p "$LOG_DIR"

--- a/plugins/openclaw/slash_sleep.py
+++ b/plugins/openclaw/slash_sleep.py
@@ -23,7 +23,7 @@ import sys
 from pathlib import Path
 from datetime import datetime
 
-SKILL_DIR = Path("/home/ethanclaw/.openclaw/workspace/skills/skillopt-sleep")
+SKILL_DIR = Path(os.path.expanduser("~/.openclaw/workspace/skills/skillopt-sleep"))
 STATE_DIR = Path(os.path.expanduser("~/.skillopt-sleep"))  # default
 STAGING_ROOT = STATE_DIR
 
@@ -32,14 +32,14 @@ def _resolve_state_dir():
 
     Priority: scan in order:
       1. ~/.skillopt-sleep/                 (default)
-      2. /home/ethanclaw/.openclaw/workspace/.skillopt-sleep/  (when staging is there)
-      3. /home/ethanclaw/.openclaw/.skillopt-sleep/            (parent of overridden claude_home)
+      2. ~/.openclaw/workspace/.skillopt-sleep/  (when staging is there)
+      3. ~/.openclaw/.skillopt-sleep/            (parent of overridden claude_home)
     Pick the first one that has a state.json OR staging dir.
     """
     candidates = [
         Path(os.path.expanduser("~/.skillopt-sleep")),
-        Path("/home/ethanclaw/.openclaw/workspace/.skillopt-sleep"),
-        Path("/home/ethanclaw/.openclaw/.skillopt-sleep"),
+        Path(os.path.expanduser("~/.openclaw/workspace/.skillopt-sleep")),
+        Path(os.path.expanduser("~/.openclaw/.skillopt-sleep")),
     ]
     # Prefer the one with state.json
     for c in candidates:

--- a/tests/test_openclaw_portability.py
+++ b/tests/test_openclaw_portability.py
@@ -1,0 +1,32 @@
+"""Tests that the OpenClaw plugin paths are portable (not hardcoded)."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+_PLUGIN_DIR = Path(__file__).resolve().parents[1] / "plugins" / "openclaw"
+
+
+def _load_slash_sleep():
+    spec = importlib.util.spec_from_file_location(
+        "slash_sleep", _PLUGIN_DIR / "slash_sleep.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_skill_dir_uses_home_expansion():
+    """SKILL_DIR must be derived from the home directory, not an absolute user."""
+    mod = _load_slash_sleep()
+    expected = Path(os.path.expanduser("~/.openclaw/workspace/skills/skillopt-sleep"))
+    assert str(mod.SKILL_DIR) == str(expected)
+
+
+def test_skill_dir_not_hardcoded_to_ethanclaw():
+    """No /home/ethanclaw residue should remain in the plugin path."""
+    mod = _load_slash_sleep()
+    assert "ethanclaw" not in str(mod.SKILL_DIR)


### PR DESCRIPTION
Make the OpenClaw plugin portable.

- Derive plugin paths from ~/.openclaw (expanduser) / \C:\Users\huaqi instead of the author's absolute /home/ethanclaw path.
- Allow overriding the repo checkout via SKILLOPT_REPO.
- Align run_sleep_cron.sh SKILL_DIR with the skill-dir layout.