### PR TITLE
fix(test): normalize cross-platform paths in Pi and Cursor config tests

### DIFF
--- a/tests/test_pi_integration.py
+++ b/tests/test_pi_integration.py
@@ -56,7 +56,7 @@ def test_explicit_pi_source_routes_only_to_pi_harvester():
 
     assert actual == expected
     pi.assert_called_once_with(
-        "/tmp/pi-home/agent/sessions",
+        cfg.pi_sessions_dir,
         scope="invoked",
         invoked_project="/repo/project",
         since_iso="2026-01-01T00:00:00Z",

--- a/tests/test_sleep_engine.py
+++ b/tests/test_sleep_engine.py
@@ -1744,7 +1744,7 @@ class TestCursorBackend(unittest.TestCase):
         )
         self.assertEqual(
             cfg.cursor_projects_dir,
-            os.path.join(os.path.expanduser("~/.cursor-custom"), "projects"),
+            os.path.join(os.path.abspath(os.path.expanduser("~/.cursor-custom")), "projects"),
         )
 
         direct_cfg = load_config(
@@ -1753,7 +1753,7 @@ class TestCursorBackend(unittest.TestCase):
         )
         self.assertEqual(
             direct_cfg.cursor_projects_dir,
-            os.path.join(os.path.expanduser("~/.cursor-config"), "projects"),
+            os.path.join(os.path.abspath(os.path.expanduser("~/.cursor-config")), "projects"),
         )
         self.assertEqual(
             resolve_cursor_path(direct_cfg.get("cursor_path")),


### PR DESCRIPTION
## Problem
In `test_pi_integration.py` and `test_sleep_engine.py`:
1. `test_explicit_pi_source_routes_only_to_pi_harvester` asserted against a hardcoded posix path string `"/tmp/pi-home/agent/sessions"` rather than the resolved `cfg.pi_sessions_dir`, failing when running on non-POSIX platforms where `pi_sessions_dir` normalizes the root path.
2. `test_cursor_path_overrides_expand_user_home` in `test_sleep_engine.py` compared `cfg.cursor_projects_dir` against un-normalized `os.path.expanduser` results, failing when path separators differed across platforms.

## Root Cause
`SleepConfig` properties (`pi_sessions_dir`, `cursor_projects_dir`) consistently apply `os.path.abspath(os.path.expanduser(...))` to normalize user home directories and resolve relative paths. The tests compared these normalized paths against raw, un-normalized string fragments.

## Solution
- Updated `test_explicit_pi_source_routes_only_to_pi_harvester` to assert against `cfg.pi_sessions_dir`.
- Updated `test_cursor_path_overrides_expand_user_home` to normalize expected test path assertions with `os.path.abspath(os.path.expanduser(...))`.

## Testing
- Ran pytest on `tests/test_pi_integration.py` and `tests/test_sleep_engine.py` (all targeted tests passing).
- Ran `ruff check` (clean).

## Risk
None. Test assertion path normalization only.
