### PR TITLE
fix(docs): clarify claude_code_exec and codex_exec optimizer support

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -44,8 +44,8 @@ model:
 | `qwen_chat` | ✓ | ✓ | Qwen served through an OpenAI-compatible endpoint (self-hosted vLLM/SGLang or a hosted gateway) |
 | `minimax_chat` | ✓ | ✓ | MiniMax API |
 | `copilot_chat` | ✓ | ✓ | GitHub Copilot CLI (`copilot -p`); alias `copilot` |
-| `codex_exec` | — | ✓ | Codex CLI execution harness |
-| `claude_code_exec` | — | ✓ | Claude Code CLI execution harness |
+| `codex_exec` | ✓ | ✓ | Codex CLI execution harness |
+| `claude_code_exec` | ✓ | ✓ | Claude Code CLI execution harness |
 | `cursor_exec` | — | ✓ | Cursor Agent CLI execution harness |
 | `copilot_exec` | — | ✓ | GitHub Copilot CLI execution harness |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -115,6 +115,30 @@ disabled. Read-only Ask-mode rollouts may explicitly disable it. Override the
 executable or sandbox through `model.cursor_exec_path` and
 `model.cursor_exec_sandbox`.
 
+To train or evaluate with the Claude Code CLI execution harness (`claude_code_exec`):
+
+```bash
+# Target-only rollout through Claude Code (optimizer defaults to configured chat backend):
+python scripts/train.py \
+  --config configs/searchqa/default.yaml \
+  --backend claude_code_exec
+
+# Explicitly drive both target and optimizer roles with Claude Code:
+python scripts/train.py \
+  --config configs/searchqa/default.yaml \
+  --cfg-options \
+    model.optimizer_backend=claude_code_exec \
+    model.target_backend=claude_code_exec
+```
+
+When `claude_code_exec` is selected as the target backend, SkillOpt streams SDK
+messages from the Claude Code process and parses text, tool calls, and tool
+results into structured trace steps (`claude_trace_steps.txt`). When
+`model.claude_trace_to_optimizer` is enabled (`true` by default), these trace
+steps are injected into the reflection prompt so the optimizer can inspect the
+agent's intermediate actions.
+
+
 ## SkillOpt-Sleep
 
 ```bash

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -18,7 +18,7 @@ selecting the generic OpenAI-compatible backend.
 | `minimax_chat` | ✓ | ✓ |
 | `copilot_chat` | ✓ | ✓ |
 | `codex_exec` | ✓ | ✓ |
-| `claude_code_exec` | — | ✓ |
+| `claude_code_exec` | ✓ | ✓ |
 | `cursor_exec` | — | ✓ |
 | `copilot_exec` | — | ✓ |
 
@@ -34,7 +34,7 @@ resolves to `https://api.minimax.io/v1` and `cn_zh` resolves to
 | `model.backend` | str | `azure_openai` | Backward-compatible high-level run label |
 | `model.optimizer` | str | `gpt-5.5` | Optimizer deployment/model |
 | `model.target` | str | `gpt-5.5` | Target deployment/model |
-| `model.optimizer_backend` | str | `openai_chat` | Optimizer client path; chat backends plus `codex_exec` |
+| `model.optimizer_backend` | str | `openai_chat` | Optimizer client path; chat backends plus `codex_exec` and `claude_code_exec` |
 | `model.target_backend` | str | `openai_chat` | Target client path; chat or exec backend |
 | `model.reasoning_effort` | str | `medium` | Shared reasoning effort |
 | `model.rewrite_reasoning_effort` | str | empty | Optional full-rewrite effort override |


### PR DESCRIPTION
Problem

Following the introduction of the Claude Code Exec optimizer backend (#238 / #233), there were discrepancies and omissions across the documentation regarding backend roles:

1. docs/reference/config.md marked claude_code_exec as — under the Optimizer column and omitted it from the model.optimizer_backend parameter description.
2. docs/guide/configuration.md marked both codex_exec and claude_code_exec as — under the Optimizer column, contradicting docs/reference/config.md and the actual backend implementation.
3. docs/reference/cli.md lacked examples for running training and evaluation with claude_code_exec.

Root Cause

The backend compatibility matrices and CLI reference were not completely updated when claude_code_exec optimizer support and SDK trace extraction were added in #238.

Solution

* Updated the backend tables in docs/reference/config.md and docs/guide/configuration.md to accurately indicate optimizer role support for codex_exec and claude_code_exec.
* Updated the model.optimizer_backend description in docs/reference/config.md to include claude_code_exec.
* Added explicit training and evaluation CLI examples for claude_code_exec in docs/reference/cli.md, along with trace injection notes.

Testing

* Verified Markdown formatting and syntax.
* Cross-referenced the documentation against backend dispatch logic in:
    * skillopt/model/__init__.py
    * skillopt/model/backend_config.py
* Cross-referenced against the relevant test cases:
    * tests/test_role_backend_resolution.py
    * tests/test_claude_code_exec_resolution.py

Risk

Low risk. Documentation-only update.

Issue

Closes #268